### PR TITLE
Add critical-section crate to std examples

### DIFF
--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -1083,6 +1083,7 @@ version = "0.1.0"
 dependencies = [
  "battery-service",
  "cfu-service",
+ "critical-section",
  "embassy-executor",
  "embassy-futures",
  "embassy-sync",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -41,6 +41,8 @@ static_cell = "2"
 embedded-hal-async = "1.0.0"
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 
+critical-section = { version = "1.1", features = ["std"] }
+
 [[bin]]
 name = "type-c-basic"
 path = "src/bin/type_c/basic.rs"


### PR DESCRIPTION
Our standard examples are failing to link, probably due to some upstream crate removing a dependency for a standard critical section. This change adds a dependency to the `critical-section` crate with the `std` feature to fix the link error.