### PR TITLE
Add initial type-C skeleton code

### DIFF
--- a/embedded-service/Cargo.toml
+++ b/embedded-service/Cargo.toml
@@ -41,6 +41,8 @@ embedded-hal-nb = { version = "1.0" }
 
 document-features = "0.2.7"
 
+bitfield = "0.17.0"
+
 [dev-dependencies]
 embassy-sync = { git = "https://github.com/embassy-rs/embassy", features = [
     "std",

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -10,6 +10,7 @@ pub use intrusive_list::*;
 pub mod activity;
 pub mod buffer;
 pub mod transport;
+pub mod type_c;
 
 /// initialize all service static interfaces as required. Ideally, this is done before subsystem initialization
 pub async fn init() {

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -1,0 +1,205 @@
+//! PD controller related code
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::once_lock::OnceLock;
+
+use super::ucsi::lpm;
+use super::{ControllerId, Error, PortId};
+use crate::intrusive_list;
+
+/// PD controller command-specific data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum InternalCommandData {
+    /// Reset the PD controller
+    Reset,
+}
+
+/// PD controller command
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Command {
+    /// Controller specific command
+    Controller(InternalCommandData),
+    /// UCSI command passthrough
+    Lpm(lpm::Command),
+}
+
+/// Controller-specific response data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum InternalResponseData {
+    /// Command complete
+    Complete,
+}
+
+impl Into<Result<InternalResponseData, Error>> for InternalResponseData {
+    fn into(self) -> Result<InternalResponseData, Error> {
+        Ok(self)
+    }
+}
+
+/// Response for controller-specific commands
+pub type InternalResponse = Result<InternalResponseData, Error>;
+
+/// PD controller command response
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Response {
+    /// Controller response
+    Controller(InternalResponse),
+    /// UCSI response passthrough
+    Lpm(lpm::Response),
+}
+
+/// PD controller
+pub struct Controller<'a> {
+    node: intrusive_list::Node,
+    id: ControllerId,
+    ports: &'a [PortId],
+    command: Channel<NoopRawMutex, Command, 1>,
+    response: Channel<NoopRawMutex, Response, 1>,
+}
+
+impl intrusive_list::NodeContainer for Controller<'static> {
+    fn get_node(&self) -> &intrusive_list::Node {
+        &self.node
+    }
+}
+
+impl<'a> Controller<'a> {
+    /// Create a new PD controller struct
+    pub fn new(id: ControllerId, ports: &'a [PortId]) -> Self {
+        Self {
+            node: intrusive_list::Node::uninit(),
+            id,
+            ports,
+            command: Channel::new(),
+            response: Channel::new(),
+        }
+    }
+
+    /// Send a command to this controller
+    pub async fn send_command(&self, command: Command) -> Response {
+        self.command.send(command).await;
+        self.response.receive().await
+    }
+
+    /// Check if this controller has the given port
+    pub fn has_port(&self, port: PortId) -> bool {
+        self.ports.iter().any(|p| *p == port)
+    }
+
+    /// Wait for a command to be sent to this controller
+    pub async fn wait_command(&self) -> Command {
+        self.command.receive().await
+    }
+
+    /// Send response
+    pub async fn send_response(&self, response: Response) {
+        self.response.send(response).await;
+    }
+}
+
+/// Trait for types that contain a controller struct
+pub trait ControllerContainer {
+    /// Get the controller struct
+    fn get_controller<'a>(&'a self) -> &'a Controller<'a>;
+}
+
+/// Internal context for managing PD controllers
+struct Context {
+    controllers: intrusive_list::IntrusiveList,
+}
+
+impl Context {
+    fn new() -> Self {
+        Self {
+            controllers: intrusive_list::IntrusiveList::new(),
+        }
+    }
+}
+
+static CONTEXT: OnceLock<Context> = OnceLock::new();
+
+/// Initialize the PD controller context
+pub fn init() {
+    CONTEXT.get_or_init(Context::new);
+}
+
+/// Register a PD controller
+pub async fn register_controller(controller: &'static impl ControllerContainer) -> Result<(), intrusive_list::Error> {
+    CONTEXT.get().await.controllers.push(controller.get_controller())
+}
+
+/// Send a command to the given controller
+async fn send_controller_command(
+    controller_id: ControllerId,
+    command: InternalCommandData,
+) -> Result<InternalResponseData, Error> {
+    let node = CONTEXT
+        .get()
+        .await
+        .controllers
+        .into_iter()
+        .find(|node| {
+            if let Some(controller) = node.data::<Controller>() {
+                controller.id == controller_id
+            } else {
+                false
+            }
+        })
+        .map_or(Error::InvalidController.into(), Ok)?;
+
+    match node
+        .data::<Controller>()
+        .unwrap()
+        .send_command(Command::Controller(command))
+        .await
+    {
+        Response::Controller(response) => response,
+        _ => Error::InvalidResponse.into(),
+    }
+}
+
+/// Reset the given controller
+pub async fn reset_controller(controller_id: ControllerId) -> Result<(), Error> {
+    send_controller_command(controller_id, InternalCommandData::Reset)
+        .await
+        .map(|_| ())
+}
+
+/// Send a command to the given port
+async fn send_port_command(port_id: PortId, command: lpm::CommandData) -> Result<lpm::ResponseData, Error> {
+    let node = CONTEXT
+        .get()
+        .await
+        .controllers
+        .into_iter()
+        .find(|node| {
+            if let Some(controller) = node.data::<Controller>() {
+                controller.has_port(port_id)
+            } else {
+                false
+            }
+        })
+        .map_or(Error::InvalidPort.into(), Ok)?;
+
+    match node
+        .data::<Controller>()
+        .unwrap()
+        .send_command(Command::Lpm(lpm::Command {
+            port: port_id,
+            operation: command,
+        }))
+        .await
+    {
+        Response::Lpm(response) => response,
+        _ => Error::InvalidResponse.into(),
+    }
+}
+
+/// Resets the given port
+pub async fn reset_port(port_id: PortId, reset_type: lpm::ResetType) -> Result<lpm::ResponseData, Error> {
+    send_port_command(port_id, lpm::CommandData::ConnectorReset(reset_type)).await
+}

