### PR TITLE
Update crates to rust 1.83

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -213,11 +213,12 @@ jobs:
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
         workdir: [ "embedded-service", "power-button-service"]
-        msrv: ["1.79"] # We're relying on namespaced-features, which
+        msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
                        # 1.79
+                       # Embassy requires 1.83
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/embedded-service/Cargo.toml
+++ b/embedded-service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "Embedded Service Layer for IPC, Feature Customization and Extension in Embedded Devices."
 repository = "https://github.com/pop-project/embedded-services"
-rust-version = "1.79"
+rust-version = "1.83"
 
 [dependencies]
 embassy-sync = { git = "https://github.com/embassy-rs/embassy" }

--- a/power-button-service/Cargo.toml
+++ b/power-button-service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "Power button service built upon embedded service"
 repository = "https://github.com/pop-project/embedded-services"
-rust-version = "1.79"
+rust-version = "1.83"
 
 [dependencies]
 defmt = { version = "0.3", optional = true }


### PR DESCRIPTION
Upstream embassy now requires 1.83