### PR TITLE
Adding storage bus traits

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,7 +86,7 @@ jobs:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,7 +162,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -214,7 +214,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "hid-service", "power-button-service", "storage-bus"]
         msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         target: [thumbv8m.main-none-eabihf]
-        workdir: [ "embedded-service", "espi-service", "power-button-service"]
+        workdir: [ "embedded-service", "espi-service", "power-button-service", "storage-bus"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/storage-bus/Cargo.toml
+++ b/storage-bus/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "storage_bus"
+version = "0.1.1"
+edition = "2021"
+description = "Storage Bus interfaces"
+repository = "https://github.com/OpenDevicePartnership/embedded-services"
+rust-version = "1.83"
+license = "MIT"
+
+[dependencies]
+embedded-services = { path = "../embedded-service" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy" }
+defmt = { version = "0.3", optional = true }
+log = { version = "0.4.14", optional = true }
+
+[features]
+default = []
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embassy-time/defmt",
+    "embassy-sync/defmt",
+    "embassy-executor/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "embassy-time/log",
+    "embassy-sync/log",
+    "embassy-executor/log",
+]

--- a/storage-bus/README.md
+++ b/storage-bus/README.md
@@ -1,0 +1,43 @@
+# Introduction
+The goal of this design is to propose a generic Storage Bus Driver interface to all flash Device drivers. Flash device drivers such as Macronix or Winbond driver can access storage devices over different kinds of busses. E.g. communication could be through SPI bus or FlexSPI Bus based on platform design. 
+
+Bus drivers introduce abstraction using generic storage traits and expose them to NOR device drivers such as Macronix or Winbond to communicate with the Hardware without worrying about low level bus protocol details. 
+
+Bus driver + generic storage traits can handle other protocol such as I2C or NVMe without any impact to the device drivers. 
+
+# Static Design
+
+## Storage Bus Driver design
+```mermaid
+        classDiagram
+            class Macronix-Device-Driver
+            class Storage-Bus["Storage Bus trait"]
+            class Spi-Storage-Bus
+            class Spi-Hal
+            class Winbond-Device-Driver
+            Winbond-Device-Driver <|--|> Storage-Bus
+            <<interface>> Storage-Bus
+            Macronix-Device-Driver <|--|> Storage-Bus
+            Storage-Bus <|--|> Spi-Storage-Bus
+            Spi-Hal <|--|> Spi-Storage-Bus
+```
+
+## Example
+```
+/// SPI Bus driver instance 
+
+pub struct SpiNorStorageBus { 
+    // Structure Fields 
+} 
+
+impl BlockingNorStorageBusDriver for SpiNorStorageBus {
+    fn send_command(
+        &mut self,
+        cmd: NorStorageCmd,
+        read_buf: Option<&mut [u8]>,
+        write_buf: Option<&[u8]>,
+    ) -> Result<(), impl NorStorageBusError> {
+        // Handle the storage commands
+    }
+}
+```

--- a/storage-bus/src/lib.rs
+++ b/storage-bus/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+
+pub mod nand;
+pub mod nor;

--- a/storage-bus/src/nand.rs
+++ b/storage-bus/src/nand.rs
@@ -1,0 +1,7 @@
+/// Blocking NAND Storage Driver. The trait introduces a method to send command to the bus
+/// The NAND device driver should use this trait APIs to send command to the bus
+pub trait BlockingNandStorageBusDriver {}
+
+/// Async NAND Storage Driver. The trait introduces a method to send command to the bus
+/// The NAND device driver should use this trait APIs to send command to the bus
+pub trait AsyncNandStorageBusDriver {}

--- a/storage-bus/src/nor.rs
+++ b/storage-bus/src/nor.rs
@@ -1,0 +1,129 @@
+#[derive(Debug, Copy, Clone, PartialEq)]
+/// Storage Mode
+pub enum NorStorageCmdMode {
+    /// Double Data Rate mode for data transfer
+    DDR,
+    /// Single Data Rate mode for data transfer
+    SDR,
+}
+#[derive(Debug, Copy, Clone)]
+/// Storage Command Type
+pub enum NorStorageCmdType {
+    /// Read transfer type
+    Read,
+    /// Write transfer type
+    Write,
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Bus Width
+pub enum NorStorageBusWidth {
+    /// 1 bit bus width
+    Single,
+    /// 2 bit bus width
+    Dual,
+    /// 4 bit bus width
+    Quad,
+    /// 8 bit bus width
+    Octal,
+}
+
+#[derive(Debug, Copy, Clone)]
+/// enum for dummy cycles
+pub enum NorStorageDummyCycles {
+    /// Dummy cycles in terms of clock cycles
+    Clocks(u8),
+    /// Dummy cycles in terms of bytes
+    Bytes(u8),
+}
+
+#[derive(Debug, Copy, Clone)]
+/// NOR Storage Command to be passed by NOR based storage device drivers
+pub struct NorStorageCmd {
+    /// Nor Storage Command lower byte
+    pub cmd_lb: u8,
+    /// Nor Storage Command upper byte                       
+    pub cmd_ub: Option<u8>,
+    /// Address of the command
+    pub addr: Option<u32>,
+    /// Address width in bytes              
+    pub addr_width: Option<u8>,
+    /// DDR or SDR mode             
+    pub mode: NorStorageCmdMode,
+    /// Number of Dummy clock cycles. Assuming max 256 dummy cycles beyond which its impractical           
+    pub dummy: NorStorageDummyCycles,
+    /// Command type - Reading data or writing data
+    pub cmdtype: Option<NorStorageCmdType>,
+    /// Bus Width - This represents width in terms of signals
+    ///     SPI - Single
+    ///     QSPI - Quad
+    ///     OctalSPI - Octal
+    ///     I2C - 1
+    pub bus_width: NorStorageBusWidth,
+    /// Number of data bytes to be transferred for this command
+    pub data_bytes: Option<u32>,
+}
+
+/// Enum with storage errors
+pub enum NorStorageBusError {
+    /// Bus not available could be used for example
+    /// 1. Bus is not available due to arbitration lost in multi master bus
+    /// 2. Bus is not powered up
+    StorageBusNotAvailable,
+    /// Bus IO error while sending command
+    /// Could be used for example
+    /// 1 - Bus read error
+    /// 2 - Bus write error
+    StorageBusIoError,
+    /// Bus internal error
+    StorageBusInternalError,
+}
+
+/// Blocking NOR Storage Driver. The trait introduces a method to send command to the bus
+/// The NOR device driver should use this trait to send command to the bus
+/// NOR Storage Bus driver shall implement this trait to support NOR storage access over the bus
+/// Bus Examples -
+///    - SPI
+///    - FlexSPI
+///    - Hyperbus
+pub trait BlockingNorStorageBusDriver {
+    /// Send Command to the bus
+    /// Parameters:
+    ///    cmd - Command to be sent to the bus
+    ///    read_buf - Read buffer to store the data read from the bus
+    ///    write_buf - Write buffer to write the data to the bus
+    /// Returns:
+    ///    Result<(), NorStorageBusError> - Result of the command sent to the bus
+    ///    NorStorageBusError - Error code if the command failed
+    fn send_command(
+        &mut self,
+        cmd: NorStorageCmd,
+        read_buf: Option<&mut [u8]>,
+        write_buf: Option<&[u8]>,
+    ) -> Result<(), NorStorageBusError>;
+}
+
+#[allow(async_fn_in_trait)]
+/// Async NOR Storage Driver. The trait introduces a method to send command to the bus
+/// The NOR Storage device driver should use this trait to send command to the bus
+/// NOR Storage Bus driver shall implement this trait to support NOR storage access over the bus
+/// Bus Examples -
+///    - SPI
+///    - FlexSPI
+///    - Hyperbus
+pub trait AsyncNorStorageBusDriver {
+    /// Send Command to the bus
+    /// Parameters:
+    ///   cmd - Command to be sent to the bus
+    ///   read_buf - Read buffer to store the data read from the bus
+    ///   write_buf - Write buffer to write the data to the bus
+    /// Returns:
+    ///   Result<(), NorStorageBusError> - Result of the command sent to the bus
+    ///   NorStorageBusError - Error code if the command failed
+    async fn send_command(
+        &mut self,
+        cmd: NorStorageCmd,
+        read_buf: Option<&mut [u8]>,
+        write_buf: Option<&[u8]>,
+    ) -> Result<(), NorStorageBusError>;
+}


### PR DESCRIPTION
This PR adds generic storage bus traits to be used by the NOR flash device drivers. Device drivers can use the traits to access the lower level storage busses like FlexSPI, SPI, etc.
PR also adds traits for NAND storage bus for future support