### PR TITLE
examples/std: Update for repo re-org

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
         "${workspaceFolder}/embedded-service/Cargo.toml",
         "${workspaceFolder}/power-button-service/Cargo.toml",
         "${workspaceFolder}/examples/rt685s-evk/Cargo.toml",
+        "${workspaceFolder}/examples/std/Cargo.toml",
     ],
     "rust-analyzer.cargo.features": [
     ]

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -20,7 +20,7 @@ embassy-executor = { git = "https://github.com/embassy-rs/embassy", version = "0
     "log",
     "integrated-timers",
 ] }
-embedded-services = { path = "../../" }
+embedded-services = { path = "../../embedded-service" }
 
 env_logger = "0.9.0"
 log = "0.4.14"


### PR DESCRIPTION
Update std example paths following embedded-services repo re-organization.