### PR TITLE
Update actions to use locked dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -142,8 +142,8 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo doc
         run: |
-          cargo doc --no-deps -F log
-          cargo doc --no-deps -F defmt
+          cargo doc --no-deps -F log --locked
+          cargo doc --no-deps -F defmt --locked
         env:
           RUSTDOCFLAGS: --cfg docsrs
 
@@ -169,7 +169,7 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # --feature-powerset runs for every combination of features
       - name: cargo hack
-        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check
+        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check --locked
 
   deny:
     # cargo-deny checks licenses, advisories, sources, and bans for
@@ -193,7 +193,7 @@ jobs:
         with:
           log-level: warn
           command: check
-          arguments: --all-features
+          arguments: --all-features --locked
 
   test:
     runs-on: ubuntu-latest
@@ -211,7 +211,7 @@ jobs:
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo test
-        run: cargo test
+        run: cargo test --locked
 
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
@@ -236,8 +236,8 @@ jobs:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
         run: |
-          cargo check -F log
-          cargo check -F defmt
+          cargo check -F log --locked
+          cargo check -F defmt --locked
 
 
   check-arm-examples:
@@ -284,7 +284,7 @@ jobs:
       - name: cargo check
         working-directory: ${{ matrix.example_directory }}
         run: |
-          cargo check
+          cargo check --locked
   
   vet:
     # cargo-vet checks for unvetted dependencies in the Cargo.lock file

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -29,4 +29,4 @@ jobs:
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: cargo check
-        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check --target ${{ matrix.target }}
+        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check --locked --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "platform-service"
+version = "0.1.0"
+dependencies = [
+ "defmt 0.3.100",
+ "embassy-executor",
+ "embassy-imxrt",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-cfu-protocol",
+ "embedded-services",
+ "heapless 0.8.0",
+ "log",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
Since we're checking in cargo.lock into the repo, it is expected that it builds with the dependencies listed in the lock file.
Updating GitHub workflows to use the locked dependencies ensures that the build is reproducible.
Also updating the lock file to include the platform-service dependency.