### PR TITLE
[RFC] ECS Demo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "editor.formatOnSave": true
     },
     "rust-analyzer.check.allTargets": false,
-    "rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
+    //"rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
     "rust-analyzer.cargo.features": [],
     "rust-analyzer.linkedProjects": [
         "examples/rt633/Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ embedded-storage = "0.3"
 embedded-storage-async = "0.4.1"
 embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false }
 fixed = "1.23.1"
+frunk = { version = "0.4.3", default-features = false }
 heapless = "0.8.*"
 log = "0.4"
 postcard = "1.*"

--- a/embedded-service/Cargo.toml
+++ b/embedded-service/Cargo.toml
@@ -30,6 +30,7 @@ embedded-storage.workspace = true
 embedded-usb-pd.workspace = true
 embedded-batteries-async.workspace = true
 fixed.workspace = true
+frunk.workspace = true
 heapless.workspace = true
 log = { workspace = true, optional = true }
 postcard.workspace = true

--- a/embedded-service/src/ecs/mod.rs
+++ b/embedded-service/src/ecs/mod.rs
@@ -1,0 +1,179 @@
+//! Embedded Entity-Component System (ECS)
+use core::{
+    cell::{Ref, RefCell, RefMut},
+    future::{self, Future},
+    ops::{Deref, DerefMut},
+};
+
+use embassy_futures::select::{select, Either};
+
+/// Used to chain the results of each layer together
+pub enum List<A, B> {
+    /// Event for the first layer
+    Head(A),
+    /// Events for the rest of the layers
+    Rest(B),
+}
+
+// Type alias that may be helpful using layer results
+/*pub type StackResult1<A> = List<A, ()>;
+pub type StackResult2<A, B> = List<A, StackResult1<B>>;
+pub type StackResult3<A, B, C> = List<A, StackResult2<B, C>>;*/
+
+/// Trait to allow for borrowing a reference to the inner type
+pub trait RefGuard<T>: Deref<Target = T> {}
+
+/// Trait to allow for borrowing a mutable reference to the inner type
+pub trait RefMutGuard<T>: DerefMut<Target = T> {}
+
+/// Core component type
+pub trait Component<T> {
+    /// Event type that we're waiting for
+    type Event;
+
+    /// Wait for an event to occur
+    fn wait_event(&self, entity: &T) -> impl Future<Output = Self::Event>;
+    /// Process the event
+    fn process(&self, entity: &mut T, event: Self::Event) -> impl Future<Output = ()>;
+}
+
+/// Entity trait
+pub trait Entity {
+    /// Underlying type of the entity
+    type Inner;
+
+    /// Get a reference to the inner entity
+    fn get_entity(&self) -> impl RefGuard<Self::Inner>;
+    /// Get a mutable reference to the inner entity
+    fn get_entity_mut(&self) -> impl RefMutGuard<Self::Inner>;
+}
+
+/// Layer trait
+pub trait Layer: Entity + Component<Self::Inner> + Sized {
+    /// Process all events for the layer and layers below it
+    fn process_all(&mut self) -> impl Future<Output = ()>;
+}
+
+/// Layer wrapper that provides common functionality and chaining logic
+pub struct LayerWrapper<L: Layer, C: Component<L::Inner>> {
+    inner: L,
+    component: RefCell<C>,
+}
+
+impl<L: Layer, C: Component<L::Inner>> Entity for LayerWrapper<L, C> {
+    type Inner = L::Inner;
+
+    fn get_entity(&self) -> impl RefGuard<Self::Inner> {
+        self.inner.get_entity()
+    }
+
+    fn get_entity_mut(&self) -> impl RefMutGuard<Self::Inner> {
+        self.inner.get_entity_mut()
+    }
+}
+
+impl<L: Layer, C: Component<L::Inner>> Component<L::Inner> for LayerWrapper<L, C> {
+    type Event = List<C::Event, L::Event>;
+
+    #[inline]
+    async fn wait_event(&self, entity: &L::Inner) -> Self::Event {
+        let mut borrow = self.component.borrow_mut();
+        let component = borrow.deref_mut();
+
+        match select(component.wait_event(entity), self.inner.wait_event(entity)).await {
+            Either::First(event) => List::Head(event),
+            Either::Second(event) => List::Rest(event),
+        }
+    }
+
+    #[inline]
+    async fn process(&self, entity: &mut L::Inner, event: Self::Event) -> () {
+        let mut borrow = self.component.borrow_mut();
+        let component = borrow.deref_mut();
+
+        match event {
+            List::Head(event) => component.process(entity, event).await,
+            List::Rest(event) => self.inner.process(entity, event).await,
+        }
+    }
+}
+
+impl<L: Layer, C: Component<L::Inner>> Layer for LayerWrapper<L, C> {
+    async fn process_all(&mut self) {
+        let mut borrow = self.get_entity_mut();
+        let entity = borrow.deref_mut();
+        let event = self.wait_event(entity).await;
+        self.process(entity, event).await;
+    }
+}
+
+impl<L: Layer, C: Component<L::Inner>> LayerWrapper<L, C> {
+    /// Create a new layer wrapper
+    pub fn new(layer: L, component: C) -> Self {
+        Self {
+            inner: layer,
+            component: RefCell::new(component),
+        }
+    }
+
+    /// Add a new component as a new layer on top of us
+    pub fn add_component<C2: Component<L::Inner>>(self, component: C2) -> LayerWrapper<Self, C2> {
+        LayerWrapper::new(self, component)
+    }
+}
+
+/// Entity that stores its value in a RefCell
+pub struct EntityRef<T> {
+    inner: RefCell<T>,
+}
+
+impl<T> RefGuard<T> for Ref<'_, T> {}
+impl<T> RefMutGuard<T> for RefMut<'_, T> {}
+
+impl<T> EntityRef<T> {
+    /// Create a new entity reference
+    pub fn new(entity: T) -> Self {
+        Self {
+            inner: RefCell::new(entity),
+        }
+    }
+
+    /// Wrap the entity in a new component layer
+    pub fn add_component<C: Component<T>>(self, component: C) -> LayerWrapper<Self, C> {
+        LayerWrapper::new(self, component)
+    }
+}
+
+impl<T> Entity for EntityRef<T> {
+    type Inner = T;
+
+    #[inline]
+    fn get_entity(&self) -> impl RefGuard<Self::Inner> {
+        self.inner.borrow()
+    }
+
+    #[inline]
+    fn get_entity_mut(&self) -> impl RefMutGuard<Self::Inner> {
+        self.inner.borrow_mut()
+    }
+}
+
+impl<T> Component<T> for EntityRef<T> {
+    type Event = ();
+
+    #[inline]
+    async fn wait_event(&self, _: &T) -> Self::Event {
+        future::pending().await
+    }
+
+    #[inline]
+    async fn process(&self, _: &mut T, _: Self::Event) {
+        ()
+    }
+}
+
+impl<T> Layer for EntityRef<T> {
+    async fn process_all(&mut self) {
+        ()
+    }
+}

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -12,6 +12,7 @@ pub mod buffer;
 pub mod cfu;
 pub mod comms;
 pub mod ec_type;
