### PR TITLE
Cfu Service

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
+        workdir: [ "embedded-service", "cfu-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,7 +86,7 @@ jobs:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
+        workdir: [ "embedded-service", "cfu-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
+        workdir: [ "embedded-service", "cfu-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,7 +162,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
+        workdir: [ "embedded-service", "cfu-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
+        workdir: [ "embedded-service", "cfu-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -214,7 +214,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
+        workdir: [ "embedded-service", "cfu-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
         msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ EC service houses the business logic that glues the EC peripheral Rust driver + 
   - library crate
 - hid-service
   - library crate
+- cfu-service
+  - library crate
+    - host traits
+    - client traits
 
 ### embedded-services
 
@@ -102,7 +106,7 @@ Protocol agnostric transport allowing dynamic number of endpoints to send and re
     erDiagram
         service_a ||..|| endpoint_a :contains
         endpoint_a ||..|| transport : send_message
-        transport ||--|{ endpoint_b : route
+        transport ||--|| endpoint_b : route
         service_b ||..|| endpoint_b :contains
         transport {
             list endpoint_a

--- a/cfu-service/Cargo.toml
+++ b/cfu-service/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "cfu-service"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# ODP dependencies
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
+embedded-services = { path = "../embedded-service" }
+
+# External dependencies
+binary_serde = "1.0.24"
+embassy-time = { git = "https://github.com/embassy-rs/embassy" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy" }
+log = { version = "0.4.14", optional = true }
+defmt = { version = "0.3", optional = true }
+heapless = "0.8.*"
+
+[features]
+default = []
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embassy-time/defmt",
+    "embassy-sync/defmt",
+    "embassy-executor/defmt",
+    "embedded-cfu-protocol/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "embassy-time/log",
+    "embassy-sync/log",
+    "embassy-executor/log",
+    "embedded-cfu-protocol/log",
+]

--- a/cfu-service/src/host.rs
+++ b/cfu-service/src/host.rs
@@ -1,0 +1,209 @@
+use core::future::Future;
+
+use binary_serde::{BinarySerde, Endianness};
+use embedded_cfu_protocol::components::CfuComponentTraits;
+use embedded_cfu_protocol::host::{CfuHostStates, CfuUpdater};
+use embedded_cfu_protocol::protocol_definitions::*;
+use embedded_cfu_protocol::{CfuImage, CfuWriter, CfuWriterDefault, CfuWriterError};
+use heapless::Vec;
+
+use crate::CfuError;
+
+/// All host side Cfu traits, in some cases this will originate from a OS driver for CFU
+pub trait CfuHost: CfuHostStates {
+    /// Get all images
+    fn get_cfu_images<I: CfuImage>(&self) -> impl Future<Output = Result<Vec<I, MAX_CMPT_COUNT>, CfuError>>;
+    /// Gets the firmware version of all components
+    fn get_all_fw_versions<T: CfuWriter>(
+        self,
+        writer: &mut T,
+        primary_cmpt: ComponentId,
+    ) -> impl Future<Output = Result<GetFwVersionResponse, CfuError>>;
+    /// Goes through the offer list and returns a slice of offer responses
+    fn process_cfu_offers<'a, T: CfuWriter>(
+        offer_commands: &'a [FwUpdateOfferCommand],
+        writer: &mut T,
+    ) -> impl Future<Output = Result<&'a [FwUpdateOfferResponse], CfuError>>;
+    /// For a specific component, update its content
+    fn update_cfu_content<T: CfuWriter>(
+        writer: &mut T,
+    ) -> impl Future<Output = Result<FwUpdateContentResponse, CfuError>>;
+    /// For a specific image that was updated, validate its content
+    fn is_cfu_image_valid<I: CfuImage>(image: I) -> impl Future<Output = Result<bool, CfuError>>;
+}
+
+pub struct CfuHostInstance<I: CfuImage, C: CfuComponentTraits> {
+    pub updater: CfuUpdater,
+    pub images: heapless::Vec<I, MAX_CMPT_COUNT>,
+    pub writer: CfuWriterDefault,
+    pub primary_cmpt: C,
+    pub host_token: HostToken,
+}
+
+impl<I: CfuImage, C: CfuComponentTraits> CfuHostInstance<I, C> {
+    #[allow(unused)]
+    fn new(primary_cmpt: C) -> Self {
+        Self {
+            updater: CfuUpdater {},
+            images: Vec::new(),
+            writer: CfuWriterDefault::default(),
+            primary_cmpt,
+            host_token: 0,
+        }
+    }
+}
+
+impl<I: CfuImage, C: CfuComponentTraits> CfuHostStates for CfuHostInstance<I, C> {
+    async fn start_transaction<T: CfuWriter>(self, _writer: &mut T) -> Result<FwUpdateOfferResponse, CfuProtocolError> {
+        let component_id = self.primary_cmpt.get_component_id();
+        let _mock_cmd = FwUpdateOfferCommand::new_with_command(
+            self.host_token,
+            component_id,
+            FwVersion::default(),
+            0,
+            InformationCodeValues::StartOfferList,
+            0,
+        );
+        let mockresponse = FwUpdateOfferResponse::default();
+        Ok(mockresponse)
+    }
+    async fn notify_start_offer_list<T: CfuWriter>(
+        self,
+        writer: &mut T,
+    ) -> Result<FwUpdateOfferResponse, CfuProtocolError> {
+        // Serialize FwUpdateOfferCommand to bytes, pull out componentid, host token
+        let component_id = self.primary_cmpt.get_component_id();
+        let mock_cmd = FwUpdateOfferCommand::new_with_command(
+            self.host_token,
+            component_id,
+            FwVersion::default(),
+            0,
+            InformationCodeValues::StartOfferList,
+            0,
+        );
+        let mut serialized_mock = [0u8; FwUpdateOfferCommand::SERIALIZED_SIZE];
+        FwUpdateOfferCommand::binary_serialize(&mock_cmd, &mut serialized_mock, Endianness::Little);
+        let mut read = [0u8; FwUpdateOfferResponse::SERIALIZED_SIZE];
+        //self.primary_cmpt.me.writer.write_read_to_component(Some(component_id), &serialized_mock, &mut read).await;
+        if let Ok(_result) = writer.cfu_write_read(None, &serialized_mock, &mut read).await {
+            if let Ok(converted) = FwUpdateOfferResponse::binary_deserialize(&read, Endianness::Little) {
+                if converted.status != CfuOfferStatus::Accept {
+                    Err(CfuProtocolError::CfuStatusError(converted.status))
+                } else {
+                    Ok(converted)
+                }
+            } else {
+                Err(CfuProtocolError::WriterError(CfuWriterError::ByteConversionError))
+            }
+        } else {
+            Err(CfuProtocolError::WriterError(CfuWriterError::StorageError))
+        }
+    }
+
+    async fn notify_end_offer_list<T: CfuWriter>(
+        self,
+        writer: &mut T,
+    ) -> Result<FwUpdateOfferResponse, CfuProtocolError> {
+        let component_id = self.primary_cmpt.get_component_id();
+        let mock_cmd = FwUpdateOfferCommand::new_with_command(
+            self.host_token,
+            component_id,
+            FwVersion::default(),
+            0,
+            InformationCodeValues::EndOfferList,
+            0,
+        );
+        let mut serialized_mock = [0u8; FwUpdateOfferCommand::SERIALIZED_SIZE];
+        FwUpdateOfferCommand::binary_serialize(&mock_cmd, &mut serialized_mock, Endianness::Little);
+        let mut read = [0u8; FwUpdateOfferResponse::SERIALIZED_SIZE];
+        if writer.cfu_write_read(None, &serialized_mock, &mut read).await.is_ok() {
+            // convert back to FwUpdateOfferResponse
+            if let Ok(converted) = FwUpdateOfferResponse::binary_deserialize(&read, Endianness::Little) {
+                Ok(converted)
+            } else {
+                // error deserializing the bytes that were read
+                Err(CfuProtocolError::WriterError(CfuWriterError::ByteConversionError))
+            }
+        } else {
+            // unsuccessful write/read from the storage interface
+            // use result.err() eventually
+            Err(CfuProtocolError::WriterError(CfuWriterError::StorageError))
+        }
+    }
+
+    async fn verify_all_updates_completed(resps: &[FwUpdateOfferResponse]) -> Result<bool, CfuProtocolError> {
+        let mut bad_components: heapless::Vec<u8, MAX_CMPT_COUNT> = Vec::new();
+        for (i, r) in resps.iter().enumerate() {
+            if r.status != CfuOfferStatus::Reject {
+                let _ = bad_components.push(i as u8);
+            }
+        }
+        if bad_components.is_empty() {
+            Ok(true)
+        } else {
+            // probably want to have the component ids that didn't respond properly here too
+            Err(CfuProtocolError::BadResponse)
+        }
+    }
+}
+
+impl<I: CfuImage, C: CfuComponentTraits> CfuHost for CfuHostInstance<I, C> {
+    async fn get_cfu_images<T: CfuImage>(&self) -> Result<Vec<T, MAX_CMPT_COUNT>, CfuError> {
+        Err(CfuError::BadImage)
+    }
+
+    async fn get_all_fw_versions<T: CfuWriter>(
+        self,
+        _writer: &mut T,
+        primary_cmpt: ComponentId,
+    ) -> Result<GetFwVersionResponse, CfuError> {
+        let mut vec: Vec<FwVerComponentInfo, MAX_CMPT_COUNT> = Vec::new();
+        let mut component_count: u8 = 0;
+        self.primary_cmpt.get_subcomponents().iter().for_each(|x| {
+            if x.is_some() {
+                component_count += 1
+            }
+        });
+        let result = self.primary_cmpt.get_fw_version().await;
+        if result.is_ok() {
+            // convert bytes back to a GetFwVersionResponse
+            let inner = FwVerComponentInfo::new(
+                FwVersion {
+                    major: 0,
+                    minor: 1,
+                    variant: 0,
+                },
+                primary_cmpt,
+                BankType::DualBank,
+            );
+            let _ = vec.push(inner);
+            let arr = vec.into_array().unwrap();
+            let resp: GetFwVersionResponse = GetFwVersionResponse {
+                header: GetFwVersionResponseHeader::new(component_count, GetFwVerRespHeaderByte3::default()),
+                component_info: arr,
+                misc_and_protocol_version: 0,
+            };
+            Ok(resp)
+        } else {
+            Err(CfuError::ProtocolError(CfuProtocolError::BadResponse))
+        }
+    }
+
+    async fn process_cfu_offers<'a, T: CfuWriter>(
+        _offer_commands: &'a [FwUpdateOfferCommand],
+        _writer: &mut T,
+    ) -> Result<&'a [FwUpdateOfferResponse], CfuError> {
+        // TODO
+        Err(CfuError::BadImage)
+    }
+
+    async fn update_cfu_content<T: CfuWriter>(_writer: &mut T) -> Result<FwUpdateContentResponse, CfuError> {
+        Err(CfuError::ProtocolError(CfuProtocolError::WriterError(
+            CfuWriterError::Other,
+        )))
+    }
+
+    async fn is_cfu_image_valid<T: CfuImage>(_image: T) -> Result<bool, CfuError> {
+        Ok(true)
+    }
+}

--- a/cfu-service/src/lib.rs
+++ b/cfu-service/src/lib.rs
@@ -1,0 +1,88 @@
+#![no_std]
+use embassy_sync::once_lock::OnceLock;
+use embedded_cfu_protocol::client::CfuReceiveContent;
+use embedded_cfu_protocol::protocol_definitions::*;
+use embedded_services::cfu::component::*;
+use embedded_services::cfu::{CfuError, ContextToken};
+use embedded_services::{comms, error, info};
+
+pub mod host;
+
+pub struct CfuClient {
+    /// Cfu Client context
+    context: ContextToken,
+    /// Comms endpoint
+    tp: comms::Endpoint,
+}
+
+/// use default "do-nothing" implementations
+impl<T, C, E: Default> CfuReceiveContent<T, C, E> for CfuClient {}
+
+impl CfuClient {
+    /// Create a new Cfu Client
+    pub fn create() -> Option<Self> {
+        Some(Self {
+            context: ContextToken::create()?,
+            tp: comms::Endpoint::uninit(comms::EndpointID::Internal(comms::Internal::Nonvol)),
+        })
+    }
+    pub async fn process_request(&self) -> Result<(), CfuError> {
+        let request = self.context.wait_request().await;
+        //let device = self.context.get_device(request.id).await?;
+        let comp = request.id;
+
+        match request.data {
+            RequestData::FwVersionRequest => {
+                info!("Received FwVersionRequest, comp {}", comp);
+                if let Ok(device) = self.context.get_device(comp).await {
+                    let resp = device
+                        .execute_device_request(request.data)
+                        .await
+                        .map_err(CfuError::ProtocolError)?;
+
+                    // TODO replace with signal to component to get its own fw version
+                    //cfu::send_request(comp, RequestData::FwVersionRequest).await?;
+                    match resp {
+                        InternalResponseData::FwVersionResponse(r) => {
+                            let ver = r.component_info[0].fw_version;
+                            info!("got fw version {:?} for comp {}", ver, comp);
+                        }
+                        _ => {
+                            error!("Invalid response to get fw version {:?} from comp {}", resp, comp);
+                            return Err(CfuError::ProtocolError(CfuProtocolError::BadResponse));
+                        }
+                    }
+                    self.context.send_response(resp).await;
+                    return Ok(());
+                }
+                Err(CfuError::InvalidComponent)
+            }
+            RequestData::GiveContent(_content_cmd) => Ok(()),
+            RequestData::GiveOffer(_offer_cmd) => Ok(()),
+            RequestData::PrepareComponentForUpdate => Ok(()),
+            RequestData::FinalizeUpdate => Ok(()),
+        }
+    }
+}
+
+impl comms::MailboxDelegate for CfuClient {
+    fn receive(&self, _message: &comms::Message) {}
+}
+
+#[embassy_executor::task]
+pub async fn task() {
+    info!("Starting cfu client task");
+    static CLIENT: OnceLock<CfuClient> = OnceLock::new();
+    let cfuclient = CLIENT.get_or_init(|| CfuClient::create().expect("cfu client singleton already initialized"));
+
+    if comms::register_endpoint(cfuclient, &cfuclient.tp).await.is_err() {
+        error!("Failed to register cfu endpoint");
+        return;
+    }
+
+    loop {
+        if let Err(e) = cfuclient.process_request().await {
+            error!("Error processing request: {:?}", e);
+        }
+    }
+}

--- a/embedded-service/Cargo.toml
+++ b/embedded-service/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/OpenDevicePartnership/embedded-services"
 rust-version = "1.83"
 
 [dependencies]
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", optional = true }
 embassy-time = { git = "https://github.com/embassy-rs/embassy" }
@@ -28,6 +29,7 @@ embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
 rand_core = "0.6.4"
 fixed = "1.23.1"
+heapless = "0.8.*"
 
 postcard = "1.*"
 serde = { version = "1.0.*", default-features = false }
@@ -60,6 +62,7 @@ defmt = [
     "embassy-executor/defmt",
     "embassy-futures/defmt",
     "embedded-usb-pd/defmt",
+    "embedded-cfu-protocol/defmt",
 ]
 log = [
     "dep:log",
@@ -67,4 +70,5 @@ log = [
     "embassy-time/log",
     "embassy-executor/log",
     "embassy-futures/log",
+    "embedded-cfu-protocol/log",
 ]

--- a/embedded-service/src/cfu/component.rs
+++ b/embedded-service/src/cfu/component.rs
@@ -1,0 +1,353 @@
+//! Device struct and methods for component communication
+use core::future::Future;
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::mutex::Mutex;
+use embedded_cfu_protocol::components::{CfuComponentInfo, CfuComponentStorage, CfuComponentTraits};
+use embedded_cfu_protocol::protocol_definitions::*;
+use embedded_cfu_protocol::{CfuWriter, CfuWriterError};
+use heapless::Vec;
+
+use super::CfuError;
+use crate::cfu::route_request;
+use crate::intrusive_list;
+
+/// Component internal update state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ComponentState {
+    /// Component not currently processing an update
+    Idle,
+    /// Component is ready to receive an offer,
+    Ready,
+    /// Component is busy with an update
+    Busy,
+    /// Component has received all new fw bytes and needs finalization logic
+    FinalizingUpdate,
+}
+
+/// Internal device state for power policy
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct InternalState {
+    /// Current state of the device
+    pub state: ComponentState,
+    /// Current consumer capability
+    pub waiting_on_subs: bool,
+}
+
+impl InternalState {
+    /// Constructor for a given `state`
+    pub fn new(state: ComponentState) -> Self {
+        Self {
+            state,
+            waiting_on_subs: false,
+        }
+    }
+    /// Constructor that uses given values for both `state` and `waiting_on_subs`
+    pub fn new_with_subcomponent_info(state: ComponentState, waiting_on_subs: bool) -> Self {
+        Self { state, waiting_on_subs }
+    }
+}
+
+impl Default for InternalState {
+    fn default() -> Self {
+        Self::new(ComponentState::Idle)
+    }
+}
+
+/// CFU Request types and necessary data
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RequestData {
+    /// Request for component's current FW version
+    FwVersionRequest,
+    /// Contains an offer for the component to evaluate
+    GiveOffer(FwUpdateOfferCommand),
+    /// Contains bytes for an accepted fw offer
+    GiveContent(FwUpdateContentCommand),
+    /// Request for component to prepare itself for an update
+    PrepareComponentForUpdate,
+    /// Request for component to execute any logic needed to finalize update
+    FinalizeUpdate,
+}
+
+/// CFU Response types and necessary data
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum InternalResponseData {
+    /// Component is mid-update and auto-rejecting offers
+    ComponentBusy,
+    /// Full response struct for getfwversion request
+    FwVersionResponse(GetFwVersionResponse),
+    /// Full response struct for fwupdateoffer request
+    OfferResponse(FwUpdateOfferResponse),
+    /// Response for each packet of fw update
+    ContentResponse(FwUpdateContentResponse),
+    /// Component has sub-components which also need to prep for fw update
+    PrimaryNeedsSubcomponentsPrepared([ComponentId; MAX_CMPT_COUNT - 1]),
+    /// Subcomponent versions
+    SubcomponentFwVersionResponse([FwVerComponentInfo; MAX_CMPT_COUNT - 1]),
+    /// Component is ready to receive offers
+    ComponentPrepared,
+}
+
+/// Channel size for device requests
+pub const DEVICE_CHANNEL_SIZE: usize = 1;
+
+/// CfuDevice struct
+/// Can be inserted in an intrusive-list+
+pub struct CfuDevice {
+    node: intrusive_list::Node,
+    component_id: ComponentId,
+    state: Mutex<NoopRawMutex, InternalState>,
+    request: Channel<NoopRawMutex, RequestData, DEVICE_CHANNEL_SIZE>,
+    response: Channel<NoopRawMutex, InternalResponseData, DEVICE_CHANNEL_SIZE>,
+}
+
+impl intrusive_list::NodeContainer for CfuDevice {
+    fn get_node(&self) -> &intrusive_list::Node {
+        &self.node
+    }
+}
+
+/// Trait for any container that holds a device
+pub trait CfuDeviceContainer {
+    /// Get the underlying device struct
+    fn get_cfu_component_device(&self) -> &CfuDevice;
+}
+
+impl CfuDeviceContainer for CfuDevice {
+    fn get_cfu_component_device(&self) -> &CfuDevice {
+        self
+    }
+}
+
+impl CfuDevice {
+    /// Constructor for CfuDevice
+    pub fn new(component_id: ComponentId) -> Self {
+        Self {
+            node: intrusive_list::Node::uninit(),
+            component_id,
+            state: Mutex::new(InternalState::default()),
+            request: Channel::new(),
+            response: Channel::new(),
+        }
+    }
+    /// Getter for component id
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+    /// Setter for component state
+    /// Intended to be used to auto-block updates if one is in-progress
+    pub async fn state(&self) -> InternalState {
+        *self.state.lock().await
+    }
+    /// Sends a request to this device and returns a response
+    pub async fn execute_device_request(&self, request: RequestData) -> Result<InternalResponseData, CfuProtocolError> {
+        self.request.send(request).await;
+        Ok(self.response.receive().await)
+    }
+
+    /// Wait for a request
+    pub async fn wait_request(&self) -> RequestData {
+        self.request.receive().await
+    }
+
+    /// Send a response
+    pub async fn send_response(&self, response: InternalResponseData) {
+        self.response.send(response).await;
+    }
+}
+
+/// Example for CFU Component
+pub struct CfuComponentDefault<W: CfuWriter> {
+    device: CfuDevice,
+    is_dual_bank: bool,
+    is_primary: bool,
+    storage_offset: usize,
+    subcomponents: [Option<ComponentId>; MAX_SUBCMPT_COUNT],
+    writer: Mutex<NoopRawMutex, W>,
+}
+
+impl<W: CfuWriter + Default> Default for CfuComponentDefault<W> {
+    fn default() -> Self {
+        Self::new(1, false, [None; MAX_SUBCMPT_COUNT], W::default())
+    }
+}
+
+impl<W: CfuWriter> CfuDeviceContainer for CfuComponentDefault<W> {
+    fn get_cfu_component_device(&self) -> &CfuDevice {
+        &self.device
+    }
+}
+
+impl<W: CfuWriter> CfuComponentDefault<W> {
+    /// Constructor
+    pub fn new(
+        id: ComponentId,
+        is_primary: bool,
+        subcomponents: [Option<ComponentId>; MAX_SUBCMPT_COUNT],
+        writer: W,
+    ) -> Self {
+        Self {
+            device: CfuDevice::new(id),
+            is_dual_bank: false,
+            is_primary,
+            storage_offset: 0,
+            subcomponents,
+            writer: Mutex::new(writer),
+        }
+    }
+    /// wait for a request and process it
+    pub async fn process_request(&self) -> Result<(), CfuError> {
+        match self.device.wait_request().await {
+            RequestData::FwVersionRequest => {
+                let fwv = self.get_fw_version().await.map_err(CfuError::ProtocolError)?;
+                let dev_inf = FwVerComponentInfo::new(fwv, self.get_component_id(), BankType::SingleBank);
+                let mut comp_info: [FwVerComponentInfo; MAX_CMPT_COUNT] = [dev_inf; MAX_CMPT_COUNT];
+                if self.is_primary_component() && self.get_subcomponents()[0].is_some() {
+                    let arr = self
+                        .get_subcomponents()
+                        .iter()
+                        .map(|x| x.unwrap_or_default())
+                        .collect::<Vec<ComponentId, MAX_SUBCMPT_COUNT>>();
+                    for (index, id) in arr.iter().enumerate() {
+                        //info!("Forwarding GetFwVersion command to sub-component: {}", id);
+                        if let InternalResponseData::FwVersionResponse(fwv) =
+                            route_request(*id, RequestData::FwVersionRequest).await?
+                        {
+                            // adding 1 here is safe because MAX_CMPT_COUNT is 1 more than MAX_SUBCMPT_COUNT
+                            comp_info[index + 1] = fwv.component_info[0];
+                        } else {
+                            /*error!(
+                                "Failed to get firmware version from sub-component: {}, adding dummy info to list",
+                                id
+                            );*/
+                            comp_info[index + 1] = FwVerComponentInfo::new(
+                                FwVersion::default(),
+                                ComponentId::default(),
+                                BankType::SingleBank,
+                            );
+                        }
+                    }
+                }
+                let resp = GetFwVersionResponse {
+                    header: GetFwVersionResponseHeader::default(),
+                    component_info: comp_info,
+                    misc_and_protocol_version: 0,
+                };
+                self.device
+                    .send_response(InternalResponseData::FwVersionResponse(resp))
+                    .await;
+            }
+            RequestData::PrepareComponentForUpdate => {
+                self.storage_prepare()
+                    .await
+                    .map_err(|_| CfuError::ProtocolError(CfuProtocolError::BadResponse))?;
+            }
+            RequestData::GiveOffer(buf) => {
+                // accept any and all offers regardless of what version it is
+                if buf.component_info.component_id == self.get_component_id() {
+                    let resp = FwUpdateOfferResponse::new_accept(0);
+                    self.device
+                        .send_response(InternalResponseData::OfferResponse(resp))
+                        .await;
+                }
+            }
+            RequestData::GiveContent(buf) => {
+                let offset = buf.header.firmware_address as usize;
+                self.writer
+                    .lock()
+                    .await
+                    .cfu_write(Some(offset), &buf.data)
+                    .await
+                    .map_err(|e| CfuError::ProtocolError(CfuProtocolError::WriterError(e)))?;
+            }
+            RequestData::FinalizeUpdate => {}
+        }
+        Ok(())
+    }
+}
+
+impl<W: CfuWriter> CfuComponentInfo for CfuComponentDefault<W> {
+    fn get_component_id(&self) -> ComponentId {
+        self.device.component_id()
+    }
+    fn get_fw_version(&self) -> impl Future<Output = Result<FwVersion, CfuProtocolError>> {
+        default_get_fw_version()
+    }
+    fn is_offer_valid(
+        &self,
+    ) -> impl Future<Output = Result<CfuOfferResponseStatus, (CfuOfferResponseStatus, RejectReason)>> {
+        default_is_offer_valid()
+    }
+    fn is_dual_bank(&self) -> bool {
+        self.is_dual_bank
+    }
+    fn is_primary_component(&self) -> bool {
+        self.is_primary
+    }
+    fn get_subcomponents(&self) -> [Option<ComponentId>; MAX_SUBCMPT_COUNT] {
+        self.subcomponents
+    }
+}
+
+impl<W: CfuWriter> CfuWriter for CfuComponentDefault<W> {
+    async fn cfu_write(&self, mem_offset: Option<usize>, data: &[u8]) -> Result<(), CfuWriterError> {
+        self.writer.lock().await.cfu_write(mem_offset, data).await
+    }
+    async fn cfu_write_read(
+        &self,
+        mem_offset: Option<usize>,
+        data: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), CfuWriterError> {
+        self.writer.lock().await.cfu_write_read(mem_offset, data, read).await
+    }
+
+    async fn cfu_read(&self, mem_offset: Option<usize>, read: &mut [u8]) -> Result<(), CfuWriterError> {
+        self.writer.lock().await.cfu_write(mem_offset, read).await
+    }
+}
+
+impl<W: CfuWriter> CfuComponentStorage for CfuComponentDefault<W> {
+    fn get_storage_offset(&self) -> usize {
+        self.storage_offset
+    }
+    async fn storage_finalize(&self) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+    async fn storage_prepare(&self) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+    async fn storage_write(&self) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+}
+
+async fn default_is_offer_valid() -> Result<CfuOfferResponseStatus, (CfuOfferResponseStatus, RejectReason)> {
+    Err((CfuOfferResponseStatus::ErrorNoOffer, RejectReason::RejectOldFw))
+}
+async fn default_get_fw_version() -> Result<FwVersion, CfuProtocolError> {
+    Ok(FwVersion::default())
+}
+
+impl<W: CfuWriter + Default> CfuComponentTraits for CfuComponentDefault<W> {}
+
+/// Example Wrapper for CFU Component
+/// Takes type which implements `CFUComponentTraits` and `CfuDeviceContainer`
+/// for message passing and cfu functionality and wraps it in a `RefCell`
+/// for interior mutability
+pub struct CfuWrapperDefault<C: CfuComponentTraits + CfuDeviceContainer + 'static> {
+    /// internal reference to the component
+    pub component: &'static C,
+}
+
+impl<C: CfuComponentTraits + CfuDeviceContainer + 'static> CfuWrapperDefault<C> {
+    /// Constructor
+    pub fn new(component: &'static C) -> Self {
+        Self { component }
+    }
+}

--- a/embedded-service/src/cfu/mod.rs
+++ b/embedded-service/src/cfu/mod.rs
@@ -1,0 +1,151 @@
+//! Cfu Service related data structures and messages
+//pub mod action;
+pub mod component;
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::once_lock::OnceLock;
+use embedded_cfu_protocol::protocol_definitions::{CfuProtocolError, ComponentId};
+
+use crate::cfu::component::{CfuDevice, CfuDeviceContainer, InternalResponseData, RequestData, DEVICE_CHANNEL_SIZE};
+use crate::{error, intrusive_list};
+
+/// Error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CfuError {
+    /// Image did not pass validation
+    BadImage,
+    /// Component either doesn't exist
+    InvalidComponent,
+    /// Component is busy
+    ComponentBusy,
+    /// Component encountered a protocol error during execution
+    ProtocolError(CfuProtocolError),
+}
+
+/// Request to the power policy service
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Request {
+    /// Component that sent this request
+    pub id: ComponentId,
+    /// Request data
+    pub data: RequestData,
+}
+
+/// Cfu context
+struct ClientContext {
+    /// Registered devices
+    devices: intrusive_list::IntrusiveList,
+    /// Request to components
+    request: Channel<NoopRawMutex, Request, { DEVICE_CHANNEL_SIZE }>,
+    /// Response from components
+    response: Channel<NoopRawMutex, InternalResponseData, { DEVICE_CHANNEL_SIZE }>,
+}
+
+impl ClientContext {
+    fn new() -> Self {
+        Self {
+            devices: intrusive_list::IntrusiveList::new(),
+            request: Channel::new(),
+            response: Channel::new(),
+        }
+    }
+}
+
+static CONTEXT: OnceLock<ClientContext> = OnceLock::new();
+
+/// Init Cfu Client service
+pub fn init() {
+    CONTEXT.get_or_init(ClientContext::new);
+}
+
+/// Register a device with the Cfu Client service
+pub async fn register_device(device: &'static impl CfuDeviceContainer) -> Result<(), intrusive_list::Error> {
+    let device = device.get_cfu_component_device();
+    if get_device(device.component_id()).await.is_some() {
+        return Err(intrusive_list::Error::NodeAlreadyInList);
+    }
+
+    CONTEXT.get().await.devices.push(device)
+}
+
+/// Find a device by its ID
+async fn get_device(id: ComponentId) -> Option<&'static CfuDevice> {
+    for device in &CONTEXT.get().await.devices {
+        if let Some(data) = device.data::<CfuDevice>() {
+            if data.component_id() == id {
+                return Some(data);
+            }
+        } else {
+            error!("Non-device located in devices list");
+        }
+    }
+
+    None
+}
+
+/// Convenience function to send a request to the Cfu service
+pub async fn send_request(from: ComponentId, request: RequestData) -> Result<InternalResponseData, CfuError> {
+    let context = CONTEXT.get().await;
+    context
+        .request
+        .send(Request {
+            id: from,
+            data: request,
+        })
+        .await;
+    Ok(context.response.receive().await)
+}
+
+/// Convenience function to route a request to a specific component
+pub async fn route_request(to: ComponentId, request: RequestData) -> Result<InternalResponseData, CfuError> {
+    let device = get_device(to).await;
+    if device.is_none() {
+        return Err(CfuError::InvalidComponent);
+    }
+    device
+        .unwrap()
+        .execute_device_request(request)
+        .await
+        .map_err(CfuError::ProtocolError)
+}
+
+/// Singleton struct to give access to the cfu client context
+pub struct ContextToken(());
+
+impl ContextToken {
+    /// Create a new context token, returning None if this function has been called before
+    pub fn create() -> Option<Self> {
+        static INIT: AtomicBool = AtomicBool::new(false);
+        if INIT.load(Ordering::SeqCst) {
+            return None;
+        }
+
+        INIT.store(true, Ordering::SeqCst);
+        Some(ContextToken(()))
+    }
+
+    /// Wait for a cfu request
+    pub async fn wait_request(&self) -> Request {
+        CONTEXT.get().await.request.receive().await
+    }
+
+    /// Send a response to a cfu request
+    pub async fn send_response(&self, response: InternalResponseData) {
+        CONTEXT.get().await.response.send(response).await
+    }
+
+    /// Get a device by its ID
+    pub async fn get_device(&self, id: ComponentId) -> Result<&'static CfuDevice, CfuError> {
+        get_device(id).await.ok_or(CfuError::InvalidComponent)
+    }
+
+    /// Provides access to the device list
+    pub async fn devices(&self) -> &intrusive_list::IntrusiveList {
+        &CONTEXT.get().await.devices
+    }
+}

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -9,6 +9,7 @@ pub use intrusive_list::*;
 /// short-hand include all pre-baked services
 pub mod activity;
 pub mod buffer;
