### PR TITLE
Update eSPI memory map layout to the latest and version it as 0.1.0

### DIFF
--- a/embedded-service/src/ec_type/generator/ec-memory-generator.py
+++ b/embedded-service/src/ec_type/generator/ec-memory-generator.py
@@ -1,0 +1,98 @@
+import sys,yaml
+
+# Function to convert YAML data to Rust structures
+def yaml_to_rust(data):
+    rust_code = "//! EC Internal Data Structures\n\n"
+    rust_code += "pub const EC_MEMMAP_VERSION: Version = Version {major: 0, minor: 1, spin: 0, res0: 0};\n\n"
+    for key, value in data.items():
+        rust_code += "#[allow(missing_docs)]\n"
+        rust_code += "#[repr(C, packed)]\n"
+        rust_code += "#[derive(Clone, Copy, Debug, Default)]\n"
+        rust_code += f"pub struct {key} {{\n"
+        for sub_key, sub_value in value.items():
+            if isinstance(sub_value, dict) and 'type' in sub_value:
+                rust_code += f"    pub {sub_key}: {sub_value['type']},\n"
+            else:
+                rust_code += f"    pub {sub_key}: {sub_value},\n"
+        rust_code += "}\n\n"
+
+    return rust_code
+
+# Function to convert YAML data to C structures
+def yaml_to_c(data):
+    c_code = "#pragma once\n\n"
+    c_code += "#include <stdint.h>\n\n"
+    c_code += "#pragma pack(push, 1)\n\n"
+    for key, value in data.items():
+        c_code += "typedef struct {\n"
+        for sub_key, sub_value in value.items():
+            if isinstance(sub_value, dict) and 'type' in sub_value:
+                c_code += f"    {type_to_c_type(sub_value['type'])} {sub_key};\n"
+            else:
+                c_code += f"    {sub_value} {sub_key};\n"
+        c_code += f"}} {key};\n\n"
+
+    c_code += "#pragma pack(pop)\n\n"
+
+    c_code += "const Version EC_MEMMAP_VERSION = {0x00, 0x01, 0x00, 0x00};\n"
+    return c_code
+
+def type_to_c_type(type_str):
+    if type_str == 'u32':
+        return 'uint32_t'
+    elif type_str == 'u16':
+        return 'uint16_t'
+    elif type_str == 'u8':
+        return 'uint8_t'
+    elif type_str == 'i32':
+        return 'int32_t'
+    elif type_str == 'i16':
+        return 'int16_t'
+    elif type_str == 'i8':
+        return 'int8_t'
+    else:
+       return type_str
+
+def open_file(file_path):
+  try:
+    with open(file_path, 'r') as file:
+      data = file.read()
+      return data
+  except FileNotFoundError:
+    print(f"File not found: {file_path}")
+  except Exception as e:
+    print(f"An error occurred: {e}")
+
+
+if __name__ == "__main__":
+  if len(sys.argv) != 2:
+    print("Usage: python yamltorust.py <file_path>")
+    sys.exit(1)
+  else:
+    file_path = sys.argv[1]
+    yaml_data = open_file(file_path)
+    
+    # Load the YAML data
+    data = yaml.safe_load(yaml_data)
+
+    # Convert the YAML data to Rust structures and print the result
+    rust_code = yaml_to_rust(data)
+
+    c_code = yaml_to_c(data)
+
+    rust_output_filename = "structure.rs"
+    c_output_filename = "ecmemory.h"
+
+    try: 
+      with open(rust_output_filename, "w") as output_file:
+        output_file.write(rust_code)
+      print(f"Rust code has been written to {rust_output_filename}")
+    except Exception as e:
+      print(f"An error occurred while writing to {rust_output_filename}: {e}")
+
+    try: 
+      with open(c_output_filename, "w") as output_file:
+        output_file.write(c_code)
+      print(f"C code has been written to {c_output_filename}")
+    except Exception as e:
+      print(f"An error occurred while writing to {c_output_filename}: {e}")

