### PR TITLE
Fix rt685-evk type-c example with new embassy-imxrt i2c config

### DIFF
--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -6,7 +6,7 @@ use defmt::info;
 use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio::{Input, Inverter, Pull};
-use embassy_imxrt::i2c::master::{I2cMaster, Speed};
+use embassy_imxrt::i2c::master::{Config, I2cMaster};
 use embassy_imxrt::i2c::Async;
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -140,7 +140,9 @@ async fn main(spawner: Spawner) {
     let int_in = Input::new(p.PIO1_7, Pull::Up, Inverter::Disabled);
     static BUS: OnceLock<Mutex<NoopRawMutex, BusMaster<'static>>> = OnceLock::new();
     let bus = BUS.get_or_init(|| {
-        Mutex::new(I2cMaster::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, Speed::Standard, p.DMA0_CH5).unwrap())
+        Mutex::new(
+            I2cMaster::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, Config::default(), p.DMA0_CH5).unwrap(),
+        )
     });
 
     let device = I2cDevice::new(bus);


### PR DESCRIPTION
https://github.com/OpenDevicePartnership/embassy-imxrt/pull/398 broke how we instantiate I2C buses, this PR fixes the type-c example.