### PR TITLE
workflows: Update cargo doc invocations to not enable both defmt and log

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -145,7 +145,9 @@ jobs:
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo doc
-        run: cargo doc --no-deps --all-features
+        run: |
+          cargo doc --no-deps -F log
+          cargo doc --no-deps -F defmt
         env:
           RUSTDOCFLAGS: --cfg docsrs
         working-directory: ${{ matrix.workdir }}


### PR DESCRIPTION
These features are mutally exclusive in embassy so run docs on both.