### PR TITLE
Intrusive Linked-List Based Service Dispatch: Activity Service Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,9 @@ embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
 
 document-features = "0.2.7"
+
+[dev-dependencies]
+embassy-sync = { git = "https://github.com/embassy-rs/embassy", features = [
+    "std",
+] }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy" }

--- a/examples/rt685s-evk/src/bin/keyboard.rs
+++ b/examples/rt685s-evk/src/bin/keyboard.rs
@@ -3,15 +3,161 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt;
+use embassy_sync::once_lock::OnceLock;
+
+mod activity_example {
+    use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+    use embassy_sync::signal::Signal;
+
+    use super::*;
+
+    pub mod backlight {
+
+        use embedded_services::activity;
+
+        use super::*;
+
+        // conceivably these actions could be permuted or extended based on whatever the "real" subscriber needs to do
+        enum Actions {
+            TurnOnBacklight,
+            TurnOffBacklight(bool),
+        }
+
+        pub struct BacklightContext {
+            activity_subscription: activity::Subscriber,
+            action_queue: Signal<NoopRawMutex, Actions>,
+        }
+
+        impl activity::ActivitySubscriber for BacklightContext {
+            fn activity_update(&self, notif: &activity::Notification) {
+                if matches!(notif.class, activity::Class::Keyboard) {
+                    // IPC wake
+                    //    Note: if depth is needed, use a channel instead
+                    self.action_queue.signal(match notif.state {
+                        activity::State::Active => Actions::TurnOnBacklight,
+                        activity::State::Inactive => Actions::TurnOffBacklight(true),
+                        activity::State::Disabled => Actions::TurnOffBacklight(false),
+                    });
+                }
+            }
+        }
+
+        impl BacklightContext {
+            pub fn new() -> Self {
+                Self {
+                    activity_subscription: activity::Subscriber::uninit(),
+                    action_queue: Signal::new(),
+                }
+            }
+
+            async fn init(&'static self) {
+                activity::register_subscriber(self, &self.activity_subscription)
+                    .await
+                    .unwrap();
+            }
+
+            async fn turn_on(&self) {
+                info!("Backlight enabled!");
+                embassy_time::Timer::after_millis(500).await;
+            }
+
+            async fn turn_off_immediate(&self) {
+                info!("Backlight off!");
+                embassy_time::Timer::after_millis(200).await;
+            }
+
+            async fn fade_off(&self) {
+                info!("Backlight fading off!");
+                embassy_time::Timer::after_millis(2000).await;
+            }
+
+            async fn event_loop(&self) {
+                loop {
+                    let event = self.action_queue.wait().await;
+
+                    match event {
+                        Actions::TurnOnBacklight => self.turn_on().await,
+                        Actions::TurnOffBacklight(fade) => {
+                            if fade {
+                                self.fade_off().await;
+                            } else {
+                                self.turn_off_immediate().await;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #[embassy_executor::task]
+        pub async fn task() {
+            static CONTEXT: OnceLock<BacklightContext> = OnceLock::new();
+            let context = CONTEXT.get_or_init(BacklightContext::new);
+            context.init().await;
+            context.event_loop().await;
+        }
+    }
+
+    pub mod publisher {
+        use super::*;
+
+        struct Keyboard {
+            activity_publisher: embedded_services::activity::Publisher,
+        }
+
+        #[embassy_executor::task]
+        pub async fn keyboard_task() {
+            static KEYBOARD: OnceLock<Keyboard> = OnceLock::new();
+
+            let keyboard = KEYBOARD.get_or_init(|| {
+                embassy_futures::block_on(async {
+                    Keyboard {
+                        activity_publisher: embedded_services::activity::register_publisher(
+                            embedded_services::activity::Class::Keyboard,
+                        )
+                        .await
+                        .unwrap(),
+                    }
+                })
+            });
+
+            let mut count = 0;
+            loop {
+                let some_times = [10, 100, 1000, 2000, 5000];
+
+                embassy_time::Timer::after_millis(some_times[count % some_times.len()]).await;
+
+                let state = match count % 3 {
+                    1 => embedded_services::activity::State::Active,
+                    2 => embedded_services::activity::State::Inactive,
+                    _ => embedded_services::activity::State::Disabled,
+                };
+
+                keyboard.activity_publisher.publish(state).await;
+
+                count += 1;
+            }
+        }
+    }
+}
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     let _p = embassy_imxrt::init(Default::default());
 
     info!("Platform initialization complete ...");
 
-    loop {
-        embedded_services_examples::delay(10_000_000);
-    }
+    embedded_services::init().await;
+
+    info!("Service initialization complete...");
+
+    // create an activity service subscriber
+    spawner.spawn(activity_example::backlight::task()).unwrap();
+
+    // create an activity service publisher
+    spawner.spawn(activity_example::publisher::keyboard_task()).unwrap();
+
+    info!("Subsystem initialization complete...");
+
+    embedded_services_examples::delay(1_000);
 }

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,0 +1,139 @@
+//! Activity Service Definitions
+
+use embassy_sync::once_lock::OnceLock;
+
+use crate::intrusive_list::*;
+
+/// potential activity service states
+#[derive(Copy, Clone, Debug)]
+pub enum State {
+    /// the service is currently active
+    Active,
+
+    /// the service is currently in-active, but could become active
+    Inactive,
+
+    /// the service is disabled and will not become active
+    Disabled,
+}
+
+/// specifies OEM identifier for extended activity services
+pub type OemIdentifier = u32;
+
+/// specifies which Activity Class is updating state
+#[derive(Copy, Clone, Debug)]
+pub enum Class {
+    /// the keyboard, if present, is currently active (keys pressed), inactive (keys released), or disabled (key scanning disabled)
+    Keyboard,
+
+    /// the trackpad, if present, is currently active (swiped), inactive (no swiped), or disabled (powered off/unavailable)
+    Trackpad,
+
+    // SecureUpdate, others as needed for ec template
+    /// OEM Extension class, for activity notifications that are OEM specific
+    Oem(OemIdentifier),
+}
+
+/// notification datagram, containing who's activity state (class) changed and what the new state is
+#[derive(Copy, Clone, Debug)]
+pub struct Notification {
+    /// activity state of this class
+    pub state: State,
+
+    /// classification of activity
+    pub class: Class,
+}
+
+/// trait to be implemented by any Activity service subscribers
+pub trait ActivitySubscriber {
+    /// async function invoked when Activity service update occurs
+    fn activity_update(&self, notif: &Notification);
+}
+
+/// actual subscriber node instance for embedding within static or singleton type T
+pub struct Subscriber {
+    node: Node,
+    instance: Cell<Option<&'static dyn ActivitySubscriber>>,
+}
+
+impl Subscriber {
+    /// use this when static initialization occurs, internal fields will be validated in register_subscriber() later
+    pub const fn uninit() -> Self {
+        Self {
+            node: Node::uninit(),
+            instance: Cell::new(None),
+        }
+    }
+
+    /// initializes the internal representation of this container's Activity Subscriber node
+    fn init<T: ActivitySubscriber>(&self, container: &'static T) {
+        self.instance.set(Some(container));
+    }
+
+    /// generates internal update over initialized data
+    fn update(&self, notif: &Notification) {
+        if let Some(subscriber) = self.instance.get() {
+            subscriber.activity_update(notif);
+        }
+    }
+}
+
+impl NodeContainer for Subscriber {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+/// Publisher handle for registered publishers
+#[derive(Copy, Clone, Debug)]
+pub struct Publisher {
+    class: Class,
+}
+
+/// register your subscriber to begin receiving updates
+pub async fn register_subscriber<T: ActivitySubscriber>(
+    this: &'static T,
+    subscriber: &'static Subscriber,
+) -> Result<()> {
+    subscriber.init(this);
+    SUBSCRIBERS.get().await.push(subscriber)
+}
+
+/// register publisher class for future usage. None returned if class slot is already occupied
+pub async fn register_publisher(class: Class) -> core::result::Result<Publisher, core::convert::Infallible> {
+    // allow multiple publishers for any class (todo - determine if limitation is necessary)
+    Ok(Publisher { class })
+}
+
+impl Publisher {
+    /// publish state update
+    pub async fn publish(&self, state: State) {
+        let subs = SUBSCRIBERS.get().await;
+
+        // build publisher-side "queue" of outbound messages
+        let notif = Notification {
+            state,
+            class: self.class,
+        };
+
+        // note: this queue publication order can later be dispatched according to priorities if using a
+        // single-executor that allows task level prioritization of futures.
+
+        for listener_node in subs {
+            let instance = listener_node.data::<Subscriber>();
+            // as subscriber list is only accessible via these safe interfaces, can perform an "invariant assert" here
+            // to catch potential state or stack corruption later
+            assert!(instance.is_some());
+
+            if let Some(subscriber) = instance {
+                subscriber.update(&notif);
+            }
+        }
+    }
+}
+
+static SUBSCRIBERS: OnceLock<IntrusiveList> = OnceLock::new();
+
+pub(crate) fn init() {
+    SUBSCRIBERS.get_or_init(IntrusiveList::new);
+}

--- a/src/intrusive_list.rs
+++ b/src/intrusive_list.rs
@@ -1,0 +1,507 @@
+//! A static lifetime'd intrusive linked list, construction only (never remove/delete)
+
+// Any type used for dynamic type coercion
+pub use core::any::Any;
+pub use core::cell::Cell;
+
+/// Interface error class information
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    /// cannot push a node to any list if it's already in one
+    NodeAlreadyInList,
+}
+
+/// override Result type for shorthand -> Result<T>
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Embedded node that "intrudes" on a structure
+#[derive(Copy, Clone, Debug)]
+pub struct IntrusiveNode {
+    /// offset from &self to struct data. Typically := sizeof(IntrusiveNode)
+    address_of_data: *const dyn Any,
+
+    /// unsafe iterator type
+    next: Option<&'static IntrusiveNode>,
+
+    /// valid address flag: used to ensure proper initialization sequencing over address_of_data
+    valid: bool,
+}
+
+/// node type for list allocation. Embed this in the "list wrapper" object, and init with Node::uninit()
+pub struct Node {
+    inner: Cell<IntrusiveNode>,
+}
+
+struct Invalid {}
+
+impl Node {
+    const INVALID: Invalid = Invalid {};
+
+    /// shorthand constant for no elements in list
+    pub const EMPTY: IntrusiveNode = IntrusiveNode {
+        address_of_data: &Node::INVALID as *const dyn Any,
+        next: None,
+        valid: false,
+    };
+
+    /// construct an uninitialized node in place
+    pub const fn uninit() -> Node {
+        Node {
+            inner: Cell::new(Node::EMPTY),
+        }
+    }
+}
+
+/// implementing this trait is required for IntrusiveList construction over type T
+pub trait NodeContainer: Any {
+    /// return the upper level node type reference attached to self
+    fn get_node(&self) -> &Node;
+}
+
+/// List of intruded nodes of unknown type(s), must be allocated statically
+pub struct IntrusiveList {
+    /// traditional head pointer on list. Static reference type is used to ensure static allocations (for safety)
+    head: Cell<Option<&'static IntrusiveNode>>,
+}
+
+impl IntrusiveNode {
+    /// generate an empty node for use within whatever type T
+    fn new<T: NodeContainer>(this_ref: &'static T) -> IntrusiveNode {
+        IntrusiveNode {
+            address_of_data: (this_ref as *const T) as *const dyn Any,
+            next: None,
+            valid: true,
+        }
+    }
+
+    /// retrieve the underlying dynamic type information (vtable)
+    pub fn data<T: NodeContainer>(&self) -> Option<&T> {
+        if self.valid {
+            // SAFETY: enforced via type constraint and new interface
+            unsafe { &*self.address_of_data }.downcast_ref()
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for IntrusiveList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntrusiveList {
+    /// construct an empty intrusive list
+    pub fn new() -> IntrusiveList {
+        IntrusiveList { head: Cell::new(None) }
+    }
+
+    /// only allow pushing to the head of the list
+    fn push_front(&self, node: &'static mut IntrusiveNode) {
+        // critical section in case of multi-threaded implementation:
+        critical_section::with(|_cs| {
+            if let Some(old_head) = self.head.get() {
+                node.next = Some(old_head);
+            }
+
+            self.head.set(Some(node));
+        });
+    }
+
+    /// generic over T: NodeContainer for list.push() proper node construction
+    pub fn push<T: NodeContainer>(&self, object: &'static T) -> Result<()> {
+        // check if node is in the list already. Valid flag will only be set if
+        // the element has been constructed and inserted into a linked list, so
+        // this check covers both same list and other list conditions.
+        if object.get_node().inner.get().valid {
+            return Err(Error::NodeAlreadyInList);
+        }
+
+        // since this API is private to this module, this is the only place where
+        // a node can be marked as valid.
+        let node = IntrusiveNode::new(object);
+        object.get_node().inner.set(node);
+
+        self.push_front(
+            // SAFETY: known safe operation due to valid flag and static lifetime
+            unsafe { &mut *object.get_node().inner.as_ptr() },
+        );
+        Ok(())
+    }
+}
+
+/// iterator wrapper type for IntrusiveNode
+pub struct IntrusiveIterator {
+    current: Option<&'static IntrusiveNode>,
+}
+
+impl<'a> IntoIterator for &'a IntrusiveList {
+    type IntoIter = IntrusiveIterator;
+    type Item = &'static IntrusiveNode;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntrusiveIterator {
+            current: self.head.get(),
+        }
+    }
+}
+
+impl Iterator for IntrusiveIterator {
+    type Item = &'static IntrusiveNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut iter = None;
+
+        if let Some(current) = self.current {
+            self.current = current.next;
+            iter = Some(current);
+        }
+
+        iter
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    trait OpA {
+        #[inline]
+        fn a(&self) -> bool {
+            true
+        }
+    }
+
+    trait OpB {
+        #[inline]
+        fn b(&self) -> bool {
+            true
+        }
+    }
+
+    struct RegistrationA {
+        node: Node,
+        owner: Cell<Option<&'static dyn OpA>>,
+    }
+
+    struct RegistrationB {
+        node: Node,
+        owner: Cell<Option<&'static dyn OpB>>,
+    }
+
+    impl NodeContainer for RegistrationA {
+        fn get_node(&self) -> &Node {
+            &self.node
+        }
+    }
+
+    impl NodeContainer for RegistrationB {
+        fn get_node(&self) -> &Node {
+            &self.node
+        }
+    }
+
+    struct ElementA {
+        a: RegistrationA,
+    }
+
+    struct ElementB {
+        b: RegistrationB,
+    }
+
+    struct ElementAB {
+        a: RegistrationA,
+        b: RegistrationB,
+    }
+
+    impl RegistrationA {
+        fn new() -> Self {
+            Self {
+                node: Node::uninit(),
+                owner: Cell::new(None),
+            }
+        }
+
+        fn init<T: OpA>(&self, obj: &'static T) {
+            self.owner.set(Some(obj));
+        }
+
+        fn test(&self) {
+            assert!(self.owner.get().is_some_and(|owner| owner.a()));
+        }
+    }
+
+    impl RegistrationB {
+        fn new() -> Self {
+            Self {
+                node: Node::uninit(),
+                owner: Cell::new(None),
+            }
+        }
+
+        fn init<T: OpB>(&self, obj: &'static T) {
+            self.owner.set(Some(obj));
+        }
+
+        fn test(&self) {
+            assert!(self.owner.get().is_some_and(|owner| owner.b()));
+        }
+    }
+
+    impl OpA for ElementA {}
+    impl OpA for ElementAB {}
+    impl OpB for ElementB {}
+    impl OpB for ElementAB {}
+
+    impl ElementA {
+        fn new() -> Self {
+            Self {
+                a: RegistrationA::new(),
+            }
+        }
+
+        fn register(&'static self, list: &IntrusiveList) -> Result<()> {
+            self.a.init(self);
+            list.push(&self.a)
+        }
+    }
+
+    impl ElementB {
+        fn new() -> Self {
+            Self {
+                b: RegistrationB::new(),
+            }
+        }
+
+        fn register(&'static self, list: &IntrusiveList) -> Result<()> {
+            self.b.init(self);
+            list.push(&self.b)
+        }
+    }
+
+    impl ElementAB {
+        fn new() -> Self {
+            Self {
+                a: RegistrationA::new(),
+                b: RegistrationB::new(),
+            }
+        }
+
+        fn register_a(&'static self, list: &IntrusiveList) -> Result<()> {
+            self.a.init(self);
+            list.push(&self.a)
+        }
+
+        fn register_b(&'static self, list: &IntrusiveList) -> Result<()> {
+            self.b.init(self);
+            list.push(&self.b)
+        }
+    }
+
+    struct RegistrationOnlyOneInstance {}
+    impl NodeContainer for RegistrationOnlyOneInstance {
+        fn get_node(&self) -> &Node {
+            static NODE: OnceLock<Node> = OnceLock::new();
+
+            NODE.get_or_init(Node::uninit)
+        }
+    }
+
+    struct RegistrationOnly {
+        node: Node,
+    }
+
+    impl NodeContainer for RegistrationOnly {
+        fn get_node(&self) -> &Node {
+            &self.node
+        }
+    }
+
+    use embassy_sync::once_lock::OnceLock;
+
+    #[test]
+    fn test_node_internal_validity() {
+        // test if invalid node will block data access
+        // NOTE: this can't be accessed outside of this crate, due to private wrapping of Node::inner.
+        static EMPTY_NODE: OnceLock<RegistrationOnlyOneInstance> = OnceLock::new();
+        let empty_node = EMPTY_NODE.get_or_init(|| RegistrationOnlyOneInstance {});
+
+        // accessing private .inner. here just for test validation. Not a consumer facing scenario
+        // SAFETY: this is not safe. Don't do this. Only here for test completeness
+        let as_element: Option<&RegistrationA> = unsafe { &*empty_node.get_node().inner.as_ptr() }.data();
+        assert!(as_element.is_none());
+    }
+
+    #[test]
+    fn test_list_mixup_checks() {
+        // test if we can mixup nodes manually
+        static EL1: OnceLock<RegistrationA> = OnceLock::new();
+        static EL2: OnceLock<RegistrationA> = OnceLock::new();
+        let first_el = EL1.get_or_init(RegistrationA::new);
+        let second_el = EL2.get_or_init(RegistrationA::new);
+        let list = IntrusiveList::new();
+
+        assert!(list.push(first_el).is_ok());
+        assert!(list.push(second_el).is_ok());
+
+        // guard against circular list construction
+        assert!(list.push(first_el).is_err());
+        assert!(list.push(second_el).is_err());
+
+        // guard against invalid node insertion
+        static SIMPLE_NODE: OnceLock<RegistrationOnly> = OnceLock::new();
+        let simple_node = SIMPLE_NODE.get_or_init(|| RegistrationOnly { node: Node::uninit() });
+        assert!(list.push(simple_node).is_ok());
+
+        // try pushing to a second list
+        let list2 = IntrusiveList::new();
+        assert!(list2.push(simple_node).is_err());
+
+        // ensure that someone can't abuse the get_node() trait to allow list mangling:
+        static EMPTY_NODE: OnceLock<RegistrationOnlyOneInstance> = OnceLock::new();
+        let empty_node = EMPTY_NODE.get_or_init(|| RegistrationOnlyOneInstance {});
+
+        static EMPTY_NODE_UNPUSHABLE: OnceLock<RegistrationOnlyOneInstance> = OnceLock::new();
+        let empty_node_unpushable = EMPTY_NODE_UNPUSHABLE.get_or_init(|| RegistrationOnlyOneInstance {});
+        // place the single iterable instance in first list
+        assert!(list.push(empty_node).is_ok());
+
+        // any subsequent pushes will fail
+        assert!(list.push(empty_node).is_err());
+        assert!(list2.push(empty_node).is_err());
+        assert!(list.push(empty_node_unpushable).is_err());
+        assert!(list2.push(empty_node_unpushable).is_err());
+    }
+
+    #[test]
+    fn test_empty_list() {
+        let list = IntrusiveList::new();
+        for _ in &list {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_monotype_list() {
+        let list_a = IntrusiveList::new();
+        let list_b = IntrusiveList::new();
+        static A: [OnceLock<ElementA>; 5] = [const { OnceLock::new() }; 5];
+        static B: [OnceLock<ElementB>; 5] = [const { OnceLock::new() }; 5];
+
+        // initialize static blocks
+        for a in &A {
+            a.get_or_init(ElementA::new);
+        }
+
+        for b in &B {
+            b.get_or_init(ElementB::new);
+        }
+
+        // construct lists
+        for a in &A {
+            assert!(embassy_futures::block_on(async { a.get().await.register(&list_a) }).is_ok());
+        }
+
+        for b in &B {
+            assert!(embassy_futures::block_on(async { b.get().await.register(&list_b) }).is_ok());
+        }
+
+        // assert validity of lists
+        for ra in &list_a {
+            let a: &RegistrationA = ra.data().unwrap();
+            a.test();
+        }
+
+        for rb in &list_b {
+            let b: &RegistrationB = rb.data().unwrap();
+            b.test();
+        }
+
+        // ensure dynamic type information is preserved
+        for ra in &list_a {
+            let b: Option<&RegistrationB> = ra.data();
+            assert!(b.is_none());
+        }
+    }
+
+    #[test]
+    fn test_multitype_list() {
+        let list_a = IntrusiveList::new();
+        static A: [OnceLock<ElementA>; 5] = [const { OnceLock::new() }; 5];
+        static AB: [OnceLock<ElementAB>; 5] = [const { OnceLock::new() }; 5];
+
+        // initialize static blocks
+        for a in &A {
+            a.get_or_init(ElementA::new);
+        }
+
+        for ab in &AB {
+            ab.get_or_init(ElementAB::new);
+        }
+
+        // construct lists
+        for a in &A {
+            assert!(embassy_futures::block_on(async { a.get().await.register(&list_a) }).is_ok());
+        }
+
+        for ab in &AB {
+            assert!(embassy_futures::block_on(async { ab.get().await.register_a(&list_a) }).is_ok());
+        }
+
+        // assert validity of lists
+        for ra in &list_a {
+            let a: &RegistrationA = ra.data().unwrap();
+            a.test();
+        }
+    }
+
+    #[test]
+    fn test_multi_list() {
+        let list_a = IntrusiveList::new();
+        let list_b = IntrusiveList::new();
+        static A: [OnceLock<ElementA>; 5] = [const { OnceLock::new() }; 5];
+        static B: [OnceLock<ElementB>; 5] = [const { OnceLock::new() }; 5];
+        static AB: [OnceLock<ElementAB>; 5] = [const { OnceLock::new() }; 5];
+
+        // initialize static blocks
+        for a in &A {
+            a.get_or_init(ElementA::new);
+        }
+
+        for b in &B {
+            b.get_or_init(ElementB::new);
+        }
+
+        for ab in &AB {
+            ab.get_or_init(ElementAB::new);
+        }
+
+        // construct lists
+        for a in &A {
+            assert!(embassy_futures::block_on(async { a.get().await.register(&list_a) }).is_ok());
+        }
+
+        for b in &B {
+            assert!(embassy_futures::block_on(async { b.get().await.register(&list_b) }).is_ok());
+        }
+
+        for ab in &AB {
+            embassy_futures::block_on(async {
+                assert!(ab.get().await.register_a(&list_a).is_ok());
+                assert!(ab.get().await.register_b(&list_b).is_ok());
+            });
+        }
+
+        // assert validity of lists
+        for ra in &list_a {
+            let a: &RegistrationA = ra.data().unwrap();
+            a.test();
+        }
+
+        for rb in &list_b {
+            let b: &RegistrationB = rb.data().unwrap();
+            b.test();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,14 @@
 
 #![no_std]
 #![warn(missing_docs)]
+
+pub mod intrusive_list;
+pub use intrusive_list::*;
+
+/// short-hand include all pre-baked services
+pub mod activity;
+
+/// initialize all service static interfaces as required. Ideally, this is done before subsystem initialization
+pub async fn init() {
+    activity::init();
+}


### PR DESCRIPTION
Implements a basic intrusive linked list for managing publisher and subscriber registrations. The activity service is implemented as an example of how that interface can be used.

Pro's:
---
- No need to specify any sizes up front
- Careful usage of traits in Service interfaces allows for extremely simple service layer interactions for consumers + producers alike
- Allows for integration with "mono-thread" or "workflow" based approaches to subsystem design
- Efficient -- sticks to Rust's "get what you use" philosophy

Con's:
---
- Backend required use of unsafe for working with raw pointers (interface does not, however)
- Requires static allocations (though, these will likely exist for any embedded application)