### PR TITLE
Pass charger device by reference to charger wrapper

### DIFF
--- a/power-policy-service/src/charger.rs
+++ b/power-policy-service/src/charger.rs
@@ -9,13 +9,13 @@ use embedded_services::{
     trace, warn,
 };
 
-pub struct Wrapper<C: ChargeController> {
-    charger_policy_state: charger::Device,
+pub struct Wrapper<'a, C: ChargeController> {
+    charger_policy_state: &'a charger::Device,
     controller: RefCell<C>,
 }
 
-impl<C: ChargeController> Wrapper<C> {
-    pub fn new(charger_policy_state: charger::Device, controller: C) -> Self {
+impl<'a, C: ChargeController> Wrapper<'a, C> {
+    pub fn new(charger_policy_state: &'a charger::Device, controller: C) -> Self {
         Self {
             charger_policy_state,
             controller: RefCell::new(controller),


### PR DESCRIPTION
Currently, the charger wrapper consumes the device object when the wrapper is instantiated.

However, when we register the charger device with the power-policy service, we pass it a static reference. Thus, the device needs to be statically allocated and therefore must not be consumed by the wrapper.

This change changes the wrapper to hold the device by reference instead.