--- a/embedded-service/src/ec_type/generator/ec-memory-generator.py
+++ b/embedded-service/src/ec_type/generator/ec-memory-generator.py
@@ -63,6 +63,21 @@ def open_file(file_path):
   except Exception as e:
     print(f"An error occurred: {e}")
 
+def check_for_32bit_alignment(data):
+  sizes = {'u32': 4, 'u16': 2, 'u8': 1, 'i32': 4, 'i16': 2, 'i8': 1}
+  for key, value in data.items():
+    size = 0
+    for sub_key, sub_value in value.items():
+      if isinstance(sub_value, dict) and 'type' in sub_value:
+        size += sizes[sub_value['type']]
+      sizes[key] = size
+  
+  for key, size in sizes.items():
+    if not is_primitive_type(key) and size % 4 != 0:
+      print(f"Warning: {key} is not 32-bit aligned. Size: {size} bytes")
+
+def is_primitive_type(type_str):
+    return type_str in ['u32', 'u16', 'u8', 'i32', 'i16', 'i8']
 
 if __name__ == "__main__":
   if len(sys.argv) != 2:
@@ -74,6 +89,8 @@ if __name__ == "__main__":
     
     # Load the YAML data
     data = yaml.safe_load(yaml_data)
+
+    check_for_32bit_alignment(data)
 
     # Convert the YAML data to Rust structures and print the result
     rust_code = yaml_to_rust(data)

--- a/embedded-service/src/ec_type/generator/ec_memory_map.yaml
+++ b/embedded-service/src/ec_type/generator/ec_memory_map.yaml
@@ -1,0 +1,186 @@
+# EC Memory layout definition
+
+Version:
+  major:
+    type: u8
+  minor:
+    type: u8
+  spin:
+    type: u8
+  res0:
+    type: u8
+
+# Size 0x14
+Capabilities:
+  events:
+    type: u32
+  fw_version:
+    type: Version
+  secure_state:
+    type: u8
+    variants:
+      INSECURE: 0
+      SECURE: 1
+  boot_status:
+    type: u8
+    variants:
+      SUCCESS: 0
+      ERROR: 1
+  fan_mask:
+    type: u8
+  battery_mask:
+    type: u8
+  temp_mask:
+    type: u16
+  key_mask:
+    type: u16
+  debug_mask:
+    type: u16
+  res0:
+    type: u16
+
+# Size 0x28
+TimeAlarm:
+  events:
+    type: u32
+  capability:
+    type: u32
+  year:
+    type: u16
+  month:
+    type: u8
+  day:
+    type: u8
+  hour:
+    type: u8
+  minute:
+    type: u8
+  second:
+    type: u8
+  valid:
+    type: u8
+  daylight:
+    type: u8
+  res1:
+    type: u8
+  milli:
+    type: u16
+  time_zone:
+    type: u16
+  res2:
+    type: u16
+  alarm_status:
+    type: u32
+  ac_time_val:
+    type: u32
+  dc_time_val:
+    type: u32
+
+
+# Size 0x64
+Battery:
+  events:
+    type: u32
+  status:
+    type: u32
+  last_full_charge:
+    type: u32
+  cycle_count:
+    type: u32
+  state:
+    type: u32
+  present_rate:
+    type: u32
+  remain_cap:
+    type: u32
+  present_volt:
+    type: u32
+  psr_state:
+    type: u32
+  psr_max_out:
+    type: u32
+  psr_max_in:
+    type: u32
+  peak_level:
+    type: u32
+  peak_power:
+    type: u32
+  sus_level:
+    type: u32
+  sus_power:
+    type: u32
+  peak_thres:
+    type: u32
+  sus_thres:
+    type: u32
+  trip_thres:
+    type: u32
+  bmc_data:
+    type: u32
+  bmd_data:
+    type: u32
+  bmd_flags:
+    type: u32
+  bmd_count:
+    type: u32
+  charge_time:
+    type: u32
+  run_time:
+    type: u32
+  sample_time:
+    type: u32
+
+# Size 0x38
+Thermal:
+  events:
+    type: u32
+  cool_mode:
+    type: u32
+  dba_limit:
+    type: u32
+  sonne_limit:
+    type: u32
+  ma_limit:
+    type: u32
+  fan1_on_temp:
+    type: u32
+  fan1_ramp_temp:
+    type: u32
+  fan1_max_temp:
+    type: u32
+  fan1_crt_temp:
+    type: u32
+  fan1_hot_temp:
+    type: u32
+  fan1_max_rpm:
+    type: u32
+  fan1_cur_rpm:
+    type: u32
+  tmp1_val:
+    type: u32
+  tmp1_timeout:
+    type: u32
+  tmp1_low:
+    type: u32
+  tmp1_high:
+    type: u32
+
+Notifications:
+  service:
+    type: u16
+  event:
+    type: u16
+
+ECMemory:
+  ver:
+    type: Version
+  caps:
+    type: Capabilities
+  notif:
+    type: Notifications
+  alarm:
+    type: TimeAlarm
+  batt:
+    type: Battery
+  therm:
+    type: Thermal