--- a/embedded-service/src/type_c/mod.rs
+++ b/embedded-service/src/type_c/mod.rs
@@ -1,0 +1,59 @@
+//! Type-C service
+
+pub mod ucsi;
+
+/// Port ID
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PortId(pub u8);
+
+/// Controller ID
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ControllerId(pub u8);
+
+/// PD controller error
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Transport error
+    Transport,
+    /// Bus error
+    Bus,
+    /// Invalid controller
+    InvalidController,
+    /// Unrecognized command
+    UnrecognizedCommand,
+    /// Invalid port
+    InvalidPort,
+    /// Invalid parameters
+    InvalidParams,
+    /// Incompatible partner
+    IncompatiblePartner,
+    /// CC communication error,
+    CcCommunication,
+    /// Failed due to dead battery condition
+    DeadBattery,
+    /// Contract negociation failed
+    ContratctNegociation,
+    /// Overcurrent
+    Overcurrent,
+    /// Swap rejected by port partner
+    SwapRejectedPartner,
+    /// Hard reset
+    HardReset,
+    /// Policy conflict
+    PolicyConflict,
+    /// Swap rejected
+    SwapRejected,
+    /// Reverse current protection
+    ReverseCurrent,
+    /// Set sink path rejected
+    SetSinkPath,
+}
+
+impl<T> Into<Result<T, Error>> for Error {
+    fn into(self) -> Result<T, Error> {
+        Err(self)
+    }
+}

--- a/embedded-service/src/type_c/mod.rs
+++ b/embedded-service/src/type_c/mod.rs
@@ -1,5 +1,6 @@
 //! Type-C service
 
+pub mod controller;
 pub mod ucsi;
 
 /// Port ID
@@ -22,6 +23,8 @@ pub enum Error {
     Bus,
     /// Invalid controller
     InvalidController,
+    /// Invalid response
+    InvalidResponse,
     /// Unrecognized command
     UnrecognizedCommand,
     /// Invalid port

--- a/embedded-service/src/type_c/ucsi/lpm.rs
+++ b/embedded-service/src/type_c/ucsi/lpm.rs
@@ -1,0 +1,37 @@
+use crate::type_c::{Error, PortId};
+
+/// Connector reset types
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResetType {
+    Hard,
+    Data,
+}
+
+/// LPM command data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CommandData {
+    ConnectorReset(ResetType),
+}
+
+/// LPM commands
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Command {
+    pub port: PortId,
+    pub operation: CommandData,
+}
+
+/// LPM response data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    Complete,
+}
+
+impl Into<Result<ResponseData, Error>> for ResponseData {
+    fn into(self) -> Result<ResponseData, Error> {
+        Ok(self)
+    }
+}

--- a/embedded-service/src/type_c/ucsi/lpm.rs
+++ b/embedded-service/src/type_c/ucsi/lpm.rs
@@ -35,3 +35,5 @@ impl Into<Result<ResponseData, Error>> for ResponseData {
         Ok(self)
     }
 }
+
+pub type Response = Result<ResponseData, Error>;