+pub mod ecs;
 pub mod fmt;
 pub mod hid;
 pub mod keyboard;

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -555,6 +555,7 @@ dependencies = [
  "embedded-storage-async",
  "embedded-usb-pd",
  "fixed",
+ "frunk",
  "heapless 0.8.0",
  "log",
  "postcard",
@@ -634,6 +635,45 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "frunk"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874b6a17738fc273ec753618bac60ddaeac48cb1d7684c3e7bd472e57a28b817"
+dependencies = [
+ "frunk_core",
+ "frunk_derives",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3529a07095650187788833d585c219761114005d5976185760cf794d265b6a5c"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99b8b3c28ae0e84b604c75f721c21dc77afb3706076af5e8216d15fd1deaae3"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05a956ef36c377977e512e227dcad20f68c2786ac7a54dacece3746046fea5ce"
+dependencies = [
+ "frunk_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "funty"

--- a/examples/std/src/bin/ecs.rs
+++ b/examples/std/src/bin/ecs.rs
@@ -1,0 +1,184 @@
+use std::option;
+
+use embassy_executor::Executor;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::once_lock::OnceLock;
+use embedded_services::ecs::{EntityRef, Layer, LayerWrapper};
+use log::info;
+use static_cell::StaticCell;
+
+pub struct Channel<M, R> {
+    pub rx: embassy_sync::channel::Channel<NoopRawMutex, M, 1>,
+    pub tx: embassy_sync::channel::Channel<NoopRawMutex, R, 1>,
+}
+
+static OPTIONAL_CHANNEL: OnceLock<Channel<optional::Message, optional::Response>> = OnceLock::new();
+static CORE_CHANNEL: OnceLock<Channel<core::Message, core::Response>> = OnceLock::new();
+
+impl<M, R> Channel<M, R> {
+    pub fn new() -> Self {
+        Self {
+            tx: embassy_sync::channel::Channel::new(),
+            rx: embassy_sync::channel::Channel::new(),
+        }
+    }
+
+    pub async fn send_response(&self, message: R) {
+        self.tx.send(message).await;
+    }
+
+    pub async fn receive_message(&self) -> M {
+        self.rx.receive().await
+    }
+
+    pub async fn send_message(&self, message: M) {
+        self.rx.send(message).await;
+    }
+
+    pub async fn receive_response(&self) -> R {
+        self.tx.receive().await
+    }
+
+    pub async fn call(&self, message: M) -> R {
+        self.send_message(message).await;
+        self.receive_response().await
+    }
+}
+
+mod core {
+    use super::*;
+    use embedded_services::ecs::Component;
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct Message(pub i32);
+    #[derive(Debug, Clone, Copy)]
+    pub struct Response(pub i32);
+
+    pub trait Trait {
+        fn function(&self, value: i32) -> i32;
+    }
+
+    pub struct MessageBridge<'a> {
+        pub channel: &'a Channel<Message, Response>,
+    }
+
+    impl MessageBridge<'_> {
+        pub fn new() -> Self {
+            Self {
+                channel: CORE_CHANNEL.get_or_init(Channel::new),
+            }
+        }
+    }
+
+    impl<T> Component<T> for MessageBridge<'_>
+    where
+        T: Trait,
+    {
+        type Event = Message;
+
+        async fn wait_event(&self, _: &T) -> Self::Event {
+            info!("Waiting for message...");
+            self.channel.receive_message().await
+        }
+
+        async fn process(&self, entity: &mut T, event: Self::Event) {
+            info!("Processing message: {:?}", event.0);
+            self.channel.send_response(Response(entity.function(event.0))).await;
+        }
+    }
+}
+
+mod optional {
+    use super::*;
+    use embedded_services::ecs::Component;
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct Message(pub f32);
+    #[derive(Debug, Clone, Copy)]
+    pub struct Response(pub f32);
+
+    pub trait Trait {
+        fn function(&self, value: f32) -> f32;
+    }
+
+    pub struct MessageBridge<'a> {
+        pub channel: &'a Channel<Message, Response>,
+    }
+
+    impl MessageBridge<'_> {
+        pub fn new() -> Self {
+            Self {
+                channel: OPTIONAL_CHANNEL.get_or_init(Channel::new),
+            }
+        }
+    }
+
+    impl<T> Component<T> for MessageBridge<'_>
+    where
+        T: Trait,
+    {
+        type Event = Message;
+
+        async fn wait_event(&self, _: &T) -> Self::Event {
+            info!("Waiting for optional message...");
+            self.channel.receive_message().await
+        }
+
+        async fn process(&self, entity: &mut T, event: Self::Event) {
+            info!("Processing optional message: {:?}", event.0);
+            self.channel.send_response(Response(entity.function(event.0))).await;
+        }
+    }
+}
+
+struct Device;
+
+impl core::Trait for Device {
+    fn function(&self, value: i32) -> i32 {
+        value + 5
+    }
+}
+
+impl optional::Trait for Device {
+    fn function(&self, value: f32) -> f32 {
+        1.5 * value
+    }
+}
+
+#[embassy_executor::task]
+async fn device_task() {
+    let mut device = EntityRef::new(Device)
+        .add_component(core::MessageBridge::new())
+        .add_component(optional::MessageBridge::new());
+
+    loop {
+        device.process_all().await;
+    }
+}
+
+#[embassy_executor::task]
+async fn main_task() {
+    let optional_channel = OPTIONAL_CHANNEL.get_or_init(Channel::new);
+    let core_channel = CORE_CHANNEL.get_or_init(Channel::new);
+
+    let message = core::Message(10);
+    info!("Sending core message: {:?}", message);
+    let response = core_channel.call(message).await;
+    info!("Response: {:?}", response.0);
+
+    let message = optional::Message(5.0);
+    info!("Sending optional message: {:?}", message);
+    let response = optional_channel.call(message).await;
+    info!("Optional response: {:?}", response.0);
+}
+
+fn main() {
+    env_logger::builder().filter_level(log::LevelFilter::Info).init();
+
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.must_spawn(device_task());
+        spawner.must_spawn(main_task());
+    });
+}