--- a/embedded-service/src/ec_type/structure.rs
+++ b/embedded-service/src/ec_type/structure.rs
@@ -1,5 +1,12 @@
 //! EC Internal Data Structures
 
+pub const EC_MEMMAP_VERSION: Version = Version {
+    major: 0,
+    minor: 1,
+    spin: 0,
+    res0: 0,
+};
+
 #[allow(missing_docs)]
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -23,6 +30,7 @@ pub struct Capabilities {
     pub temp_mask: u16,
     pub key_mask: u16,
     pub debug_mask: u16,
+    pub res0: u16,
 }
 
 #[allow(missing_docs)]
@@ -53,6 +61,7 @@ pub struct TimeAlarm {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Battery {
     pub events: u32,
+    pub status: u32,
     pub last_full_charge: u32,
     pub cycle_count: u32,
     pub state: u32,
@@ -103,9 +112,18 @@ pub struct Thermal {
 #[allow(missing_docs)]
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Default)]
+pub struct Notifications {
+    pub service: u16,
+    pub event: u16,
+}
+
+#[allow(missing_docs)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ECMemory {
     pub ver: Version,
     pub caps: Capabilities,
+    pub notif: Notifications,
     pub alarm: TimeAlarm,
     pub batt: Battery,
     pub therm: Thermal,

--- a/espi-service/src/espi_service.rs
+++ b/espi-service/src/espi_service.rs
@@ -161,10 +161,10 @@ pub async fn espi_service(mut espi: espi::Espi<'static>, memory_map_buffer: &'st
         unsafe { &mut *(memory_map_buffer.as_mut_ptr() as *mut ec_type::structure::ECMemory) };
 
     info!("Initializing memory map");
-    memory_map.ver.major = 0;
-    memory_map.ver.minor = 1;
-    memory_map.ver.spin = 0;
-    memory_map.ver.res0 = 0;
+    memory_map.ver.major = ec_type::structure::EC_MEMMAP_VERSION.major;
+    memory_map.ver.minor = ec_type::structure::EC_MEMMAP_VERSION.minor;
+    memory_map.ver.spin = ec_type::structure::EC_MEMMAP_VERSION.spin;
+    memory_map.ver.res0 = ec_type::structure::EC_MEMMAP_VERSION.res0;
 
     let espi_service = ESPI_SERVICE.get_or_init(|| Service::new(memory_map));
     comms::register_endpoint(espi_service, &espi_service.endpoint)


### PR DESCRIPTION
- Add EC memory layout YAML file to source control
- Add Python generator to generate both C and Rust header files for the EC memory layout
- Update the EC memory layout to the latest generated from YAML file
- Version the EC memory layout as 0.1.0
- Update eSPI service to set the version on initialization