### PR TITLE
[RFC] Implement initial thermal service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-fans"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-fans#0b79127122bbbb2c01abfad43d65b0814455dcd7"
+
+[[package]]
+name = "embedded-fans-async"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-fans#0b79127122bbbb2c01abfad43d65b0814455dcd7"
+dependencies = [
+ "embedded-fans",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +638,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "embedded-sensors-hal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971cd616a2326c63f660375e485e2f4573575b0bd293d228d7817c2b07be3475"
+
+[[package]]
+name = "embedded-sensors-hal-async"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fa0eb7de28c2ea3ed7eeeb9e2d48470fa92728910ecf5468944c754a823d799"
+dependencies = [
+ "embedded-sensors-hal",
+ "paste",
 ]
 
 [[package]]
@@ -1230,6 +1259,23 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thermal-service"
+version = "0.1.0"
+dependencies = [
+ "defmt 0.3.100",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-sensors-hal-async",
+ "embedded-services 0.1.0",
+ "log",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "battery-service",
+    "thermal-service",
     "cfu-service",
     "embedded-service",
     "espi-service",
@@ -38,6 +39,8 @@ embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy" }
 embedded-batteries-async = { git = "https://github.com/OpenDevicePartnership/embedded-batteries" }
+embedded-fans-async = { git = "https://github.com/OpenDevicePartnership/embedded-fans" }
+embedded-sensors-hal-async = "0.1.0"
 embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
@@ -55,3 +58,6 @@ postcard = "1.*"
 rand_core = "0.6.4"
 serde = { version = "1.0.*", default-features = false }
 tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x" }
+
+[patch.crates-io]
+embedded-fans = { git = "https://github.com/OpenDevicePartnership/embedded-fans" }

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -15,6 +15,7 @@ pub mod ec_type;
 pub mod fmt;
 pub mod hid;
 pub mod keyboard;
+pub mod oem;
 pub mod power;
 pub mod type_c;
 

--- a/embedded-service/src/oem/mod.rs
+++ b/embedded-service/src/oem/mod.rs
@@ -1,0 +1,83 @@
+//! Module to contain OEM-specific definitions
+
+pub mod vendor;
+
+/// Vendor ID
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(transparent)]
+pub struct VendorId(pub u16);
+
+/// Header for generic OEM messages
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MessageHeader {
+    /// Target vendor for this message
+    pub vendor: VendorId,
+    /// Vendor-spcific value
+    pub function: u16,
+}
+
+impl MessageHeader {
+    /// Create new OEM message header
+    pub fn new(vendor: VendorId, function: u16) -> Self {
+        Self { vendor, function }
+    }
+}
+
+/// Data for generic OEM messages
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MessageData {
+    /// A single bool value
+    Bool(bool),
+
+    /// A single u8 value
+    U8(u8),
+    /// A single u16 value
+    U16(u16),
+    /// A single u32 value
+    U32(u32),
+    /// A single u64 value
+    U64(u64),
+    /// A single i8 value
+    I8(i8),
+    /// A single i16 value
+    I16(i16),
+    /// A single i32 value
+    I32(i32),
+    /// A single i64 value
+    I64(i64),
+
+    /// A single usize value
+    Usize(usize),
+    /// A single isize value
+    Isize(isize),
+
+    /// A single f32 value
+    F32(f32),
+
+    /// A single string slice
+    Str(&'static str),
+
+    /// Arbitrary data
+    Bytes(&'static [u8]),
+}
+
+/// Generic OEM message
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Message {
+    /// Message header
+    pub header: MessageHeader,
+    /// Message data
+    pub data: MessageData,
+}
+
+impl Message {
+    /// Create a new OEM message
+    pub fn new(vendor: VendorId, function: u16, data: MessageData) -> Self {
+        let header = MessageHeader::new(vendor, function);
+        Self { header, data }
+    }
+}

--- a/embedded-service/src/oem/vendor.rs
+++ b/embedded-service/src/oem/vendor.rs
@@ -1,0 +1,5 @@
+//! Module to contain vendor ID definitions
+use super::VendorId;
+
+/// Surface vendor ID
+pub const SURFACE: VendorId = VendorId(42);

--- a/thermal-service/Cargo.toml
+++ b/thermal-service/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "thermal-service"
+version = "0.1.0"
+edition = "2021"
+description = "Thermal service implementation"
+repository = "https://github.com/OpenDevicePartnership/embedded-services"
+rust-version = "1.85"
+license = "MIT"
+
+[dependencies]
+defmt = { workspace = true, optional = true }
+embassy-executor.workspace = true
+embassy-futures.workspace = true
+embassy-sync.workspace = true
+embassy-time.workspace = true
+embedded-hal-async.workspace = true
+embedded-hal.workspace = true
+embedded-services.workspace = true
+embedded-sensors-hal-async.workspace = true
+embedded-fans-async.workspace = true
+log = { workspace = true, optional = true }
+
+[features]
+default = []
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embassy-time/defmt",
+    "embassy-sync/defmt",
+    "embassy-executor/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "embassy-time/log",
+    "embassy-sync/log",
+    "embassy-executor/log",
+]

--- a/thermal-service/src/context.rs
+++ b/thermal-service/src/context.rs
@@ -1,0 +1,120 @@
+//! Thermal service
+use crate::fan;
+use crate::sensor;
+use core::sync::atomic::{AtomicBool, Ordering};
+use embassy_sync::once_lock::OnceLock;
+use embedded_services::{error, intrusive_list};
+
+/// Error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The requested device does not exist
+    InvalidDevice,
+}
+
+struct Context {
+    /// Registered temperature sensors
+    sensors: intrusive_list::IntrusiveList,
+    /// Registered fans
+    fans: intrusive_list::IntrusiveList,
+}
+
+impl Context {
+    fn new() -> Self {
+        Self {
+            sensors: intrusive_list::IntrusiveList::new(),
+            fans: intrusive_list::IntrusiveList::new(),
+        }
+    }
+}
+
+static CONTEXT: OnceLock<Context> = OnceLock::new();
+
+/// Init thermal service context
+pub fn init() {
+    CONTEXT.get_or_init(Context::new);
+}
+
+/// Register a sensor with the thermal service
+pub async fn register_sensor(sensor: &'static sensor::DeviceNode) -> Result<(), intrusive_list::Error> {
+    if get_sensor(sensor.device.id()).await.is_some() {
+        return Err(intrusive_list::Error::NodeAlreadyInList);
+    }
+
+    CONTEXT.get().await.sensors.push(sensor)
+}
+
+/// Register a fan with the thermal service
+pub async fn register_fan(fan: &'static fan::Device) -> Result<(), intrusive_list::Error> {
+    if get_fan(fan.id()).await.is_some() {
+        return Err(intrusive_list::Error::NodeAlreadyInList);
+    }
+
+    CONTEXT.get().await.fans.push(fan)
+}
+
+/// Find a sensor by its ID
+async fn get_sensor(id: sensor::DeviceId) -> Option<&'static sensor::Device> {
+    for sensor in &CONTEXT.get().await.sensors {
+        if let Some(data) = sensor.data::<sensor::DeviceNode>() {
+            if data.device.id() == id {
+                return Some(data.device);
+            }
+        } else {
+            error!("Non-device located in sensors list");
+        }
+    }
+
+    None
+}
+
+/// Find a fan by its ID
+async fn get_fan(id: fan::DeviceId) -> Option<&'static fan::Device> {
+    for fan in &CONTEXT.get().await.fans {
+        if let Some(data) = fan.data::<fan::Device>() {
+            if data.id() == id {
+                return Some(data);
+            }
+        } else {
+            error!("Non-device located in fan list");
+        }
+    }
+
+    None
+}
+
+/// Singleton struct to give access to the thermal context
+pub struct ContextToken(());
+impl ContextToken {
+    /// Create a new context token, returning None if this function has been called before
+    pub fn create() -> Option<Self> {
+        static INIT: AtomicBool = AtomicBool::new(false);
+        if INIT.load(Ordering::SeqCst) {
+            return None;
+        }
+
+        INIT.store(true, Ordering::SeqCst);
+        Some(ContextToken(()))
+    }
+
+    /// Get a sensor by its ID
+    pub async fn get_sensor(&self, id: sensor::DeviceId) -> Result<&'static sensor::Device, Error> {
+        get_sensor(id).await.ok_or(Error::InvalidDevice)
+    }
+
+    /// Provides access to the sensors list
+    pub async fn sensors(&self) -> &intrusive_list::IntrusiveList {
+        &CONTEXT.get().await.sensors
+    }
+
+    /// Get a fan by its ID
+    pub async fn get_fan(&self, id: fan::DeviceId) -> Result<&'static fan::Device, Error> {
+        get_fan(id).await.ok_or(Error::InvalidDevice)
+    }
+
+    /// Provides access to the fans list
+    pub async fn fans(&self) -> &intrusive_list::IntrusiveList {
+        &CONTEXT.get().await.fans
+    }
+}

