### PR TITLE
Fix cfu_read wrapper's internal call

### DIFF
--- a/embedded-service/src/cfu/component.rs
+++ b/embedded-service/src/cfu/component.rs
@@ -307,7 +307,7 @@ impl<W: CfuWriter> CfuWriter for CfuComponentDefault<W> {
     }
 
     async fn cfu_read(&self, mem_offset: Option<usize>, read: &mut [u8]) -> Result<(), CfuWriterError> {
-        self.writer.lock().await.cfu_write(mem_offset, read).await
+        self.writer.lock().await.cfu_read(mem_offset, read).await
     }
 }
 


### PR DESCRIPTION
In the implementation of CfuWriter for CfuComponentDefault, fixes the cfu_read function to call the internal cfu_read instead of cfu_write