### PR TITLE
RFC: Implement Activity Service: Pre-allocated Subscriber Count Method

### DIFF
--- a/examples/rt685s-evk/src/bin/keyboard.rs
+++ b/examples/rt685s-evk/src/bin/keyboard.rs
@@ -5,13 +5,95 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt;
 
+mod backlight {
+    use defmt::info;
+    use embedded_services::activity::{Class, State, SubscriberHandle};
+
+    pub struct Context {
+        pub activity_handle: SubscriberHandle,
+    }
+
+    pub async fn init() -> Context {
+        Context {
+            activity_handle: embedded_services::activity::subscribe().await.ok().unwrap(),
+        }
+    }
+
+    pub async fn turn_on() {
+        info!("Backlight on!");
+        embassy_time::Timer::after_millis(500).await;
+    }
+
+    pub async fn turn_off() {
+        info!("Backlight off!");
+        embassy_time::Timer::after_millis(500).await;
+    }
+
+    #[embassy_executor::task]
+    pub async fn process_activity_event(mut handle: SubscriberHandle) {
+        loop {
+            let activity = embedded_services::activity::wait(&mut handle).await;
+
+            match activity.class {
+                Class::Keyboard => match activity.state {
+                    State::Active => turn_on().await,
+                    _ => turn_off().await,
+                },
+                _ => (), // don't care otherwise
+            }
+        }
+    }
+}
+
+mod keyboard {
+    use defmt::info;
+    use embedded_services::activity::{Class, PublisherHandle, State};
+
+    pub struct Context {
+        publisher_handle: PublisherHandle,
+    }
+
+    pub async fn init() -> Context {
+        Context {
+            publisher_handle: embedded_services::activity::register_publisher(Class::Keyboard)
+                .await
+                .unwrap(),
+        }
+    }
+
+    #[embassy_executor::task]
+    pub async fn keyscan_loop(context: Context) {
+        loop {
+            use embassy_time::Timer;
+
+            info!("Setting Keyboard Activity to ACTIVE");
+            embedded_services::activity::publish(&context.publisher_handle, State::Active).await;
+            Timer::after_secs(2).await;
+
+            info!("Setting Keyboard Activity to INACTIVE");
+            embedded_services::activity::publish(&context.publisher_handle, State::Inactive).await;
+            Timer::after_secs(2).await;
+        }
+    }
+}
+
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     let _p = embassy_imxrt::init(Default::default());
+
+    embedded_services::init();
 
     info!("Platform initialization complete ...");
 
