### PR TITLE
embedded-service: refactor logging macros

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -173,7 +173,7 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # --feature-powerset runs for every combination of features
       - name: cargo hack
-        run: cargo hack --feature-powerset check
+        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check
         working-directory: ${{ matrix.workdir }}
 
   deny:
@@ -230,5 +230,7 @@ jobs:
         with:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
-        run: cargo check
+        run: |
+          cargo check -F log
+          cargo check -F defmt
         working-directory: ${{ matrix.workdir }}

--- a/embedded-service/src/fmt.rs
+++ b/embedded-service/src/fmt.rs
@@ -1,81 +1,179 @@
 //! Logging macro implementations and other formating functions
 
-/// Logs a trace message using the underlying logger
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! trace {
-    ($s:literal $(, $x:expr)* $(,)?) => {
-        {
-            #[cfg(feature = "defmt")]
-            ::defmt::trace!($s $(, $x)*);
-            #[cfg(feature = "log")]
-            ::log::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "defmt", feature = "log")))]
-            let _ = ($( & $x ),*);
-        }
-    };
+#[cfg(all(feature = "log", feature = "defmt", not(doc)))]
+compile_error!("features `log` and `defmt` are mutually exclusive");
+
+#[cfg(all(not(doc), feature = "defmt"))]
+mod defmt {
+    /// Logs a trace message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! trace {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::defmt::trace!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs a debug message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! debug {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::defmt::debug!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs an info message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! info {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::defmt::info!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs a warning using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! warn {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::defmt::warn!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs an error using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! error {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::defmt::error!($s $(, $x)*);
+            }
+        };
+    }
 }
 
-/// Logs a debug message using the underlying logger
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! debug {
-    ($s:literal $(, $x:expr)* $(,)?) => {
-        {
-            #[cfg(feature = "defmt")]
-            ::defmt::debug!($s $(, $x)*);
-            #[cfg(feature = "log")]
-            ::log::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "defmt", feature = "log")))]
-            let _ = ($( & $x ),*);
-        }
-    };
+#[cfg(all(not(doc), feature = "log"))]
+mod log {
+    /// Logs a trace message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! trace {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::log::trace!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs a debug message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! debug {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::log::debug!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs an info message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! info {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::log::info!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs a warning using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! warn {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::log::warn!($s $(, $x)*);
+            }
+        };
+    }
+
+    /// Logs an error using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! error {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                ::log::error!($s $(, $x)*);
+            }
+        };
+    }
 }
 
-/// Logs a info message using the underlying logger
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! info {
-    ($s:literal $(, $x:expr)* $(,)?) => {
-        {
-            #[cfg(feature = "defmt")]
-            ::defmt::info!($s $(, $x)*);
-            #[cfg(feature = "log")]
-            ::log::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "defmt", feature = "log")))]
-            let _ = ($( & $x ),*);
-        }
-    };
-}
+// Provide this implementation for `cargo doc`
+#[cfg(any(doc, not(any(feature = "defmt", feature = "log"))))]
+mod none {
+    /// Logs a trace message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! trace {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                let _ = ($( & $x ),*);
+            }
+        };
+    }
 
-/// Logs a warning using the underlying logger
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! warn {
-    ($s:literal $(, $x:expr)* $(,)?) => {
-        {
-            #[cfg(feature = "defmt")]
-            ::defmt::warn!($s $(, $x)*);
-            #[cfg(feature = "log")]
-            ::log::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "defmt", feature = "log")))]
-            let _ = ($( & $x ),*);
-        }
-    };
-}
+    /// Logs a debug message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! debug {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                let _ = ($( & $x ),*);
+            }
+        };
+    }
 
-/// Logs an error using the underlying logger
-#[macro_export]
-#[collapse_debuginfo(yes)]
-macro_rules! error {
-    ($s:literal $(, $x:expr)* $(,)?) => {
-        {
-            #[cfg(feature = "defmt")]
-            ::defmt::error!($s $(, $x)*);
-            #[cfg(feature = "log")]
-            ::log::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "defmt", feature = "log")))]
-            let _ = ($( & $x ),*);
-        }
-    };
+    /// Logs an info message using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! info {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                let _ = ($( & $x ),*);
+            }
+        };
+    }
+
+    /// Logs a warning using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! warn {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                let _ = ($( & $x ),*);
+            }
+        };
+    }
+
+    /// Logs an error using the underlying logger
+    #[macro_export]
+    #[collapse_debuginfo(yes)]
+    macro_rules! error {
+        ($s:literal $(, $x:expr)* $(,)?) => {
+            {
+                let _ = ($( & $x ),*);
+            }
+        };
+    }
 }

--- a/power-button-service/Cargo.toml
+++ b/power-button-service/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.83"
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+log = { version = "0.4.14", optional = true }
 embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }


### PR DESCRIPTION
Split up logging macros implementations along feature lines. Using these macros as is in dependent crates can leak the `defmt` and `log` features resulting in warnings if it only supports one of the features.