### PR TITLE
espi-service: update due to imxrt breakage

### DIFF
--- a/espi-service/Cargo.toml
+++ b/espi-service/Cargo.toml
@@ -13,7 +13,7 @@ embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", rev = "35d430666574379ef2186c25172ca848ae19d11b", features = [
     "defmt",
     "time-driver",
     "time",

--- a/espi-service/src/espi_service.rs
+++ b/espi-service/src/espi_service.rs
@@ -213,7 +213,7 @@ pub async fn espi_service(mut espi: espi::Espi<'static>, memory_map_buffer: &'st
             Ok(espi::Event::Port80) => {
                 info!("eSPI Port 80");
             }
-            Ok(espi::Event::WireChange) => {
+            Ok(espi::Event::WireChange(_)) => {
                 info!("eSPI WireChange");
             }
             Err(_) => {

--- a/examples/rt633/Cargo.toml
+++ b/examples/rt633/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m-rt = "0.7.3"
 defmt = "0.3.6"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features = ["print-defmt"] }
-embassy-imxrt = { version = "0.1.0", git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", rev = "35d430666574379ef2186c25172ca848ae19d11b", features = [
     "defmt",
     "time-driver",
     "time",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m-rt = "0.7.3"
 defmt = "0.3.6"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features = ["print-defmt"] }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", rev = "35d430666574379ef2186c25172ca848ae19d11b", features = [
     "defmt",
     "time-driver",
     "time",


### PR DESCRIPTION
- Fix breakage due to embassy-imxrt
- Lock embassy-imxrt to a commit to avoid accidental breakage in the future
   - https://github.com/OpenDevicePartnership/embassy-imxrt/commit/35d430666574379ef2186c25172ca848ae19d11b