### PR DESCRIPTION
Entity-component systems are designs based on an entity object to which multiple component objects can be attached. Each component adds a specific behavior to the entity. This is common in video games where structurally, the only difference between your character and an enemy might be that one will have a `PlayerInput` component and the other will have a `AiInput` component. This type of design can be very useful in embedded development where it's common for a single device to present many different types of functionalities (e.g. a PD controller could also be a GPIO extender). The message-based approach of services also requires an implementation to bridge from messages to function calls on a hardware device. From an ECS perspective we can interpret the aforementioned PD controller as: an entity (the base driver object), PD message bridge (component), GPIO extender message bridge (component). This allows new and optional functionalities to be added to a device without (ideally) needing to touch existing code.

Using an existing Rust ECS framework in embedded services is difficult because:
* `no-std`
* We're using async
* We're not making a video game
* It needs to integrate with our existing messaging

None of the Rust ECS frameworks I examined (`hecs` being the most prominent light-weight one mentioned). Were not compatible with the above restrictions.

A very simple ECS would look like
```rust
// Normal version
struct Entity {
    components: Vec<&dyn Component>,
}

trait Component {
    fn do_something(&self);
}

impl Entity {
    fn do_something(&self) {
        for component in &self.components {
            component.do_something();
        }
    }
}
```

