### PR TITLE
Config attribute for defmt feature on EmbeddedCrcError

### DIFF
--- a/platform-service/src/embedded_crc.rs
+++ b/platform-service/src/embedded_crc.rs
@@ -1,24 +1,11 @@
 use crc::Algorithm;
-#[cfg(feature = "defmt")]
-use defmt::Format;
 
 pub struct EmbeddedCrc<W: crc::Width> {
     algorithm: &'static Algorithm<W>,
     current_crc: Option<W>,
 }
 
-#[cfg(feature = "defmt")]
-#[derive(Clone, Copy, Debug, Default, Format)]
-pub enum EmbeddedCrcError {
-    #[default]
-    CrcErrorUnknown,
-    CrcErrorWidth,
-    CrcErrorPolynomial,
-    CrcErrorXorOut,
-    CrcErrorMutexGet,
-}
-
-#[cfg(not(feature = "defmt"))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy, Debug, Default)]
 pub enum EmbeddedCrcError {
     #[default]


### PR DESCRIPTION
Improve code quality by using cfg_attr flag for defmt feature on EmbeddedCrcError instead of creating two types