### PR TITLE
Remove embassy-imxrt rev lock

### DIFF
--- a/espi-service/Cargo.toml
+++ b/espi-service/Cargo.toml
@@ -13,7 +13,7 @@ embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", rev = "35d430666574379ef2186c25172ca848ae19d11b", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
     "defmt",
     "time-driver",
     "time",

--- a/examples/rt633/Cargo.toml
+++ b/examples/rt633/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m-rt = "0.7.3"
 defmt = "0.3.6"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features = ["print-defmt"] }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", rev = "35d430666574379ef2186c25172ca848ae19d11b", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
     "defmt",
     "time-driver",
     "time",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m-rt = "0.7.3"
 defmt = "0.3.6"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features = ["print-defmt"] }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", rev = "35d430666574379ef2186c25172ca848ae19d11b", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
     "defmt",
     "time-driver",
     "time",


### PR DESCRIPTION
Turns out, it is a really bad idea to force your client to lock to the same version of a dependency.