+pub mod cfu;
 pub mod comms;
 pub mod ec_type;
 pub mod fmt;
@@ -22,6 +23,7 @@ pub async fn init() {
     comms::init();
     activity::init();
     hid::init();
+    cfu::init();
     keyboard::init();
     power::policy::init();
 }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 embassy-sync = { git = "https://github.com/embassy-rs/embassy", features = [
     "log",
+    "std",
 ] }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", optional = true }
 embassy-time = { git = "https://github.com/embassy-rs/embassy", features = [
@@ -25,7 +26,10 @@ embedded-services = { path = "../../embedded-service", features = ["log"] }
 power-policy-service = { path = "../../power-policy-service", features = [
     "log",
 ] }
+cfu-service = { path = "../../cfu-service", features = ["log"] }
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 
 env_logger = "0.9.0"
 log = "0.4.14"
+heapless = "0.8.0"
 static_cell = "2"

--- a/examples/std/src/bin/cfu_client.rs
+++ b/examples/std/src/bin/cfu_client.rs
@@ -1,0 +1,100 @@
+use embassy_executor::{Executor, Spawner};
+use embassy_sync::once_lock::OnceLock;
+use embedded_cfu_protocol::CfuWriterDefault;
+use log::*;
+use static_cell::StaticCell;
+
+use embedded_cfu_protocol::protocol_definitions::{ComponentId, FwUpdateOfferCommand, FwVersion, MAX_SUBCMPT_COUNT};
+use embedded_services::cfu;
+use embedded_services::cfu::component::CfuComponentDefault;
+
+use crate::cfu::component::RequestData;
+
+#[embassy_executor::task]
+async fn device_task0(component: &'static CfuComponentDefault<CfuWriterDefault>) {
+    loop {
+        if let Err(e) = component.process_request().await {
+            error!("Error processing request: {:?}", e);
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn device_task1(component: &'static CfuComponentDefault<CfuWriterDefault>) {
+    loop {
+        if let Err(e) = component.process_request().await {
+            error!("Error processing request: {:?}", e);
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn run(spawner: Spawner) {
+    embedded_services::init().await;
+
+    info!("Creating device 0");
+    static DEVICE0: OnceLock<CfuComponentDefault<CfuWriterDefault>> = OnceLock::new();
+    let mut subs: [Option<ComponentId>; MAX_SUBCMPT_COUNT] = [None; MAX_SUBCMPT_COUNT];
+    subs[0] = Some(2);
+    let device0 = DEVICE0.get_or_init(|| CfuComponentDefault::new(1, true, subs, CfuWriterDefault::new()));
+    cfu::register_device(device0).await.unwrap();
+    spawner.must_spawn(device_task0(device0));
+
+    info!("Creating device 1");
+    static DEVICE1: OnceLock<CfuComponentDefault<CfuWriterDefault>> = OnceLock::new();
+    let device1 =
+        DEVICE1.get_or_init(|| CfuComponentDefault::new(2, false, [None; MAX_SUBCMPT_COUNT], CfuWriterDefault::new()));
+    cfu::register_device(device1).await.unwrap();
+    spawner.must_spawn(device_task1(device1));
+
+    let dummy_offer0 = FwUpdateOfferCommand::new(
+        0,
+        1,
+        FwVersion {
+            major: 1,
+            minor: 23,
+            variant: 45,
+        },
+        0,
+        0,
+    );
+    let dummy_offer1 = FwUpdateOfferCommand::new(
+        0,
+        2,
+        FwVersion {
+            major: 1,
+            minor: 23,
+            variant: 45,
+        },
+        0,
+        0,
+    );
+
+    match cfu::route_request(1, RequestData::GiveOffer(dummy_offer0)).await {
+        Ok(resp) => {
+            info!("got okay response to device0 update {:?}", resp);
+        }
+        Err(e) => {
+            error!("offer failed with error {:?}", e);
+        }
+    }
+    match cfu::route_request(2, RequestData::GiveOffer(dummy_offer1)).await {
+        Ok(resp) => {
+            info!("got okay response to device1 update {:?}", resp);
+        }
+        Err(e) => {
+            error!("device1 offer failed with error {:?}", e);
+        }
+    }
+}
+
+fn main() {
+    env_logger::builder().filter_level(log::LevelFilter::Info).init();
+
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.must_spawn(cfu_service::task());
+        spawner.must_spawn(run(spawner));
+    });
+}


### PR DESCRIPTION
Defines a Cfu Client service crate, integrates the necessary hooks in the embedded-service crate, and creates an example for a cfu-client.

This PR also stubs out a Cfu host service based on the host traits from the pulled in embedded-cfu-protocol crate. Most EC's will be clients and not hosts for CFU offers.