### PR TITLE
RFC: Implement Activity Service: Product Specified Services

### DIFF
--- a/examples/rt685s-evk/src/bin/keyboard.rs
+++ b/examples/rt685s-evk/src/bin/keyboard.rs
@@ -3,15 +3,165 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt;
+use embassy_sync::once_lock::OnceLock;
+use {embassy_imxrt, embedded_services};
+static SERVICES: OnceLock<embedded_services::Services<PlatformServices>> = OnceLock::new();
 
-#[embassy_executor::main]
-async fn main(_spawner: Spawner) {
-    let _p = embassy_imxrt::init(Default::default());
+// todo: wrap in macro
+pub struct PlatformServices {
+    activity: embedded_services::DynamicService<embedded_services::activity::Manager, 2, 1>,
+}
+impl embedded_services::DynamicServiceBlock for PlatformServices {
+    fn get(
+        &self,
+        service: embedded_services::DynamicServiceListing,
+    ) -> Option<embedded_services::DynamicServiceInstance<'_>> {
+        use embedded_services::*;
+        match service {
+            DynamicServiceListing::Activity => Some(DynamicServiceInstance::Activity(&self.activity)),
+            _ => None,
+        }
+    }
+}
 
-    info!("Platform initialization complete ...");
+async fn backlight_on() {
+    info!("Backlight turned ON!");
+    embassy_time::Timer::after_millis(500).await;
+}
+
+async fn backlight_off() {
+    info!("Backlight turned OFF!");
+    embassy_time::Timer::after_millis(500).await;
+}
+
+#[embassy_executor::task]
+async fn backlight_activity_consumer() {
+    use embedded_services::DynamicServiceBlock;
+
+    let activity_service_enum = SERVICES
+        .get()
+        .await
+        .dynamic
+        .get(embedded_services::DynamicServiceListing::Activity)
+        .unwrap();
+
+    let activity_service = match activity_service_enum {
+        embedded_services::DynamicServiceInstance::Activity(activity_service) => activity_service,
+        _ => panic!(), // activity service not available on this platform!
+    };
+
+    let mut subscriber = activity_service.subscribe().unwrap();
 
     loop {
-        embedded_services_examples::delay(10_000_000);
+        use embedded_services::activity::{Class, State};
+        let activity = subscriber.wait().await;
+
+        match activity.class {
+            Class::Keyboard => match activity.state {
+                State::Active => backlight_on().await,
+                _ => backlight_off().await,
+            },
+            _ => (), // don't care
+        }
+    }
+}
+
+async fn kick_screen_on() {
+    info!("Telling OS to turn on screen!");
+    embassy_time::Timer::after_millis(800).await;
+}
+
+#[embassy_executor::task]
+async fn screen_activity_consumer() {
+    use embedded_services::DynamicServiceBlock;
+
+    let activity_service_enum = SERVICES
+        .get()
+        .await
+        .dynamic
+        .get(embedded_services::DynamicServiceListing::Activity)
+        .unwrap();
+
+    let activity_service = match activity_service_enum {
+        embedded_services::DynamicServiceInstance::Activity(activity_service) => activity_service,
+        _ => panic!(), // activity service not available on this platform!
+    };
+
+    let mut subscriber = activity_service.subscribe().unwrap();
+
+    loop {
+        use embedded_services::activity::{Class, State};
+        let activity = subscriber.wait().await;
+
+        match activity.class {
+            Class::Keyboard => match activity.state {
+                State::Active => kick_screen_on().await,
+                _ => (), // nothing to do
+            },
+            _ => (), // don't care
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn keyboard_activity_generator() {
+    use embedded_services::DynamicServiceBlock;
+
+    let activity_service_enum = SERVICES
+        .get()
+        .await
+        .dynamic
+        .get(embedded_services::DynamicServiceListing::Activity)
+        .unwrap();
+
+    let activity_service = match activity_service_enum {
+        embedded_services::DynamicServiceInstance::Activity(activity_service) => activity_service,
+        _ => panic!(), // activity service not available on this platform!
+    };
+
+    let publisher = activity_service.register_publisher().unwrap();
+
+    loop {
+        info!("Keyboard::Activity = ACTIVE!");
+        publisher
+            .publish(embedded_services::activity::Notification {
+                state: embedded_services::activity::State::Active,
+                class: embedded_services::activity::Class::Keyboard,
+            })
+            .await;
+        embassy_time::Timer::after_secs(2).await;
+
+        info!("Keyboard::Activity = INACTIVE!");
+        publisher
+            .publish(embedded_services::activity::Notification {
+                state: embedded_services::activity::State::Inactive,
+                class: embedded_services::activity::Class::Keyboard,
+            })
+            .await;
+        embassy_time::Timer::after_secs(2).await;
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let _p = embassy_imxrt::init(Default::default());
+
+    info!("Platform initialization complete");
+
+    SERVICES.get_or_init(|| {
+        embedded_services::init(PlatformServices {
+            activity: embedded_services::configure(embedded_services::activity::Config {}),
+        })
+    });
+
+    info!("Service initialization complete");
+
+    let _ = spawner.spawn(keyboard_activity_generator());
+    let _ = spawner.spawn(backlight_activity_consumer());
+    let _ = spawner.spawn(screen_activity_consumer());
+
+    embedded_services_examples::delay(1_000);
+    loop {
+        embassy_time::Timer::after_secs(10).await;
     }
 }

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,0 +1,58 @@
+//! activity (dynamic) service definitions
+
+use crate::Service;
+
+/// potential activity service states
+#[derive(Copy, Clone, Debug)]
+pub enum State {
+    /// the service is currently active
+    Active,
+
+    /// the service is currently in-active, but could become active
+    Inactive,
+
+    /// the service is disabled and will not become active
+    Disabled,
+}
+
+/// specifies OEM identifier for extended activity services
+pub type OemIdentifier = u32;
+
+/// specifies which Activity Class is updating state
+#[derive(Copy, Clone, Debug)]
+pub enum Class {
+    /// the keyboard, if present, is currently active (keys pressed), inactive (keys released), or disabled (key scanning disabled)
+    Keyboard,
+
+    /// the trackpad, if present, is currently active (swiped), inactive (no swiped), or disabled (powered off/unavailable)
+    Trackpad,
+
+    // SecureUpdate, others as needed for ec template
+    /// OEM Extension class, for activity notifications that are OEM specific
+    Oem(OemIdentifier),
+}
+
+/// notification datagram, containing who's activity state (class) changed and what the new state is
+#[derive(Copy, Clone, Debug)]
+pub struct Notification {
+    /// activity state of this class
+    pub state: State,
+
+    /// classification of activity
+    pub class: Class,
+}
+
+/// primary service instance
+pub struct Manager {}
+
+/// service configuration, if any (TODO Oem Limitations, for example)
+pub struct Config {}
+
+impl Service for Manager {
+    type Notification = Notification;
+    type Config = Config;
+
+    fn init(_config: Self::Config) -> Self {
+        Self {}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,101 @@
 
 #![no_std]
 #![warn(missing_docs)]
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::pubsub::{DynPublisher, DynSubscriber, PubSubChannel};
+
+pub struct Publisher<'a, T: Clone>(DynPublisher<'a, T>);
+pub struct Subscriber<'a, T: Clone>(DynSubscriber<'a, T>);
+
+pub trait Service {
+    type Notification: Clone;
+    type Config;
+
+    fn init(config: Self::Config) -> Self;
+}
+
+pub trait DynamicServiceInterface<T: Service> {
+    fn subscribe(&self) -> Result<Subscriber<'_, T::Notification>, OutOfSubscriptionSlots>;
+    fn register_publisher(&self) -> Result<Publisher<'_, T::Notification>, OutOfPublisherSlots>;
+}
+
+pub struct DynamicService<T: Service, const SUBS: usize, const PUBS: usize> {
+    inner: T,
+    chn: PubSubChannel<NoopRawMutex, T::Notification, 1, SUBS, PUBS>,
+}
+
+pub fn configure<T: Service, const SUBS: usize, const PUBS: usize>(config: T::Config) -> DynamicService<T, SUBS, PUBS> {
+    DynamicService {
+        inner: T::init(config),
+        chn: PubSubChannel::new(),
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct OutOfSubscriptionSlots();
+#[derive(Copy, Clone, Debug)]
+pub struct OutOfPublisherSlots();
+
+impl<T: Service, const SUBS: usize, const PUBS: usize> DynamicServiceInterface<T> for DynamicService<T, SUBS, PUBS> {
+    fn subscribe(&self) -> Result<Subscriber<'_, T::Notification>, OutOfSubscriptionSlots> {
+        match self.chn.dyn_subscriber() {
+            Ok(sub) => Ok(Subscriber(sub)),
+            Err(_) => Err(OutOfSubscriptionSlots()),
+        }
+    }
+
+    fn register_publisher(&self) -> Result<Publisher<'_, T::Notification>, OutOfPublisherSlots> {
+        match self.chn.dyn_publisher() {
+            Ok(pbl) => Ok(Publisher(pbl)),
+            Err(_) => Err(OutOfPublisherSlots()),
+        }
+    }
+}
+
+impl<'a, T: Clone> Subscriber<'a, T> {
+    pub async fn wait(&mut self) -> T {
+        self.0.next_message_pure().await
+    }
+}
+
+impl<'a, T: Clone> Publisher<'a, T> {
+    pub async fn publish(&self, notification: T) {
+        self.0.publish(notification).await;
+    }
+}
+
+pub mod activity;
+pub enum DynamicServiceListing {
+    Activity,
+    OEM(usize),
+}
+
+pub enum DynamicServiceInstance<'a> {
+    Activity(&'a dyn DynamicServiceInterface<activity::Manager>),
+}
+
+pub struct ReadRequest {}
+pub trait DynamicServiceBlock {
+    fn get(&self, service: DynamicServiceListing) -> Option<DynamicServiceInstance<'_>>;
+}
+
+pub struct Services<T: DynamicServiceBlock> {
+    pub read: ReadRequest,
+    pub dynamic: T,
+}
+
+pub fn init<T: DynamicServiceBlock>(dynamic_allocated: T) -> Services<T> {
+    Services {
+        read: ReadRequest::new(),
+        dynamic: dynamic_allocated,
+    }
+}
+
+impl ReadRequest {
+    fn new() -> ReadRequest {
+        let mut r = ReadRequest {};
+        // r._name_::init(&mut r._name_);
+        r
+    }
+}


### PR DESCRIPTION
This method of implementing the service layer is built around a central registery that is made accessible to all potential consumers of the services. This allows for a generic interface to publishing and subscribing, which is both good and bad. It allows for more flexibility in general, but also places more burden on the implementer to ensure storage is appropriately tuned for their application.

Pro's
---
- Highly flexible interface
- Allows for optimal storage without requiring additional OEM "re-route" services
- Allows for easier OEM service definitions
- Centralized, unified API for service interfacing

Con's
---
- A bit more obtuse interface; requires stronger Rust foundations to understand
- Requires that tasks are allocated at the product/OEM level rather than in the subsystem directly.