### PR TITLE
Add Basic NVRAM Platform Service Abstraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "embedded-service",
     "espi-service",
     "hid-service",
+    "platform-service",
     "power-button-service",
     "power-policy-service",
     "storage-bus",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -65,3 +65,8 @@ type-c-service = { path = "../../type-c-service", features = ["defmt"] }
 static_cell = "2.1.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
+
+platform-service = { path = "../../platform-service", features = [
+    "defmt",
+    "imxrt685",
+] }

--- a/examples/rt685s-evk/src/bin/nvram.rs
+++ b/examples/rt685s-evk/src/bin/nvram.rs
@@ -1,0 +1,47 @@
+#![no_std]
+#![no_main]
+
+extern crate rt685s_evk_example;
+
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let _p = embassy_imxrt::init(Default::default());
+
+    use platform_service::nvram;
+
+    #[repr(usize)]
+    enum Entries {
+        // These sections are unusable:
+        //     0,
+        //     1,
+        //     2,
+        General = 3,
+        Special = 4,
+    }
+
+    static NVRAM_TABLE: nvram::Table<2> = nvram::Table::new(&[Entries::General as usize, Entries::Special as usize]);
+
+    embedded_services::init().await;
+    nvram::init(&NVRAM_TABLE).await.unwrap();
+
+    let mut general_section = nvram::lookup_section(NVRAM_TABLE.get_index(Entries::General as usize).unwrap())
+        .await
+        .unwrap();
+
+    general_section.write(0);
+    general_section.write(1);
+
+    use defmt::info;
+
+    info!("general_section = {:?}", general_section.read());
+
+    let special = nvram::lookup_section(NVRAM_TABLE.get_index(Entries::Special as usize).unwrap())
+        .await
+        .unwrap();
+    info!("special = {:?}", special.read());
+
+    let untouchable: Option<nvram::ManagedSection> = nvram::lookup_section(10).await;
+    info!("Attempted invalid section is_none = {:?}", untouchable.is_none());
+}

--- a/platform-service/Cargo.toml
+++ b/platform-service/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "platform-service"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+defmt = { workspace = true, optional = true }
+embassy-executor.workspace = true
+embassy-sync.workspace = true
+embassy-time.workspace = true
+embedded-cfu-protocol.workspace = true
+embedded-services.workspace = true
+heapless.workspace = true
+log = { workspace = true, optional = true }
+embassy-imxrt = { workspace = true, optional = true, features = [
+    "unstable-pac",
+] }
+
+[features]
+# TODO find method to unblock CI gate without requiring chip specification at library level
+imxrt = ["embassy-imxrt/mimxrt633s"]
+imxrt685 = ["embassy-imxrt/mimxrt685s"]
+
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embassy-time/defmt",
+    "embassy-sync/defmt",
+    "embassy-executor/defmt",
+    "embedded-cfu-protocol/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "embassy-time/log",
+    "embassy-sync/log",
+    "embassy-executor/log",
+    "embedded-cfu-protocol/log",
+]

--- a/platform-service/src/imxrt/mod.rs
+++ b/platform-service/src/imxrt/mod.rs
@@ -1,0 +1,28 @@
+use core::ops::Range;
+use embassy_imxrt::pac;
+
+pub(crate) fn nvram_read(address: usize) -> u32 {
+    // TODO introduce RTC GPReg interface directly from embassy_imxrt
+
+    // SAFETY: safe from single executor
+    let rtc = unsafe { &*pac::Rtc::ptr() };
+
+    rtc.gpreg(address).read().bits()
+}
+
+pub(crate) fn nvram_write(address: usize, value: u32) {
+    // TODO introduce RTC GPReg interface directly from embassy_imxrt
+
+    // SAFETY: safe from single executor
+    let rtc = unsafe { &*pac::Rtc::ptr() };
+
+    rtc.gpreg(address).write(|w|
+        // SAFETY: safe from single executor 
+        unsafe { w.bits(value) });
+}
+
+pub(crate) fn nvram_valid_range() -> Range<usize> {
+    // TODO introduce RTC GPReg interface directly from embassy_imxrt
+    // indices 0, 1, 2 are utilized by timer_driver in embassy_imxrt
+    3..8
+}