-    loop {
-        embedded_services_examples::delay(10_000_000);
-    }
+    let kb = keyboard::init().await;
+
+    spawner.spawn(keyboard::keyscan_loop(kb)).unwrap();
+
+    let bl = backlight::init().await;
+
+    spawner
+        .spawn(backlight::process_activity_event(bl.activity_handle))
+        .unwrap();
+
+    embedded_services_examples::delay(10_000);
 }

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -1,0 +1,138 @@
+//! Top level activity service generics and interface
+
+/// potential activity service states
+#[derive(Copy, Clone, Debug)]
+pub enum State {
+    /// the service is currently active
+    Active,
+
+    /// the service is currently in-active, but could become active
+    Inactive,
+
+    /// the service is disabled and will not become active
+    Disabled,
+}
+
+/// specifies OEM identifier for extended activity services
+pub type OemIdentifier = u32;
+
+/// specifies which Activity Class is updating state
+#[derive(Copy, Clone, Debug)]
+pub enum Class {
+    /// the keyboard, if present, is currently active (keys pressed), inactive (keys released), or disabled (key scanning disabled)
+    Keyboard,
+
+    /// the trackpad, if present, is currently active (swiped), inactive (no swiped), or disabled (powered off/unavailable)
+    Trackpad,
+
+    // SecureUpdate, others as needed for ec template
+    /// OEM Extension class, for activity notifications that are OEM specific
+    Oem(OemIdentifier),
+}
+
+/// notification datagram, containing who's activity state (class) changed and what the new state is
+#[derive(Copy, Clone, Debug)]
+pub struct Notification {
+    /// activity state of this class
+    pub state: State,
+
+    /// classification of activity
+    pub class: Class,
+}
+
+use core::cell::Cell;
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+// use OnceLock for pub-sub interface allocation
+use embassy_sync::once_lock::OnceLock;
+// backend is PubSubChannel
+use embassy_sync::pubsub::{Error, PubSubChannel, Publisher, Subscriber};
+
+const MAX_SUBSCRIBERS: usize = 64; // TODO
+
+struct Manager {
+    chn: PubSubChannel<NoopRawMutex, Notification, 1, MAX_SUBSCRIBERS, 1>,
+    keyboard_publisher_registered: Cell<bool>,
+    trackpad_publisher_registered: Cell<bool>,
+}
+
+/// Opaque handle to publisher, cannot be constructed outside of register_publisher()
+pub struct PublisherHandle(Class);
+
+/// Opaque subscriber handle, disallow unapproved subscription methods for this service
+pub struct SubscriberHandle(Subscriber<'static, NoopRawMutex, Notification, 1, MAX_SUBSCRIBERS, 1>);
+
+static MANAGER: OnceLock<Manager> = OnceLock::new();
+static PUBLISHER: OnceLock<Publisher<'static, NoopRawMutex, Notification, 1, MAX_SUBSCRIBERS, 1>> = OnceLock::new();
+
+/// generate a subscriber handle
+pub async fn subscribe() -> Result<SubscriberHandle, Error> {
+    let subscribe_attempt = MANAGER.get().await.chn.subscriber();
+
+    if subscribe_attempt.is_err() {
+        Err(subscribe_attempt.err().unwrap())
+    } else {
+        Ok(SubscriberHandle(subscribe_attempt.unwrap()))
+    }
+}
+
+/// wait for the next activity event broadcast
+pub async fn wait(subscriber: &mut SubscriberHandle) -> Notification {
+    subscriber.0.next_message_pure().await
+}
+
+/// attempt to register a publisher for Activity Class class. None if there is already a publisher registered for this class
+pub async fn register_publisher(class: Class) -> Option<PublisherHandle> {
+    match class {
+        // only allow one registered keyboard activity publisher
+        Class::Keyboard => {
+            let manager = MANAGER.get().await;
+
+            if manager.keyboard_publisher_registered.get() {
+                None
+            } else {
+                manager.keyboard_publisher_registered.set(true);
+                Some(PublisherHandle(class))
+            }
+        }
+
+        // only allow one registered trackpad activity publisher
+        Class::Trackpad => {
+            let manager = MANAGER.get().await;
+
+            if manager.trackpad_publisher_registered.get() {
+                None
+            } else {
+                manager.trackpad_publisher_registered.set(true);
+                Some(PublisherHandle(class))
+            }
+        }
+
+        // allow any number of OEM activity publishers
+        Class::Oem(_tag) => Some(PublisherHandle(class)),
+    }
+}
+
+/// allow a publisher to transmit data to any current subscribers
+/// API is only accessible if the publisher handle has been constructed validly via registration above
+pub async fn publish(handle: &PublisherHandle, state: State) {
+    PUBLISHER
+        .get()
+        .await
+        .publish(Notification {
+            state: state,
+            class: handle.0,
+        })
+        .await;
+}
+
+/// initialize service resources
+pub(crate) fn init() {
+    let man = MANAGER.get_or_init(|| Manager {
+        chn: PubSubChannel::new(),
+        keyboard_publisher_registered: Cell::new(false),
+        trackpad_publisher_registered: Cell::new(false),
+    });
+
+    PUBLISHER.get_or_init(|| man.chn.publisher().unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,15 @@
 
 #![no_std]
 #![warn(missing_docs)]
+
+// pub struct Subscription<T> {
+
+// }
+
+/// export activity services
+pub mod activity;
+
+/// initialize all services
+pub fn init() {
+    activity::init();
+}


### PR DESCRIPTION
Implements an activity services example for a keyboard<->backlight interaction, using a statically allocated publisher queue and fixed-length subscriber bounds. This has the following Pros and Cons (versus other approaches):

Pro's
---
- Very simple to use static API. Simply call services::activity::subscribe() to start waiting on data.

- Does not require any "manual" configuration from product consumers -- just a single call to services::init() at startup.

Con's
---
- Fixed number of subscriber support. This means there could be wasted bytes in the subscriber slots, or the product may need to implement a "piggy-back" publisher for service consumers beyond what the framework needs out of the box.