To remove dynamic allocation and dynamic dispatch we can come up with a basic embedded-friendly version:
```
struct Entity<A: Component, B: Component> {
    components: (A, B),
}

impl <A: Component, B: Component> Entity<A, B> {
    fn do_something(&self) {
        self.components.0.do_something();
        self.components.1.do_something();
    }
}
```

But this doesn't generalize well because Rust doesn't currently support variadic generics. But we can layer things to get the same result:
```
struct ComponentLayer<I: Layer, C: Component> {
    inner: I,
    component: C,
}

trait Layer {
    fn do_something(&self);
}
type Stack = ComponentLayer<ComponentLayer<Entity, A>, B>;

impl<I: Inner, C: Component> Layer for ComponentLayer<I, C> {
    fn do_something(&self) {
        self.component.do_something();
        self.inner.do_something();
    }
}
```

This allows each layer to chain the next one, replacing the loop in the original example. This PR is a rough draft of an ECS that is based on these ideas. Each component is capable of producing a message and then processing that message. Normally, the message produced by each layer is bubbled up through the stack and then is sent down the stack to be processed. **But layers can be inserted anywhere into the stack to allow for filtering/modifying messages and to control how lower layers in the stack process their messages. In addition to composing functionality together this design provides a natural way for custom code to control and modify existing functionality.**


Future improvements:
* Compile-time checking of layer types: It should be possible to define layers that only work on top of specific layers, something like `struct TypedLayer<I: Layer<MessageA, MessageB>>` for a layer that will only work on top of two layers that produce messages of types `MessageA` and `MessageB`.
* Ergonomics around the message value each layer sees: this implementation uses the same type-layering concept to allow each layer to append its message type and pass things up the stack. Need to make this easier to use with something like `fn message<&T>(&self) -> Option<T>` and `fn message_mut(&self) -> Option<&mut T>` to make it easy for layers to inspect/edit the exact messages they're interested in.
* In addition to the message type M, components should have a response type R, to allow more control over exactly how a message is processed and a response is sent back.