### PR TITLE
Type-C debug accessory support

### DIFF
--- a/embedded-service/src/type_c/comms.rs
+++ b/embedded-service/src/type_c/comms.rs
@@ -1,0 +1,13 @@
+//! Comms service message definitions
+
+use embedded_usb_pd::GlobalPortId;
+
+/// Message generated when a debug acessory is connected or disconnected
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DebugAccessoryMessage {
+    /// Port
+    pub port: GlobalPortId,
+    /// Connected
+    pub connected: bool,
+}

--- a/embedded-service/src/type_c/mod.rs
+++ b/embedded-service/src/type_c/mod.rs
@@ -5,6 +5,7 @@ use embedded_usb_pd::type_c;
 
 use crate::power::policy;
 
+pub mod comms;
 pub mod controller;
 pub mod event;
 

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -535,6 +535,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield 0.17.0",
  "bitflags",
+ "bitvec",
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -1,6 +1,7 @@
 use embassy_executor::{Executor, Spawner};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::Timer;
+use embedded_services::comms;
 use embedded_services::power::{self, policy};
 use embedded_services::type_c::{controller, ControllerId};
 use embedded_usb_pd::type_c::Current;
@@ -65,6 +66,20 @@ mod test_controller {
             events.set_plug_inserted_or_removed(true);
             self.events.signal(events);
         }
+
+        /// Simulate a debug accessory source connecting
+        pub fn connect_debug_accessory_source(&self, current: Current) {
+            self.status.set(PortStatus {
+                contract: Some(Contract::Source(current.into())),
+                connection_present: true,
+                debug_connection: true,
+            });
+
+            let mut events = PortEventKind::none();
+            events.set_plug_inserted_or_removed(true);
+            events.set_new_power_contract_as_consumer(true);
+            self.events.signal(events);
+        }
     }
 
     pub struct Controller<'a> {
@@ -113,6 +128,40 @@ mod test_controller {
     pub type Wrapper<'a> = type_c_service::wrapper::ControllerWrapper<'a, 1, Controller<'a>>;
 }
 
+mod debug {
+    use embedded_services::{
+        comms::{self, Endpoint, EndpointID, Internal},
+        info,
+        type_c::comms::DebugAccessoryMessage,
+    };
+
+    pub struct Listener {
+        pub tp: Endpoint,
+    }
+
+    impl Listener {
+        pub fn new() -> Self {
+            Self {
+                tp: Endpoint::uninit(EndpointID::Internal(Internal::Usbc)),
+            }
+        }
+    }
+
+    impl comms::MailboxDelegate for Listener {
+        fn receive(&self, message: &comms::Message) -> Result<(), comms::MailboxDelegateError> {
+            if let Some(message) = message.data.get::<DebugAccessoryMessage>() {
+                if message.connected {
+                    info!("Port{}: Debug accessory connected", message.port.0);
+                } else {
+                    info!("Port{}: Debug accessory disconnected", message.port.0);
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
 #[embassy_executor::task]
 async fn controller_task(state: &'static test_controller::ControllerState) {
     static WRAPPER: OnceLock<test_controller::Wrapper> = OnceLock::new();
@@ -139,6 +188,11 @@ async fn task(spawner: Spawner) {
 
     controller::init();
 
+    // Register debug accessory listener
+    static LISTENER: OnceLock<debug::Listener> = OnceLock::new();
+    let listener = LISTENER.get_or_init(debug::Listener::new);
+    comms::register_endpoint(listener, &listener.tp).await.unwrap();
+
     static STATE: OnceLock<test_controller::ControllerState> = OnceLock::new();
     let state = STATE.get_or_init(test_controller::ControllerState::new);
 
@@ -153,6 +207,15 @@ async fn task(spawner: Spawner) {
 
     info!("Simulating disconnection");
     state.disconnect();
+    Timer::after_millis(250).await;
+
+    info!("Simulating debug accessory connection");
+    state.connect_debug_accessory_source(Current::UsbDefault);
+    Timer::after_millis(250).await;
+
+    info!("Simulating debug accessory disconnection");
+    state.disconnect();
+    Timer::after_millis(250).await;
 }
 
 fn main() {


### PR DESCRIPTION
Adds support for debug accessory connect/disconnect and broadcast a message in response. This is currently on top of https://github.com/OpenDevicePartnership/embedded-services/pull/122 while that is in review. Please start with commit 6470bcee9ef012651c19078fa6f12310f7e2c5b1 for now.