--- a/thermal-service/src/fan.rs
+++ b/thermal-service/src/fan.rs
@@ -1,0 +1,200 @@
+//! Fan Device
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::mutex::Mutex;
+use embedded_fans_async as fan_traits;
+use embedded_services::{intrusive_list, oem, Node};
+
+/// Fan error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// An invalid request was received
+    InvalidRequest,
+    /// Device encountered a hardware failure
+    HardwareFailure,
+}
+
+/// Fan request
+// TODO: More generic requests that make sense
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Request {
+    /// Get RPM
+    GetRpm,
+    /// Get Min RPM
+    GetMinRpm,
+    /// Get Max RPM
+    GetMaxRpm,
+    /// Set RPM
+    SetRpm(u32),
+
+    /// Get DBA
+    GetDba,
+    /// Get Min DBA
+    GetMinDba,
+    /// Get Max DBA
+    GetMaxDba,
+
+    /// Get Sones
+    GetSones,
+    /// Get Min Sones
+    GetMinSones,
+    /// Get Max Sones
+    GetMaxSones,
+
+    /// OEM-specific request
+    Oem(oem::Message),
+}
+
+/// Fan response
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Response {
+    /// Response for any request that is successful but does not require data
+    Success,
+    /// Current RPM
+    GetRpm(u32),
+    /// Min RPM
+    GetMinRpm(u32),
+    /// Max RPM
+    GetMaxRpm(u32),
+
+    /// Get DBA
+    GetDba(u32),
+    /// Get Min DBA
+    GetMinDba(u32),
+    /// Get Max DBA
+    GetMaxDba(u32),
+
+    /// Get Sones
+    GetSones(u32),
+    /// Get Min Sones
+    GetMinSones(u32),
+    /// Get Max Sones
+    GetMaxSones(u32),
+
+    /// OEM-specific response
+    Oem(oem::Message),
+}
+
+/// Device ID new type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceId(pub u8);
+
+/// Generic process function which OEMs can still include in their trait override
+pub async fn process_request<T: Controller + ?Sized>(controller: &mut T, request: Request) -> Result<Response, Error> {
+    match request {
+        Request::GetRpm => {
+            let rpm = controller.rpm().await.map_err(|_| Error::HardwareFailure)?;
+            Ok(Response::GetRpm(rpm as u32))
+        }
+        Request::SetRpm(rpm) => {
+            controller
+                .set_speed_rpm(rpm as u16)
+                .await
+                .map_err(|_| Error::HardwareFailure)?;
+            Ok(Response::Success)
+        }
+        Request::GetMinRpm => {
+            let min_rpm = controller.min_rpm();
+            Ok(Response::GetMinRpm(min_rpm as u32))
+        }
+        Request::GetMaxRpm => {
+            let max_rpm = controller.max_rpm();
+            Ok(Response::GetMaxRpm(max_rpm as u32))
+        }
+        _ => Err(Error::InvalidRequest),
+    }
+}
+
+/// Trait which driver implementers use to bridge gap between requests and hardware calls
+#[allow(async_fn_in_trait)]
+pub trait Controller: fan_traits::Fan + fan_traits::RpmSense {
+    async fn process_request(&mut self, request: Request) -> Result<Response, Error> {
+        process_request(self, request).await
+    }
+}
+
+/// Fan device struct
+pub struct Device {
+    /// Intrusive list node
+    node: Node,
+    /// Device ID
+    id: DeviceId,
+    /// Channel for requests to the device
+    request: Channel<NoopRawMutex, Request, 1>,
+    /// Channel for responses from the device
+    response: Channel<NoopRawMutex, Result<Response, Error>, 1>,
+}
+
+impl Device {
+    /// Create a new sensor device
+    pub fn new(id: DeviceId) -> Self {
+        Self {
+            node: Node::uninit(),
+            id,
+            request: Channel::new(),
+            response: Channel::new(),
+        }
+    }
+
+    /// Get the device ID
+    pub fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    /// Wait for a request
+    pub async fn wait_request(&self) -> Request {
+        self.request.receive().await
+    }
+
+    /// Send a response
+    pub async fn send_response(&self, response: Result<Response, Error>) {
+        self.response.send(response).await;
+    }
+
+    /// Execute request and wait for response
+    pub async fn execute_request(&self, request: Request) -> Result<Response, Error> {
+        self.request.send(request).await;
+        self.response.receive().await
+    }
+}
+
+impl intrusive_list::NodeContainer for Device {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+/// Fan struct containing device for comms and driver
+pub struct Fan<T: Controller> {
+    /// Underlying device
+    pub device: Device,
+    /// Underlying controller
+    pub controller: Mutex<NoopRawMutex, T>,
+}
+
+impl<T: Controller> Fan<T> {
+    /// New fan
+    pub fn new(id: DeviceId, driver: T) -> Self {
+        Self {
+            device: Device::new(id),
+            controller: Mutex::new(driver),
+        }
+    }
+
+    /// Process request for fan
+    pub async fn wait_and_process(&self) {
+        let request = self.device.wait_request().await;
+        let response = self.controller.lock().await.process_request(request).await;
+        self.device.send_response(response).await;
+    }
+}
+
+/// Should be called by a wrapper task per fan (since tasks themselves cannot be generic)
+pub async fn task<T: Controller>(fan: &'static Fan<T>) {
+    loop {
+        fan.wait_and_process().await;
+    }
+}

--- a/thermal-service/src/lib.rs
+++ b/thermal-service/src/lib.rs
@@ -1,0 +1,172 @@
+#![no_std]
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::mutex::Mutex;
+use embassy_sync::once_lock::OnceLock;
+use embedded_services::{comms, error, info};
+pub use thermal_zone::*;
+
+pub mod fan;
+pub mod mptf;
+pub mod sensor;
+pub mod thermal_zone;
+
+/// Contains information concerning where to route unknown messages (dictated by the supplied OemKey)
+/// and if the service should route standard MPTF messages to the OEM or handle them itself.
+///
+/// A better strategy will likely be implemented, but this is the general idea.
+pub struct Oem {
+    route: comms::OemKey,
+    route_mptf: bool,
+}
+
+impl Oem {
+    pub fn new(route: comms::OemKey, route_mptf: bool) -> Self {
+        Self { route, route_mptf }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ServiceMsg {
+    pub msg: mptf::Request,
+    pub from: comms::EndpointID,
+}
+
+impl ServiceMsg {
+    pub fn new(msg: mptf::Request, from: comms::EndpointID) -> Self {
+        Self { msg, from }
+    }
+}
+
+pub struct ThermalService<T: ThermalZone> {
+    endpoint: comms::Endpoint,
+    request: Channel<NoopRawMutex, ServiceMsg, 1>,
+    oem: Oem,
+    tz: Mutex<NoopRawMutex, T>,
+}
+
+impl<T: ThermalZone> ThermalService<T> {
+    fn new(tz: T, oem: Oem) -> Option<Self> {
+        Some(Self {
+            endpoint: comms::Endpoint::uninit(comms::EndpointID::Internal(comms::Internal::Thermal)),
+            request: Channel::new(),
+            oem,
+            tz: Mutex::new(tz),
+        })
+    }
+
+    // Process a received standard MPTF request
+    async fn process_mptf_request(&self, service_msg: mptf::Request) -> Result<mptf::Response, mptf::Error> {
+        let tz = self.tz.lock().await;
+
+        match service_msg {
+            // Standard command
+            mptf::Request::GetTmp(_) => tz.get_tmp().await,
+            mptf::Request::GetThrs(_) => tz.get_thrs().await,
+            mptf::Request::SetThrs(_, timeout, low, high) => tz.set_thrs(timeout, low, high).await,
+            mptf::Request::SetScp(_, policy, acstc_limit, pow_limit) => {
+                tz.set_scp(policy, acstc_limit, pow_limit).await
+            }
+
+            // DWORD Variable - Thermal
+            mptf::Request::GetCrtTemp => tz.get_crt_temp().await,
+            mptf::Request::SetCrtTemp(temp) => tz.set_crt_temp(temp).await,
+            mptf::Request::GetProcHotTemp => tz.get_proc_hot_temp().await,
+            mptf::Request::SetProcHotTemp(temp) => tz.set_proc_hot_temp(temp).await,
+            mptf::Request::GetProfileType => tz.get_profile_type().await,
+            mptf::Request::SetProfileType(profile_type) => tz.set_profile_type(profile_type).await,
+
+            // DWORD Variable - Fan
+            mptf::Request::GetFanOnTemp => tz.get_fan_on_temp().await,
+            mptf::Request::SetFanOnTemp(temp) => tz.set_fan_on_temp(temp).await,
+            mptf::Request::GetFanRampTemp => tz.get_fan_ramp_temp().await,
+            mptf::Request::SetFanRampTemp(temp) => tz.set_fan_ramp_temp(temp).await,
+            mptf::Request::GetFanMaxTemp => tz.get_fan_max_temp().await,
+            mptf::Request::SetFanMaxTemp(temp) => tz.set_fan_max_temp(temp).await,
+            mptf::Request::GetFanMinRpm => tz.get_fan_min_rpm().await,
+            mptf::Request::GetFanMaxRpm => tz.get_fan_max_rpm().await,
+            mptf::Request::GetFanCurrentRpm => tz.get_fan_current_rpm().await,
+
+            // DWORD Variable - Fan Optional
+            mptf::Request::GetFanMinDba => tz.get_fan_min_dba().await,
+            mptf::Request::GetFanMaxDba => tz.get_fan_max_dba().await,
+            mptf::Request::GetFanCurrentDba => tz.get_fan_current_dba().await,
+            mptf::Request::GetFanMinSones => tz.get_fan_min_sones().await,
+            mptf::Request::GetFanMaxSones => tz.get_fan_max_sones().await,
+            mptf::Request::GetFanCurrentSones => tz.get_fan_current_sones().await,
+        }
+    }
+
+    async fn wait_service_msg(&self) -> ServiceMsg {
+        self.request.receive().await
+    }
+
+    async fn wait_and_process(&self) {
+        let request = self.wait_service_msg().await;
+        let response = self.process_mptf_request(request.msg).await;
+        self.endpoint.send(request.from, &response).await.unwrap()
+    }
+}
+
+impl<T: ThermalZone> comms::MailboxDelegate for ThermalService<T> {
+    fn receive(&self, message: &comms::Message) -> Result<(), comms::MailboxDelegateError> {
+        // This method gets called by embedded-services any time a message is sent to this service
+        // We check if its a standard MPTF request, and if so, handle it ourselves (unless OEM wants to handle them)
+        // Unknown messages get routed to the OEM as well
+        //
+        // Unfortunately since this method isn't async can't use the async endpoint.send() method here
+        // So have to come up with a cleaner way to move the message to move non-MPTF messages to a generic buffer
+        // for later forwarding by a different async task.
+        if !self.oem.route_mptf {
+            // If MPTF request, send to our request channel for processing
+            if let Some(&msg) = message.data.get::<mptf::Request>() {
+                self.request
+                    .try_send(ServiceMsg::new(msg, message.from))
+                    .map_err(|_| comms::MailboxDelegateError::BufferFull)
+            } else {
+                // TODO: Route unknown message to OEM
+                info!("Routing to: {}", self.oem.route);
+                todo!()
+            }
+        } else {
+            // TODO: Always route message to OEM
+            info!("Routing to: {}", self.oem.route);
+            todo!()
+        }
+    }
+}
+
+// Just one instance of the service should be running
+// TODO: Have to reconsider because this can't be made generic over any impl ThermalZone
+static SERVICE: OnceLock<ThermalService<&'static GenericThermalZone>> = OnceLock::new();
+
+// This task exists solely to listen for incoming requests and then process them appropriately
+#[embassy_executor::task]
+pub async fn rx_task() {
+    let s = SERVICE.get().await;
+
+    loop {
+        s.wait_and_process().await;
+    }
+}
+
+/// This must be called to initialize the Thermal service and spawn additional tasks
+pub async fn init(spawner: embassy_executor::Spawner, tz: &'static GenericThermalZone, oem: Oem) {
+    info!("Starting thermal service task");
+    let service =
+        SERVICE.get_or_init(|| ThermalService::new(tz, oem).expect("Thermal service singleton already initialized"));
+
+    if comms::register_endpoint(service, &service.endpoint).await.is_err() {
+        error!("Failed to register thermal service endpoint");
+        return;
+    }
+
+    // If the OEM doesn't want to handle MPTF logic, spawn the generic ThermalZone task
+    if !service.oem.route_mptf {
+        spawner.must_spawn(thermal_zone::generic_task(SERVICE.get().await, tz));
+    }
+
+    // But always spawn the task for receiving thermal messages
+    spawner.must_spawn(rx_task());
+}

--- a/thermal-service/src/mptf.rs
+++ b/thermal-service/src/mptf.rs
@@ -1,0 +1,140 @@
+//! Definitions for standard MPTF messages the generic Thermal service can expect
+//! These will need to be fleshed out and ensure they meet required MPTF/ACPI specs and whatnot
+//!
+//! Transport services such as eSPI and SSH would then need to make sure they agree on this format
+//! as they would then be responsible for converting raw data into these types and forwarding them
+//! to thermal.
+pub type TzId = u8;
+pub type Dword = u32;
+pub type DeciKelvin = Dword;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Error {
+    InvalidParameter,
+    UnsupportedRevision,
+    HardwareError,
+}
+
+impl From<Error> for u8 {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::InvalidParameter => 1,
+            Error::UnsupportedRevision => 2,
+            Error::HardwareError => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Request {
+    // EC_THM_GET_TMP
+    GetTmp(TzId),
+
+    // EC_THM_GET_THRS
+    GetThrs(TzId),
+    // EC_THM_SET_THRS
+    SetThrs(TzId, Dword, DeciKelvin, DeciKelvin),
+
+    // EC_THM_SET_SCP
+    SetScp(TzId, Dword, Dword, Dword),
+
+    // EC_THM_GET_VAR(218246e7-baf6-45f1-aa13-07e4845256b8)
+    GetCrtTemp,
+    // EC_THM_SET_VAR(218246e7-baf6-45f1-aa13-07e4845256b8)
+    SetCrtTemp(DeciKelvin),
+
+    // EC_THM_GET_VAR(22dc52d2-fd0b-47ab-95b8-26552f9831a5)
+    GetProcHotTemp,
+    // EC_THM_SET_VAR(22dc52d2-fd0b-47ab-95b8-26552f9831a5)
+    SetProcHotTemp(DeciKelvin),
+
+    // EC_THM_GET_VAR(23b4a025-cdfd-4af9-a411-37a24c574615)
+    GetProfileType,
+    // EC_THM_SET_VAR(23b4a025-cdfd-4af9-a411-37a24c574615)
+    SetProfileType(Dword),
+
+    // EC_THM_GET_VAR(ba17b567-c368-48d5-bc6f-a312a41583c1)
+    GetFanOnTemp,
+    // EC_THM_SET_VAR(ba17b567-c368-48d5-bc6f-a312a41583c1)
+    SetFanOnTemp(DeciKelvin),
+
+    // EC_THM_GET_VAR(3a62688c-d95b-4d2d-bacc-90d7a5816bcd)
+    GetFanRampTemp,
+    // EC_THM_SET_VAR(3a62688c-d95b-4d2d-bacc-90d7a5816bcd)
+    SetFanRampTemp(DeciKelvin),
+
+    // EC_THM_GET_VAR(dcb758b1-f0fd-4ec7-b2c0-ef1e2a547b76)
+    GetFanMaxTemp,
+    // EC_THM_SET_VAR(dcb758b1-f0fd-4ec7-b2c0-ef1e2a547b76)
+    SetFanMaxTemp(DeciKelvin),
+
+    // EC_THM_GET_VAR(db261c77-934b-45e2-9742-256c62badb7a)
+    GetFanMinRpm,
+
+    // EC_THM_GET_VAR(5cf839df-8be7-42b9-9ac5-3403ca2c8a6a)
+    GetFanMaxRpm,
+
+    // EC_THM_GET_VAR(adf95492-0776-4ffc-84f3-b6c8b5269683)
+    GetFanCurrentRpm,
+
+    // EC_THM_GET_VAR()
+    GetFanMinDba,
+
+    // EC_THM_GET_VAR()
+    GetFanMaxDba,
+
+    // EC_THM_GET_VAR()
+    GetFanCurrentDba,
+
+    // EC_THM_GET_VAR()
+    GetFanMinSones,
+
+    // EC_THM_GET_VAR()
+    GetFanMaxSones,
+
+    // EC_THM_GET_VAR()
+    GetFanCurrentSones,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Response {
+    // Standard command
+    GetTmp(DeciKelvin),
+    GetThrs(Dword, DeciKelvin, DeciKelvin),
+    SetThrs,
+    SetScp,
+
+    // DWORD Variable - Thermal
+    GetCrtTemp(DeciKelvin),
+    SetCrtTemp,
+    GetProcHotTemp(DeciKelvin),
+    SetProcHotTemp,
+    GetProfileType(DeciKelvin),
+    SetProfileType,
+
+    // DWORD Variable - Fan
+    GetFanOnTemp(DeciKelvin),
+    SetFanOnTemp,
+    GetFanRampTemp(DeciKelvin),
+    SetFanRampTemp,
+    GetFanMaxTemp(DeciKelvin),
+    SetFanMaxTemp,
+    GetFanMinRpm(Dword),
+    GetFanMaxRpm(Dword),
+    GetFanCurrentRpm(Dword),
+
+    // DWORD Variable - Fan Optional
+    GetFanMinDba(Dword),
+    GetFanMaxDba(Dword),
+    GetFanCurrentDba(Dword),
+    GetFanMinSones(Dword),
+    GetFanMaxSones(Dword),
+    GetFanCurrentSones(Dword),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Notify {
+    Threshold,
+    Critical,
+    ProcHot,
+}

--- a/thermal-service/src/sensor.rs
+++ b/thermal-service/src/sensor.rs
@@ -1,0 +1,167 @@
+//! Sensor Device
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::mutex::Mutex;
+use embedded_sensors_hal_async::temperature::{TemperatureSensor, TemperatureThresholdWait};
+use embedded_services::{intrusive_list, oem, Node};
+
+/// Sensor error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// An invalid request was received
+    InvalidRequest,
+    /// Device encountered a hardware failure
+    HardwareFailure,
+}
+
+/// Sensor request
+// TODO: More generic requests that make sense
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Request {
+    /// Current temperature measurement
+    GetCurTemp,
+    /// Set low alert thresholds
+    SetThresholdLow(f32),
+    /// Set high alert thresholds
+    SetThresholdHigh(f32),
+
+    /// OEM-specific request
+    Oem(oem::Message),
+}
+
+/// Sensor response
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Response {
+    /// Response for any request that is successful but does not require data
+    Success,
+    /// Current temperature of sensor in dC
+    GetCurTemp(f32),
+
+    /// OEM-specific response
+    Oem(oem::Message),
+}
+
+/// Device ID new type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceId(pub u8);
+
+/// Generic process function which OEMs can still include in their trait override
+pub async fn process_request<T: Controller + ?Sized>(controller: &mut T, request: Request) -> Result<Response, Error> {
+    match request {
+        Request::GetCurTemp => {
+            let temp = controller.temperature().await.map_err(|_| Error::HardwareFailure)?;
+            Ok(Response::GetCurTemp(temp))
+        }
+        Request::SetThresholdLow(_low) => todo!(),
+        Request::SetThresholdHigh(_low) => todo!(),
+        _ => Err(Error::InvalidRequest),
+    }
+}
+
+/// Trait which driver implementers use to bridge gap between requests and hardware calls
+#[allow(async_fn_in_trait)]
+pub trait Controller: TemperatureSensor + TemperatureThresholdWait {
+    async fn process_request(&mut self, request: Request) -> Result<Response, Error> {
+        process_request(self, request).await
+    }
+}
+
+/// Sensor device struct
+pub struct Device {
+    /// Device ID
+    id: DeviceId,
+    /// Channel for requests to the device
+    request: Channel<NoopRawMutex, Request, 1>,
+    /// Channel for responses from the device
+    response: Channel<NoopRawMutex, Result<Response, Error>, 1>,
+}
+
+impl Device {
+    /// Create a new sensor device
+    pub fn new(id: DeviceId) -> Self {
+        Self {
+            id,
+            request: Channel::new(),
+            response: Channel::new(),
+        }
+    }
+
+    /// Get the device ID
+    pub fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    /// Wait for a request
+    pub async fn wait_request(&self) -> Request {
+        self.request.receive().await
+    }
+
+    /// Send a response
+    pub async fn send_response(&self, response: Result<Response, Error>) {
+        self.response.send(response).await;
+    }
+
+    /// Execute request and wait for response
+    pub async fn execute_request(&self, request: Request) -> Result<Response, Error> {
+        self.request.send(request).await;
+        self.response.receive().await
+    }
+}
+
+/// Wrapper around Device for insertion into intrusive linked list
+pub struct DeviceNode {
+    /// Intrusive list node
+    node: Node,
+    /// Static reference to device
+    pub device: &'static Device,
+}
+
+impl DeviceNode {
+    pub fn new(device: &'static Device) -> Self {
+        Self {
+            node: Node::uninit(),
+            device,
+        }
+    }
+}
+
+impl intrusive_list::NodeContainer for DeviceNode {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+/// Sensor struct containing device for comms and driver
+pub struct Sensor<T: Controller> {
+    /// Underlying device
+    pub device: Device,
+    /// Underlying controller
+    pub controller: Mutex<NoopRawMutex, T>,
+}
+
+impl<T: Controller> Sensor<T> {
+    /// New sensor
+    pub fn new(id: DeviceId, controller: T) -> Self {
+        Self {
+            device: Device::new(id),
+            controller: Mutex::new(controller),
+        }
+    }
+
+    /// Process request for sensor
+    pub async fn wait_and_process(&self) {
+        let request = self.device.wait_request().await;
+        let response = self.controller.lock().await.process_request(request).await;
+        self.device.send_response(response).await;
+    }
+}
+
+/// Should be called by a wrapper task per sensor (since tasks themselves cannot be generic)
+pub async fn task<T: Controller>(sensor: &'static Sensor<T>) {
+    loop {
+        sensor.wait_and_process().await;
+    }
+}

--- a/thermal-service/src/thermal_zone.rs
+++ b/thermal-service/src/thermal_zone.rs
@@ -1,0 +1,588 @@
+use crate::fan;
+use crate::mptf;
+use crate::sensor;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use embassy_time::Timer;
+use embedded_services::comms;
+use embedded_services::error;
+use embedded_services::info;
+
+/// Convert deciKelvin to degrees Celsius
+pub const fn dk_to_c(dk: mptf::DeciKelvin) -> f32 {
+    (dk / 10) as f32 - 273.15
+}
+
+/// Convert degrees Celsius to deciKelvin
+pub const fn c_to_dk(c: f32) -> mptf::DeciKelvin {
+    ((c + 273.15) * 10.0) as mptf::DeciKelvin
+}
+
+#[allow(async_fn_in_trait)]
+pub trait ThermalZone {
+    async fn get_tmp(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_thrs(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_thrs(
+        &self,
+        timeout: mptf::Dword,
+        low: mptf::Dword,
+        high: mptf::Dword,
+    ) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_scp(
+        &self,
+        cooling_policy: mptf::Dword,
+        acoustic_lim: mptf::Dword,
+        power_lim: mptf::Dword,
+    ) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_crt_temp(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_crt_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_proc_hot_temp(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_proc_hot_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_profile_type(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_profile_type(&self, profile_type: mptf::Dword) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_on_temp(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_fan_on_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_ramp_temp(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_fan_ramp_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_max_temp(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn set_fan_max_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_min_rpm(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_max_rpm(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_current_rpm(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_min_dba(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_max_dba(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_current_dba(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_min_sones(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_max_sones(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn get_fan_current_sones(&self) -> Result<mptf::Response, mptf::Error>;
+
+    async fn ramp_response(&self, temp: f32) -> Result<(), ()>;
+}
+
+impl<T: ThermalZone + ?Sized> ThermalZone for &T {
+    async fn get_tmp(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_tmp(self).await
+    }
+
+    async fn get_thrs(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_thrs(self).await
+    }
+
+    async fn set_thrs(
+        &self,
+        timeout: mptf::Dword,
+        low: mptf::Dword,
+        high: mptf::Dword,
+    ) -> Result<mptf::Response, mptf::Error> {
+        T::set_thrs(self, timeout, low, high).await
+    }
+
+    async fn set_scp(
+        &self,
+        cooling_policy: mptf::Dword,
+        acoustic_lim: mptf::Dword,
+        power_lim: mptf::Dword,
+    ) -> Result<mptf::Response, mptf::Error> {
+        T::set_scp(self, cooling_policy, acoustic_lim, power_lim).await
+    }
+
+    async fn get_crt_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_crt_temp(self).await
+    }
+
+    async fn set_crt_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        T::set_crt_temp(self, temp).await
+    }
+
+    async fn get_proc_hot_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_proc_hot_temp(self).await
+    }
+
+    async fn set_proc_hot_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        T::set_proc_hot_temp(self, temp).await
+    }
+
+    async fn get_profile_type(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_profile_type(self).await
+    }
+
+    async fn set_profile_type(&self, profile_type: mptf::Dword) -> Result<mptf::Response, mptf::Error> {
+        T::set_profile_type(self, profile_type).await
+    }
+
+    async fn get_fan_on_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_on_temp(self).await
+    }
+
+    async fn set_fan_on_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        T::set_fan_on_temp(self, temp).await
+    }
+
+    async fn get_fan_ramp_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_ramp_temp(self).await
+    }
+
+    async fn set_fan_ramp_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        T::set_fan_ramp_temp(self, temp).await
+    }
+
+    async fn get_fan_max_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_max_temp(self).await
+    }
+
+    async fn set_fan_max_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        T::set_fan_max_temp(self, temp).await
+    }
+
+    async fn get_fan_min_rpm(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_min_rpm(self).await
+    }
+
+    async fn get_fan_max_rpm(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_max_rpm(self).await
+    }
+
+    async fn get_fan_current_rpm(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_current_rpm(self).await
+    }
+
+    async fn get_fan_min_dba(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_min_dba(self).await
+    }
+
+    async fn get_fan_max_dba(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_max_dba(self).await
+    }
+
+    async fn get_fan_current_dba(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_current_dba(self).await
+    }
+
+    async fn get_fan_min_sones(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_min_sones(self).await
+    }
+
+    async fn get_fan_max_sones(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_max_sones(self).await
+    }
+
+    async fn get_fan_current_sones(&self) -> Result<mptf::Response, mptf::Error> {
+        T::get_fan_current_sones(self).await
+    }
+
+    async fn ramp_response(&self, temp: f32) -> Result<(), ()> {
+        T::ramp_response(self, temp).await
+    }
+}
+
+enum FanState {
+    Off,
+    On,
+    Ramping,
+    Max,
+}
+
+// State for the generic MPTF thermal zone
+struct GenericThermalZoneState {
+    cur_temp: f32, // Cached, previous measured temperature
+
+    thresholds: (u32, f32, f32),
+    cooling_policy: u32,
+    crt_temp: f32,
+    proc_hot_temp: f32,
+    profile_type: u32,
+    acoustic_lim: u32,
+    power_lim: u32,
+
+    fan_on_temp: f32,
+    fan_ramp_temp: f32,
+    fan_max_temp: f32,
+    fan_state: FanState,
+}
+
+impl Default for GenericThermalZoneState {
+    fn default() -> Self {
+        Self {
+            cur_temp: 0.0,
+
+            thresholds: (0, 0.0, 0.0),
+            cooling_policy: 0,
+            crt_temp: 100.0,
+            proc_hot_temp: 85.0,
+            profile_type: 0,
+            acoustic_lim: 0,
+            power_lim: 0,
+
+            fan_on_temp: 177.0,
+            fan_ramp_temp: 180.0,
+            fan_max_temp: 200.0,
+            fan_state: FanState::Off,
+        }
+    }
+}
+
+// A generic MPTF Thermal Zone
+pub struct GenericThermalZone {
+    state: Mutex<NoopRawMutex, GenericThermalZoneState>,
+    sensor: &'static sensor::Device,
+    fan: &'static fan::Device,
+}
+
+impl GenericThermalZone {
+    async fn threshold_check(&self, thermal_service: &'static crate::ThermalService<&'static GenericThermalZone>) {
+        let state = self.state.lock().await;
+
+        // If temp trips a threshold, notify host (which should notify OSPM)
+        if state.cur_temp <= state.thresholds.1 || state.cur_temp >= state.thresholds.2 {
+            thermal_service
+                .endpoint
+                .send(
+                    comms::EndpointID::External(comms::External::Host),
+                    &mptf::Notify::Threshold,
+                )
+                .await
+                .unwrap();
+        }
+
+        // If temp rises above PROCHOT, send the notification somewhere
+        if state.cur_temp <= state.thresholds.1 || state.cur_temp >= state.thresholds.2 {
+            // TODO: Send PROCHOT notification somewhere
+        }
+
+        // If temp rises above critical, notify Host and also notify power service to shutdown
+        if state.cur_temp >= state.crt_temp {
+            thermal_service
+                .endpoint
+                .send(
+                    comms::EndpointID::External(comms::External::Host),
+                    &mptf::Notify::Critical,
+                )
+                .await
+                .unwrap();
+
+            // TODO: Actually figure out message to send to Power service
+            thermal_service
+                .endpoint
+                .send(
+                    comms::EndpointID::Internal(comms::Internal::Power),
+                    &mptf::Notify::Critical,
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    async fn handle_fan_state(&self) {
+        let mut state = self.state.lock().await;
+
+        // Handle fan response to measured temperature
+        match state.fan_state {
+            FanState::Off => {
+                // If temp rises above Fan Min On Temp, set fan to min RPM
+                if state.cur_temp >= state.fan_on_temp {
+                    let min_rpm = match self.fan.execute_request(fan::Request::GetMinRpm).await {
+                        Ok(fan::Response::GetMinRpm(rpm)) => rpm,
+                        _ => todo!(),
+                    };
+
+                    self.fan.execute_request(fan::Request::SetRpm(min_rpm)).await.unwrap();
+                    state.fan_state = FanState::On;
+                    info!("\n\nFan turned ON\n\n");
+                }
+            }
+
+            FanState::On => {
+                // If temp rises above Fan Ramp Temp, set fan to begin ramp curve
+                if state.cur_temp >= state.fan_ramp_temp {
+                    state.fan_state = FanState::Ramping;
+                    info!("\n\nFan ramping!\n\n");
+
+                // If falls below on temp, turn fan off
+                } else if state.cur_temp < state.fan_on_temp {
+                    self.fan.execute_request(fan::Request::SetRpm(0)).await.unwrap();
+                    state.fan_state = FanState::Off;
+                    info!("\n\nFan turned OFF\n\n");
+                }
+            }
+
+            FanState::Ramping => {
+                // If temp falls below ramp temp, set to On state
+                if state.cur_temp < state.fan_ramp_temp {
+                    let min_rpm = match self.fan.execute_request(fan::Request::GetMinRpm).await {
+                        Ok(fan::Response::GetMinRpm(rpm)) => rpm,
+                        _ => todo!(),
+                    };
+
+                    self.fan.execute_request(fan::Request::SetRpm(min_rpm)).await.unwrap();
+                    state.fan_state = FanState::On;
+                }
+
+                // If temp stays below max temp, continue ramp response
+                if state.cur_temp < state.fan_max_temp {
+                    self.ramp_response(state.cur_temp).await.unwrap();
+
+                // If above max, go to max state
+                } else {
+                    let max_rpm = match self.fan.execute_request(fan::Request::GetMaxRpm).await {
+                        Ok(fan::Response::GetMaxRpm(rpm)) => rpm,
+                        _ => todo!(),
+                    };
+
+                    self.fan.execute_request(fan::Request::SetRpm(max_rpm)).await.unwrap();
+                    state.fan_state = FanState::Max;
+                    info!("\n\nFan at MAX!\n\n");
+                }
+            }
+
+            FanState::Max => {
+                if state.cur_temp < state.fan_max_temp {
+                    state.fan_state = FanState::Ramping;
+                }
+            }
+        }
+    }
+
+    pub fn new(sensor: &'static sensor::Device, fan: &'static fan::Device) -> Self {
+        Self {
+            state: Mutex::new(GenericThermalZoneState::default()),
+            sensor,
+            fan,
+        }
+    }
+}
+
+impl ThermalZone for GenericThermalZone {
+    async fn get_tmp(&self) -> Result<mptf::Response, mptf::Error> {
+        Ok(mptf::Response::GetTmp(c_to_dk(self.state.lock().await.cur_temp)))
+    }
+
+    async fn get_thrs(&self) -> Result<mptf::Response, mptf::Error> {
+        let (timeout, low, high) = self.state.lock().await.thresholds;
+        let low = c_to_dk(low);
+        let high = c_to_dk(high);
+        Ok(mptf::Response::GetThrs(timeout, low, high))
+    }
+
+    async fn set_thrs(
+        &self,
+        timeout: mptf::Dword,
+        low: mptf::Dword,
+        high: mptf::Dword,
+    ) -> Result<mptf::Response, mptf::Error> {
+        let low = dk_to_c(low);
+        let high = dk_to_c(high);
+        self.state.lock().await.thresholds = (timeout, low, high);
+        Ok(mptf::Response::SetThrs)
+    }
+
+    async fn set_scp(
+        &self,
+        cooling_policy: mptf::Dword,
+        acoustic_lim: mptf::Dword,
+        power_lim: mptf::Dword,
+    ) -> Result<mptf::Response, mptf::Error> {
+        let mut state = self.state.lock().await;
+        state.cooling_policy = cooling_policy;
+        state.acoustic_lim = acoustic_lim;
+        state.power_lim = power_lim;
+
+        Ok(mptf::Response::SetScp)
+    }
+
+    async fn get_crt_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        let dk = c_to_dk(self.state.lock().await.crt_temp);
+        Ok(mptf::Response::GetCrtTemp(dk))
+    }
+
+    async fn set_crt_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        self.state.lock().await.crt_temp = dk_to_c(temp);
+        Ok(mptf::Response::SetCrtTemp)
+    }
+
+    async fn get_proc_hot_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        let dk = c_to_dk(self.state.lock().await.proc_hot_temp);
+        Ok(mptf::Response::GetProcHotTemp(dk))
+    }
+
+    async fn set_proc_hot_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        self.state.lock().await.proc_hot_temp = dk_to_c(temp);
+        Ok(mptf::Response::SetProcHotTemp)
+    }
+
+    async fn get_profile_type(&self) -> Result<mptf::Response, mptf::Error> {
+        let prof = self.state.lock().await.profile_type;
+        Ok(mptf::Response::GetProfileType(prof))
+    }
+
+    async fn set_profile_type(&self, profile_type: mptf::Dword) -> Result<mptf::Response, mptf::Error> {
+        self.state.lock().await.profile_type = profile_type;
+        Ok(mptf::Response::SetProfileType)
+    }
+
+    async fn get_fan_on_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        let dk = c_to_dk(self.state.lock().await.fan_on_temp);
+        Ok(mptf::Response::GetFanOnTemp(dk))
+    }
+
+    async fn set_fan_on_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        self.state.lock().await.fan_on_temp = dk_to_c(temp);
+        Ok(mptf::Response::SetFanOnTemp)
+    }
+
+    async fn get_fan_ramp_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        let dk = c_to_dk(self.state.lock().await.fan_ramp_temp);
+        Ok(mptf::Response::GetFanRampTemp(dk))
+    }
+
+    async fn set_fan_ramp_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        self.state.lock().await.fan_ramp_temp = dk_to_c(temp);
+        Ok(mptf::Response::SetFanRampTemp)
+    }
+
+    async fn get_fan_max_temp(&self) -> Result<mptf::Response, mptf::Error> {
+        let dk = c_to_dk(self.state.lock().await.fan_max_temp);
+        Ok(mptf::Response::GetFanMaxTemp(dk))
+    }
+
+    async fn set_fan_max_temp(&self, temp: mptf::DeciKelvin) -> Result<mptf::Response, mptf::Error> {
+        self.state.lock().await.fan_max_temp = dk_to_c(temp);
+        Ok(mptf::Response::SetFanMaxTemp)
+    }
+
+    async fn get_fan_min_rpm(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetMinRpm).await {
+            Ok(fan::Response::GetMinRpm(rpm)) => Ok(mptf::Response::GetFanMinRpm(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_max_rpm(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetMaxRpm).await {
+            Ok(fan::Response::GetMinRpm(rpm)) => Ok(mptf::Response::GetFanMaxRpm(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_current_rpm(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetRpm).await {
+            Ok(fan::Response::GetRpm(rpm)) => Ok(mptf::Response::GetFanCurrentRpm(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_min_dba(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetMinDba).await {
+            Ok(fan::Response::GetMinDba(rpm)) => Ok(mptf::Response::GetFanMinDba(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_max_dba(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetMinDba).await {
+            Ok(fan::Response::GetMinDba(rpm)) => Ok(mptf::Response::GetFanMinDba(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_current_dba(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetDba).await {
+            Ok(fan::Response::GetDba(rpm)) => Ok(mptf::Response::GetFanCurrentDba(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_min_sones(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetMinSones).await {
+            Ok(fan::Response::GetMinSones(rpm)) => Ok(mptf::Response::GetFanMinSones(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_max_sones(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetMaxSones).await {
+            Ok(fan::Response::GetMaxSones(rpm)) => Ok(mptf::Response::GetFanMaxSones(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn get_fan_current_sones(&self) -> Result<mptf::Response, mptf::Error> {
+        match self.fan.execute_request(fan::Request::GetSones).await {
+            Ok(fan::Response::GetSones(rpm)) => Ok(mptf::Response::GetFanCurrentSones(rpm)),
+            _ => Err(mptf::Error::HardwareError),
+        }
+    }
+
+    async fn ramp_response(&self, temp: f32) -> Result<(), ()> {
+        let min_rpm = match self.fan.execute_request(fan::Request::GetMinRpm).await {
+            Ok(fan::Response::GetMinRpm(rpm)) => rpm,
+            _ => return Err(()),
+        };
+        let max_rpm = match self.fan.execute_request(fan::Request::GetMaxRpm).await {
+            Ok(fan::Response::GetMaxRpm(rpm)) => rpm,
+            _ => return Err(()),
+        };
+
+        // Some response curve that makes no sense at all for now
+        let set_rpm = (max_rpm - min_rpm) / temp as u32;
+        self.fan.execute_request(fan::Request::SetRpm(set_rpm)).await.unwrap();
+
+        Ok(())
+    }
+}
+
+// TODO: Make this actually generic over any impl ThermalZone, so OEM can use this glue logic
+#[embassy_executor::task]
+pub async fn generic_task(
+    thermal_service: &'static crate::ThermalService<&'static GenericThermalZone>,
+    tz: &'static GenericThermalZone,
+) {
+    // Proof of concept logic
+    // Would be rewritten to make better use of threshold alert interrupts as opposed to time based polling
+    loop {
+        // Measure current temperature
+        tz.state.lock().await.cur_temp = match tz.sensor.execute_request(sensor::Request::GetCurTemp).await {
+            Ok(sensor::Response::GetCurTemp(temp)) => temp,
+            Err(e) => {
+                error!("Error reading temperature: {:?}", e);
+                tz.state.lock().await.cur_temp
+            }
+            _ => {
+                error!("Unknown error occurred.");
+                tz.state.lock().await.cur_temp
+            }
+        };
+
+        // Check if the current temperature exceeds various thresholds and act accordingly
+        tz.threshold_check(thermal_service).await;
+
+        // Handle fan state in response to current temperature
+        tz.handle_fan_state().await;
+
+        // Wait briefly
+        Timer::after_millis(1000).await;
+    }
+}


### PR DESCRIPTION
This draft PR is to demonstrate how I've been thinking about how to structure the generic thermal service and also includes examples of how Surface-specific thermal abstractions can be built on top of some of the provided generic building blocks.

The actual code is not polished by any means and implementation details are subject to change, it just currently exists to rapidly prototype some of the higher-level ideas. For example, still want to experiment with the ECS approach for handling OEM-specific device commands as opposed to the current `Controller` trait approach.

So mainly interested in feedback for how I'm approaching this at a higher-level at the moment and not necessarily on current code quality, but concerns or questions about how some ideas will actually translate to code are welcome as well.

The core files to look at would be:
`thermal-service`
`surface-thermal-service`
`examples/std/surface.rs`

And here are diagrams of my current design to help visualize it:

<img width="644" alt="Thermal Service Overview" src="https://github.com/user-attachments/assets/79586fe6-ed87-4268-b793-49883b31a166" />

<img width="856" alt="Thermal Flow" src="https://github.com/user-attachments/assets/973fb14f-21a7-4ad6-9198-4a341754de36" />