--- a/embedded-service/src/type_c/ucsi/mod.rs
+++ b/embedded-service/src/type_c/ucsi/mod.rs
@@ -1,0 +1,85 @@
+//! Ucsi types, see spec at https://www.usb.org/document-library/usb-type-cr-connector-system-software-interface-ucsi-specification
+#![allow(missing_docs)]
+
+use bitfield::bitfield;
+
+use crate::type_c::Error;
+
+pub mod lpm;
+pub mod ppm;
+
+/// Ucsi opcodes, see spec for more detail
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum UsciOpcode {
+    PpmReset = 0x01,
+    Cancel,
+    ConnectorReset,
+    AckCcCi,
+    SetNotificationEnable,
+    GetCapability,
+    GetConnectorCapability,
+    SetCcom,
+    SetUor,
+    SetPdm,
+    SetPdr,
+    GetAlternateModes,
+    GetCamSupported,
+    GetCurrentCam,
+    SetNewCam,
+    GetPdos,
+    GetCableProperty,
+    GetConnectorStatus,
+    GetErrorStatus,
+    SetPowerLevel,
+    GetPdMessage,
+    GetAttentionVdo,
+    GetCamCs = 0x18,
+    LpmFwUpdateRequest,
+    SecurityRequest,
+    SetRetimerMode,
+    SetSinkPath,
+    SetPdos,
+    ReadPowerLevel,
+    ChunkingSupport,
+    SetUsb = 0x21,
+    GetLpmPpmInfo,
+}
+
+bitfield! {
+    /// Command status and connect change indicator, see spec for more details
+    #[derive(Copy, Clone)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct Cci(u32);
+    impl Debug;
+    pub eom, set_eom: 0, 0;
+    pub port, set_port: 1, 7;
+    pub data_len, set_data_len: 8, 15;
+    pub vdm, set_vdm: 16, 16;
+    pub reserved, _: 17, 22;
+    pub security_req, set_security_req: 23, 23;
+    pub fw_update_req, set_fw_update_req: 24, 24;
+    pub not_supported, set_not_supported: 25, 25;
+    pub cancel_complete, set_cancel_complete: 26, 26;
+    pub reset_complete, set_reset_complete: 27, 27;
+    pub busy, set_busy: 28, 28;
+    pub ack_command, set_ack_command: 29, 29;
+    pub error, set_error: 30, 30;
+    pub cmd_complete, set_cmd_complete: 31, 31;
+}
+
+/// UCSI commands
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Command {
+    PpmCommand(ppm::Command),
+    LpmCommand(lpm::Command),
+}
+
+/// UCSI command responses
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Response {
+    PpmResponse(Result<ppm::ResponseData, Error>),
+    LpmResponse(Result<lpm::ResponseData, Error>),
+}

--- a/embedded-service/src/type_c/ucsi/mod.rs
+++ b/embedded-service/src/type_c/ucsi/mod.rs
@@ -3,8 +3,6 @@
 
 use bitfield::bitfield;
 
-use crate::type_c::Error;
-
 pub mod lpm;
 pub mod ppm;
 
@@ -80,6 +78,6 @@ pub enum Command {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Response {
-    PpmResponse(Result<ppm::ResponseData, Error>),
-    LpmResponse(Result<lpm::ResponseData, Error>),
+    PpmResponse(ppm::Response),
+    LpmResponse(lpm::Response),
 }

--- a/embedded-service/src/type_c/ucsi/ppm.rs
+++ b/embedded-service/src/type_c/ucsi/ppm.rs
@@ -49,3 +49,5 @@ impl Into<Result<ResponseData, Error>> for ResponseData {
         Ok(self)
     }
 }
+
+pub type Response = Result<ResponseData, Error>;

--- a/embedded-service/src/type_c/ucsi/ppm.rs
+++ b/embedded-service/src/type_c/ucsi/ppm.rs
@@ -1,0 +1,51 @@
+use bitfield::bitfield;
+
+use crate::type_c::Error;
+
+bitfield! {
+    /// PPM notifications that can be enabled, see spec for more details
+    #[derive(Copy, Clone)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct SetNotificationEnableData(u32);
+    impl Debug;
+    pub cmd_complete, set_cmd_complete: 0, 0;
+    pub external_supply_change, set_external_supply_change: 1, 1;
+    pub power_op_mode_change, set_power_op_mode_change: 2, 2;
+    pub attention, set_attention: 3, 3;
+    pub fw_update_req, set_fw_update_req: 4, 4;
+    pub provider_caps_change, set_provider_caps_change: 5, 5;
+    pub power_lvl_change, set_power_lvl_change: 6, 6;
+    pub pd_reset_complete, set_pd_reset_complete: 7, 7;
+    pub cam_change, set_cam_change: 8, 8;
+    pub battery_charge_change, set_battery_charge_change: 9, 9;
+    pub security_req, set_security_req: 10, 10;
+    pub connector_partner_change, set_connector_partner_change: 11, 11;
+    pub power_dir_change, set_power_dir_change: 12, 12;
+    pub set_retimer_mode, set_set_retimer_mode: 13, 13;
+    pub connect_change, set_connect_change: 14, 14;
+    pub error, set_error: 15, 15;
+    pub sink_path_change, set_sink_path_change: 16, 16;
+}
+
+/// Commands that only affect the PPM level and don't need to be sent to an LPM
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Command {
+    Reset,
+    Cancel,
+    AckCcCi,
+    SetNotificationEnable(SetNotificationEnableData),
+}
+
+/// PPM command response data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    Complete,
+}
+
+impl Into<Result<ResponseData, Error>> for ResponseData {
+    fn into(self) -> Result<ResponseData, Error> {
+        Ok(self)
+    }
+}

