### PR TITLE
embedded-service: Re-add buffer module

### DIFF
--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -8,6 +8,7 @@ pub use intrusive_list::*;
 
 /// short-hand include all pre-baked services
 pub mod activity;
+pub mod buffer;
 pub mod transport;
 
 /// initialize all service static interfaces as required. Ideally, this is done before subsystem initialization


### PR DESCRIPTION
The buffer module was removed from lib.rs during the re-org. Add it back.