--- a/platform-service/src/lib.rs
+++ b/platform-service/src/lib.rs
@@ -1,0 +1,32 @@
+#![no_std]
+
+/// NVRAM platform service abstraction
+pub mod nvram;
+
+#[cfg(any(feature = "imxrt", feature = "imxrt685"))]
+pub(crate) mod imxrt;
+
+#[cfg(any(feature = "imxrt", feature = "imxrt685"))]
+pub(crate) use imxrt::*;
+
+#[cfg(not(any(feature = "imxrt", feature = "imxrt685")))]
+mod defaults {
+    use core::ops::Range;
+
+    pub(crate) fn nvram_read(_address: usize) -> u32 {
+        0
+    }
+    pub(crate) fn nvram_write(_address: usize, _value: u32) {}
+
+    pub(crate) fn nvram_valid_range() -> Range<usize> {
+        0..0
+    }
+}
+
+#[cfg(not(any(feature = "imxrt", feature = "imxrt685")))]
+pub(crate) use defaults::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/platform-service/src/nvram.rs
+++ b/platform-service/src/nvram.rs
@@ -1,0 +1,106 @@
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::once_lock::OnceLock;
+
+use crate::nvram_valid_range;
+
+// Describes a u32 section of non-volatile RAM
+struct Info {
+    // the starting address/offset and length in u32 words of the section
+    offset: usize,
+
+    guard: Mutex<CriticalSectionRawMutex, ()>,
+}
+
+/// Section descriptor table for linking indices to offsets
+pub struct Table<const N: usize> {
+    sections: [Info; N],
+}
+
+impl<const N: usize> Table<N> {
+    /// Generate a Section descriptor table of length N
+    pub const fn new(valid_offsets: &[usize; N]) -> Self {
+        let mut as_info: [Info; N] = [const { Info::new(0) }; N];
+
+        // have to while loop here for const fn
+        let mut i = 0;
+        while i < N {
+            as_info[i].offset = valid_offsets[i];
+
+            i += 1;
+        }
+
+        Self { sections: as_info }
+    }
+
+    /// Get the index associated with given offset, for passing context key around as needed
+    pub fn get_index(&self, offset: usize) -> Option<usize> {
+        self.sections
+            .iter()
+            .enumerate()
+            .find_map(|(index, info)| if info.offset == offset { Some(index) } else { None })
+    }
+}
+
+/// Table initialization errors
+#[derive(Copy, Clone, Debug)]
+pub enum TableError {
+    /// Offset constructed is not accessible per NVRAM implementation
+    InvalidOffset(usize),
+}
+
+impl Info {
+    const fn new(offset: usize) -> Self {
+        Self {
+            offset,
+            guard: Mutex::new(()),
+        }
+    }
+}
+
+/// Guarded handle to section
+pub struct ManagedSection {
+    info: &'static Info,
+}
+
+impl ManagedSection {
+    const fn new(info: &'static Info) -> Self {
+        Self { info }
+    }
+
+    /// Attempt to read an offset from a section. Returns None if the offset is invalid or the section is marked inaccessible
+    pub fn read(&self) -> u32 {
+        self.info.guard.lock(|_| crate::nvram_read(self.info.offset))
+    }
+
+    /// Attempt to write value to offset within section. Returns read(offset) on success, None on failure
+    pub fn write(&mut self, value: u32) {
+        // mutex guard ensures only one writer to this region at a time
+        self.info.guard.lock(|_| crate::nvram_write(self.info.offset, value));
+    }
+}
+
+static LAYOUT: OnceLock<&'static [Info]> = OnceLock::new();
+
+/// Initialize the NVRAM service with a given table of named sections
+pub async fn init<const N: usize>(table: &'static Table<N>) -> Result<(), TableError> {
+    for entry in &table.sections {
+        if !nvram_valid_range().contains(&entry.offset) {
+            return Err(TableError::InvalidOffset(entry.offset));
+        }
+    }
+
+    LAYOUT.get_or_init(|| &table.sections);
+    Ok(())
+}
+
+/// General API for attempting to interact with named NVRAM sections
+pub async fn lookup_section(index: usize) -> Option<ManagedSection> {
+    let layout = LAYOUT.get().await;
+
+    if layout.len() <= index {
+        None
+    } else {
+        Some(ManagedSection::new(&layout[index]))
+    }
+}


### PR DESCRIPTION
Adds a preliminary platform services crate for managing and abstracting common mechanisms like NVRAM without imposing knowledge of underlying implementer on users of said features.

Has a temporary work around for missing GPREG management APIs in embassy-imxrt