--- a/examples/std/src/bin/type_c.rs
+++ b/examples/std/src/bin/type_c.rs
@@ -1,0 +1,110 @@
+use embassy_executor::{Executor, Spawner};
+use embassy_sync::once_lock::OnceLock;
+use embassy_time::Timer;
+use embedded_services::type_c::ucsi::lpm;
+use embedded_services::type_c::{controller, ControllerId, Error, PortId};
+use log::*;
+use static_cell::StaticCell;
+
+const CONTROLLER0: ControllerId = ControllerId(0);
+const PORT0: PortId = PortId(0);
+const PORT1: PortId = PortId(1);
+
+mod test_controller {
+    use super::*;
+
+    pub struct Controller<'a> {
+        pub controller: controller::Controller<'a>,
+    }
+
+    impl controller::ControllerContainer for Controller<'_> {
+        fn get_controller(&self) -> &controller::Controller {
+            &self.controller
+        }
+    }
+
+    impl<'a> Controller<'a> {
+        pub fn new(id: ControllerId, ports: &'a [PortId]) -> Self {
+            Self {
+                controller: controller::Controller::new(id, ports),
+            }
+        }
+
+        async fn process_controller_command(
+            &self,
+            command: controller::InternalCommandData,
+        ) -> Result<controller::InternalResponseData, Error> {
+            match command {
+                controller::InternalCommandData::Reset => {
+                    info!("Reset controller");
+                    controller::InternalResponseData::Complete.into()
+                }
+            }
+        }
+
+        async fn process_port_command(&self, command: lpm::Command) -> Result<lpm::ResponseData, Error> {
+            match command.operation {
+                lpm::CommandData::ConnectorReset(reset_type) => {
+                    info!("Reset ({:#?}) for port {:#?}", reset_type, command.port);
+                    lpm::ResponseData::Complete.into()
+                }
+            }
+        }
+
+        pub async fn process(&self) {
+            let response = match self.controller.wait_command().await {
+                controller::Command::Controller(command) => {
+                    controller::Response::Controller(self.process_controller_command(command).await)
+                }
+                controller::Command::Lpm(command) => {
+                    controller::Response::Lpm(self.process_port_command(command).await)
+                }
+            };
+
+            self.controller.send_response(response).await
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn controller_task() {
+    static CONTROLLER: OnceLock<test_controller::Controller> = OnceLock::new();
+
+    static PORTS: [PortId; 2] = [PORT0, PORT1];
+
+    let controller = CONTROLLER.get_or_init(|| test_controller::Controller::new(CONTROLLER0, &PORTS));
+    controller::register_controller(controller).await.unwrap();
+
+    loop {
+        controller.process().await;
+    }
+}
+
+#[embassy_executor::task]
+async fn task(spawner: Spawner) {
+    embedded_services::init().await;
+
+    controller::init();
+
+    info!("Starting controller task");
+    spawner.must_spawn(controller_task());
+    // Wait for controller to be registered
+    Timer::after_secs(1).await;
+
+    controller::reset_controller(CONTROLLER0).await.unwrap();
+    info!("Reset controller done");
+    controller::reset_port(PORT0, lpm::ResetType::Hard).await.unwrap();
+    info!("Reset port 0 done");
+    controller::reset_port(PORT1, lpm::ResetType::Data).await.unwrap();
+    info!("Reset port 1 done");
+}
+
+fn main() {
+    env_logger::builder().filter_level(log::LevelFilter::Info).init();
+
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(task(spawner)).unwrap();
+    });
+}


### PR DESCRIPTION
This PR adds the initial type-C service skeleton. The service manages a list of PD controllers and provides functions to send commands to both controllers and ports on the controllers.