### PR TITLE
Add send_device_request method on CfuDevice + FinalizeUpdate enum content

### DIFF
--- a/cfu-service/src/lib.rs
+++ b/cfu-service/src/lib.rs
@@ -60,7 +60,7 @@ impl CfuClient {
             RequestData::GiveContent(_content_cmd) => Ok(()),
             RequestData::GiveOffer(_offer_cmd) => Ok(()),
             RequestData::PrepareComponentForUpdate => Ok(()),
-            RequestData::FinalizeUpdate => Ok(()),
+            RequestData::FinalizeUpdate(_content_cmd) => Ok(()),
         }
     }
 }

--- a/embedded-service/src/cfu/component.rs
+++ b/embedded-service/src/cfu/component.rs
@@ -315,7 +315,7 @@ impl<W: CfuWriter> CfuWriter for CfuComponentDefault<W> {
     }
 
     async fn cfu_read(&self, mem_offset: Option<usize>, read: &mut [u8]) -> Result<(), CfuWriterError> {
-        self.writer.lock().await.cfu_write(mem_offset, read).await
+        self.writer.lock().await.cfu_read(mem_offset, read).await
     }
 }
 

--- a/embedded-service/src/cfu/component.rs
+++ b/embedded-service/src/cfu/component.rs
@@ -140,18 +140,18 @@ impl CfuDevice {
     pub fn component_id(&self) -> ComponentId {
         self.component_id
     }
-    
+
     /// Setter for component state
     /// Intended to be used to auto-block updates if one is in-progress
     pub async fn state(&self) -> InternalState {
         *self.state.lock().await
     }
-    
+
     /// Sends a request to this device without waiting for a response
     pub async fn send_device_request(&self, request: RequestData) {
         self.request.send(request).await;
     }
-    
+
     /// Sends a request to this device and returns a response
     pub async fn execute_device_request(&self, request: RequestData) -> Result<InternalResponseData, CfuProtocolError> {
         self.request.send(request).await;


### PR DESCRIPTION
Adding send_device_request() method on CfuDevice in order to send a message to itself without blocking and waiting for a response. This is an alternative method to execute_device_request(). Where execute_device_request should be used for requesting data from other devices, send_device_request selects the next execution path from the same object.

Along with this, the FinalizeUpdate entry for RequestData also takes in a FwUpdateContentCommand for routing and replying after a content message.