### PR TITLE
type-c-service/tps6699x: Add workaround for autofet sink rejection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#443ffd8b6df67844208ceec58d5443e01b99a159"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#443ffd8b6df67844208ceec58d5443e01b99a159"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#443ffd8b6df67844208ceec58d5443e01b99a159"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "document-features",
 ]
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#b57a8293f9d064363136f320f0a6d85a7def5e35"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#b8948c96b8c8e920c837307d30653cfd74cf80cd"
 dependencies = [
  "bitfield 0.19.0",
  "defmt 0.3.100",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#aa42e1dd71dca6acefb2c0a0d53703dd49f9bb06"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x#7bd036665a51afaa9872d45890ac80d20a6f9802"
 dependencies = [
  "bincode",
  "bitfield 0.19.0",

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embassy-executor"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "critical-section",
  "document-features",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "document-features",
 ]
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#6034b17728b3528e42c8499a2893dc35d51d5590"
 dependencies = [
  "embassy-executor",
  "heapless 0.8.0",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#b57a8293f9d064363136f320f0a6d85a7def5e35"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#b8948c96b8c8e920c837307d30653cfd74cf80cd"
 dependencies = [
  "bitfield 0.19.0",
  "embedded-hal-async",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#aa42e1dd71dca6acefb2c0a0d53703dd49f9bb06"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x#7bd036665a51afaa9872d45890ac80d20a6f9802"
 dependencies = [
  "bincode",
  "bitfield 0.19.0",


### PR DESCRIPTION
When the controller is running FW with autofet enabled, commands related to sink control will be rejected. Normally this should be an error, but we're going to temporarily ignore this failure to allow existing devices to update to FW with autofet disabled without fear of getting stuck in a dead battery state.