### PR TITLE
Fix cargo clippy warnings

### DIFF
--- a/embedded-service/src/buffer.rs
+++ b/embedded-service/src/buffer.rs
@@ -55,6 +55,12 @@ impl<'a, T> Buffer<'a, T> {
         unsafe { self.buffer.as_mut().unwrap().len() }
     }
 
+    /// Returns `true`` if the buffer has a length of 0
+    // SAFETY: The buffer is always valid
+    pub fn is_empty(&self) -> bool {
+        unsafe { self.buffer.as_mut().unwrap().is_empty() }
+    }
+
     fn borrow(&self, mutable: bool) {
         let status = match (self.status.get(), mutable) {
             (Status::None, false) => Status::Immutable(1),

--- a/embedded-service/src/comms.rs
+++ b/embedded-service/src/comms.rs
@@ -204,7 +204,7 @@ impl Endpoint {
     pub const fn uninit(id: EndpointID) -> Self {
         Self {
             node: Node::uninit(),
-            id: id,
+            id,
             delegator: Cell::new(None),
         }
     }
@@ -292,7 +292,7 @@ fn get_list(target: EndpointID) -> &'static OnceLock<IntrusiveList> {
 /// Send a generic message to an endpoint
 pub async fn send(from: EndpointID, to: EndpointID, data: &impl Any) -> Result<(), Infallible> {
     route(Message {
-        from: from,
+        from,
         to,
         data: Data::new(data),
     })

--- a/embedded-service/src/fmt.rs
+++ b/embedded-service/src/fmt.rs
@@ -11,6 +11,7 @@ mod defmt {
     macro_rules! trace {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
+                let _ = ($s, $( &$x ),*);
                 ::defmt::trace!($s $(, $x)*);
             }
         };
@@ -22,6 +23,7 @@ mod defmt {
     macro_rules! debug {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
+                let _ = ($s, $( &$x ),*);
                 ::defmt::debug!($s $(, $x)*);
             }
         };
@@ -33,6 +35,7 @@ mod defmt {
     macro_rules! info {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
+                let _ = ($s, $( &$x ),*);
                 ::defmt::info!($s $(, $x)*);
             }
         };
@@ -44,6 +47,7 @@ mod defmt {
     macro_rules! warn {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
+                let _ = ($s, $( &$x ),*);
                 ::defmt::warn!($s $(, $x)*);
             }
         };
@@ -55,6 +59,7 @@ mod defmt {
     macro_rules! error {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
+                let _ = ($s, $( &$x ),*);
                 ::defmt::error!($s $(, $x)*);
             }
         };
@@ -128,7 +133,7 @@ mod none {
     macro_rules! trace {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($( & $x ),*);
+                let _ = ($s, $( &$x ),*);
             }
         };
     }
@@ -139,7 +144,7 @@ mod none {
     macro_rules! debug {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($( & $x ),*);
+                let _ = ($s, $( &$x ),*);
             }
         };
     }
@@ -150,7 +155,7 @@ mod none {
     macro_rules! info {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($( & $x ),*);
+                let _ = ($s, $( &$x ),*);
             }
         };
     }
@@ -161,7 +166,7 @@ mod none {
     macro_rules! warn {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($( & $x ),*);
+                let _ = ($s, $( &$x ),*);
             }
         };
     }
@@ -172,7 +177,7 @@ mod none {
     macro_rules! error {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($( & $x ),*);
+                let _ = ($s, $( &$x ),*);
             }
         };
     }

--- a/embedded-service/src/hid/command.rs
+++ b/embedded-service/src/hid/command.rs
@@ -44,9 +44,9 @@ impl TryFrom<u16> for ReportType {
     }
 }
 
-impl Into<u16> for ReportType {
-    fn into(self) -> u16 {
-        match self {
+impl From<ReportType> for u16 {
+    fn from(value: ReportType) -> Self {
+        match value {
             ReportType::Input => 0x01 << FEATURE_SHIFT,
             ReportType::Output => 0x02 << FEATURE_SHIFT,
             ReportType::Feature => 0x03 << FEATURE_SHIFT,
@@ -77,9 +77,9 @@ impl TryFrom<u16> for PowerState {
     }
 }
 
-impl Into<u16> for PowerState {
-    fn into(self) -> u16 {
-        match self {
+impl From<PowerState> for u16 {
+    fn from(value: PowerState) -> Self {
+        match value {
             PowerState::On => 0x0,
             PowerState::Sleep => 0x1,
         }
@@ -106,9 +106,9 @@ impl TryFrom<u16> for ReportFreq {
     }
 }
 
-impl Into<u16> for ReportFreq {
-    fn into(self) -> u16 {
-        match self {
+impl From<ReportFreq> for u16 {
+    fn from(value: ReportFreq) -> Self {
+        match value {
             ReportFreq::Infinite => 0x0,
             ReportFreq::Msecs(value) => value,
         }
@@ -136,9 +136,9 @@ impl TryFrom<u16> for Protocol {
     }
 }
 
-impl Into<u16> for Protocol {
-    fn into(self) -> u16 {
-        match self {
+impl From<Protocol> for u16 {
+    fn from(value: Protocol) -> Self {
+        match value {
             Protocol::Boot => 0x0,
             Protocol::Report => 0x1,
         }
@@ -183,9 +183,9 @@ impl TryFrom<u16> for Opcode {
     }
 }
 
-impl Into<u16> for Opcode {
-    fn into(self) -> u16 {
-        match self {
+impl From<Opcode> for u16 {
+    fn from(value: Opcode) -> Self {
+        match value {
             Opcode::Reset => 0x01 << OPCODE_SHIFT,
             Opcode::GetReport => 0x02 << OPCODE_SHIFT,
             Opcode::SetReport => 0x03 << OPCODE_SHIFT,
@@ -202,26 +202,20 @@ impl Into<u16> for Opcode {
 impl Opcode {
     /// Return true if the command has data to read from the host
     pub fn requires_host_data(&self) -> bool {
-        match self {
-            Opcode::SetReport | Opcode::SetIdle | Opcode::Vendor => true,
-            _ => false,
-        }
+        matches!(self, Opcode::SetReport | Opcode::SetIdle | Opcode::Vendor)
     }
 
     /// Return true if the command requires a report ID
     pub fn requires_report_id(&self) -> bool {
-        match self {
-            Opcode::GetReport | Opcode::SetReport | Opcode::GetIdle | Opcode::SetIdle => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Opcode::GetReport | Opcode::SetReport | Opcode::GetIdle | Opcode::SetIdle
+        )
     }
 
     /// Return true if the command has a response read from the data register
     pub fn has_response(&self) -> bool {
-        match self {
-            Opcode::GetReport | Opcode::GetIdle | Opcode::GetProtocol => true,
-            _ => false,
-        }
+        matches!(self, Opcode::GetReport | Opcode::GetIdle | Opcode::GetProtocol)
     }
 }
 
@@ -241,9 +235,9 @@ pub enum Command<'a> {
     Vendor,
 }
 
-impl Into<Opcode> for Command<'_> {
-    fn into(self) -> Opcode {
-        match self {
+impl From<Command<'_>> for Opcode {
+    fn from(value: Command<'_>) -> Self {
+        match value {
             Command::Reset => Opcode::Reset,
             Command::GetReport(_, _) => Opcode::GetReport,
             Command::SetReport(_, _, _) => Opcode::SetReport,
@@ -257,9 +251,9 @@ impl Into<Opcode> for Command<'_> {
     }
 }
 
-impl Into<Opcode> for &Command<'_> {
-    fn into(self) -> Opcode {
-        self.clone().into()
+impl From<&Command<'_>> for Opcode {
+    fn from(value: &Command<'_>) -> Self {
+        value.clone().into()
     }
 }
 
@@ -311,7 +305,7 @@ impl<'a> Command<'a> {
             }
         }
 
-        let report_type = report_type.ok_or_else(|| Error::InvalidReportType);
+        let report_type = report_type.ok_or(Error::InvalidReportType);
         let command = match opcode {
             Opcode::Reset => Command::Reset,
             Opcode::GetReport => {

--- a/embedded-service/src/hid/mod.rs
+++ b/embedded-service/src/hid/mod.rs
@@ -103,20 +103,21 @@ impl Descriptor {
             return Err(Error::InvalidData);
         }
 
-        let mut descriptor = Descriptor::default();
-        descriptor.w_hid_desc_length = u16::from_le_bytes([buf[0], buf[1]]);
-        descriptor.bcd_version = u16::from_le_bytes([buf[2], buf[3]]);
-        descriptor.w_report_desc_length = u16::from_le_bytes([buf[4], buf[5]]);
-        descriptor.w_report_desc_register = u16::from_le_bytes([buf[6], buf[7]]);
-        descriptor.w_input_register = u16::from_le_bytes([buf[8], buf[9]]);
-        descriptor.w_max_input_length = u16::from_le_bytes([buf[10], buf[11]]);
-        descriptor.w_output_register = u16::from_le_bytes([buf[12], buf[13]]);
-        descriptor.w_max_output_length = u16::from_le_bytes([buf[14], buf[15]]);
-        descriptor.w_command_register = u16::from_le_bytes([buf[16], buf[17]]);
-        descriptor.w_data_register = u16::from_le_bytes([buf[18], buf[19]]);
-        descriptor.w_vendor_id = u16::from_le_bytes([buf[20], buf[21]]);
-        descriptor.w_product_id = u16::from_le_bytes([buf[22], buf[23]]);
-        descriptor.w_version_id = u16::from_le_bytes([buf[24], buf[25]]);
+        let descriptor = Descriptor {
+            w_hid_desc_length: u16::from_le_bytes([buf[0], buf[1]]),
+            bcd_version: u16::from_le_bytes([buf[2], buf[3]]),
+            w_report_desc_length: u16::from_le_bytes([buf[4], buf[5]]),
+            w_report_desc_register: u16::from_le_bytes([buf[6], buf[7]]),
+            w_input_register: u16::from_le_bytes([buf[8], buf[9]]),
+            w_max_input_length: u16::from_le_bytes([buf[10], buf[11]]),
+            w_output_register: u16::from_le_bytes([buf[12], buf[13]]),
+            w_max_output_length: u16::from_le_bytes([buf[14], buf[15]]),
+            w_command_register: u16::from_le_bytes([buf[16], buf[17]]),
+            w_data_register: u16::from_le_bytes([buf[18], buf[19]]),
+            w_vendor_id: u16::from_le_bytes([buf[20], buf[21]]),
+            w_product_id: u16::from_le_bytes([buf[22], buf[23]]),
+            w_version_id: u16::from_le_bytes([buf[24], buf[25]]),
+        };
 
         Ok(descriptor)
     }

--- a/embedded-service/src/intrusive_list.rs
+++ b/embedded-service/src/intrusive_list.rs
@@ -141,7 +141,7 @@ pub struct IntrusiveIterator {
     current: Option<&'static IntrusiveNode>,
 }
 
-impl<'a> IntoIterator for &'a IntrusiveList {
+impl IntoIterator for &IntrusiveList {
     type IntoIter = IntrusiveIterator;
     type Item = &'static IntrusiveNode;
 
@@ -173,7 +173,7 @@ pub struct OnlyT<'a, T> {
     _marker: core::marker::PhantomData<&'a T>,
 }
 
-impl<'a, T: NodeContainer> OnlyT<'a, T> {
+impl<T: NodeContainer> OnlyT<'_, T> {
     /// Create a new `OnlyTIter` from an `IntrusiveIterator`.
     pub fn new(iter: IntrusiveIterator) -> Self {
         Self {

--- a/embedded-service/src/power/mod.rs
+++ b/embedded-service/src/power/mod.rs
@@ -1,2 +1,3 @@
 //! Module for anything power related
+#[allow(clippy::module_inception)]
 pub mod policy;

--- a/embedded-service/src/power/policy/action/device.rs
+++ b/embedded-service/src/power/policy/action/device.rs
@@ -21,7 +21,7 @@ pub enum AnyState<'a> {
     ConnectedProvider(Device<'a, ConnectedProvider>),
 }
 
-impl<'a> AnyState<'a> {
+impl AnyState<'_> {
     /// Return the kind of the contained state
     pub fn kind(&self) -> StateKind {
         match self {
@@ -113,7 +113,7 @@ impl<'a> Device<'a, Detached> {
     }
 }
 
-impl<'a> Device<'a, Idle> {
+impl Device<'_, Idle> {
     /// Notify the power policy service of an updated consumer power capability
     pub async fn notify_consumer_power_capability(&self, capability: Option<PowerCapability>) -> Result<(), Error> {
         self.notify_consumer_power_capability_internal(capability).await

--- a/embedded-service/src/power/policy/action/policy.rs
+++ b/embedded-service/src/power/policy/action/policy.rs
@@ -21,7 +21,7 @@ pub enum AnyState<'a> {
     ConnectedProvider(Policy<'a, ConnectedProvider>),
 }
 
-impl<'a> AnyState<'a> {
+impl AnyState<'_> {
     /// Return the kind of the contained state
     pub fn kind(&self) -> StateKind {
         match self {

--- a/embedded-service/src/power/policy/device.rs
+++ b/embedded-service/src/power/policy/device.rs
@@ -222,7 +222,7 @@ impl Device {
     }
 
     /// Try to provide access to the device actions for the given state
-    pub async fn try_device_action<'a, S: action::Kind>(&'a self) -> Result<action::device::Device<'a, S>, Error> {
+    pub async fn try_device_action<S: action::Kind>(&self) -> Result<action::device::Device<S>, Error> {
         let state = self.state().await.kind();
         if S::kind() != state {
             return Err(Error::InvalidState(S::kind(), state));
@@ -231,7 +231,7 @@ impl Device {
     }
 
     /// Provide access to the current device state
-    pub async fn device_action<'a>(&'a self) -> action::device::AnyState<'a> {
+    pub async fn device_action(&self) -> action::device::AnyState {
         match self.state().await.kind() {
             StateKind::Detached => action::device::AnyState::Detached(action::device::Device::new(self)),
             StateKind::Idle => action::device::AnyState::Idle(action::device::Device::new(self)),
@@ -246,9 +246,7 @@ impl Device {
 
     /// Try to provide access to the policy actions for the given state
     /// Implemented here for lifetime reasons
-    pub(super) async fn try_policy_action<'a, S: action::Kind>(
-        &'a self,
-    ) -> Result<action::policy::Policy<'a, S>, Error> {
+    pub(super) async fn try_policy_action<S: action::Kind>(&self) -> Result<action::policy::Policy<S>, Error> {
         let state = self.state().await.kind();
         if S::kind() != state {
             return Err(Error::InvalidState(S::kind(), state));
@@ -258,7 +256,7 @@ impl Device {
 
     /// Provide access to the current policy actions
     /// Implemented here for lifetime reasons
-    pub(super) async fn policy_action<'a>(&'a self) -> action::policy::AnyState<'a> {
+    pub(super) async fn policy_action(&self) -> action::policy::AnyState {
         match self.state().await.kind() {
             StateKind::Detached => action::policy::AnyState::Detached(action::policy::Policy::new(self)),
             StateKind::Idle => action::policy::AnyState::Idle(action::policy::Policy::new(self)),
@@ -272,7 +270,7 @@ impl Device {
     }
 
     /// Detach the device, this action is available in all states
-    pub async fn detach<'a>(&'a self) -> Result<action::device::Device<'a, action::Detached>, Error> {
+    pub async fn detach(&self) -> Result<action::device::Device<action::Detached>, Error> {
         match self.device_action().await {
             action::device::AnyState::Detached(state) => Ok(state),
             action::device::AnyState::Idle(state) => state.detach().await,

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -227,15 +227,12 @@ impl ContextToken {
     }
 
     /// Try to provide access to the actions available to the policy for the given state and device
-    pub async fn try_policy_action<'a, S: action::Kind>(
-        &'a self,
-        id: DeviceId,
-    ) -> Result<action::policy::Policy<'a, S>, Error> {
+    pub async fn try_policy_action<S: action::Kind>(&self, id: DeviceId) -> Result<action::policy::Policy<S>, Error> {
         self.get_device(id).await?.try_policy_action().await
     }
 
     /// Provide access to current policy actions
-    pub async fn policy_action<'a>(&'a self, id: DeviceId) -> Result<action::policy::AnyState<'a>, Error> {
+    pub async fn policy_action(&self, id: DeviceId) -> Result<action::policy::AnyState, Error> {
         Ok(self.get_device(id).await?.policy_action().await)
     }
 }

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -426,7 +426,7 @@ impl ContextToken {
                     false
                 }
             })
-            .map_or(Err(PdError::InvalidController), Ok)?;
+            .ok_or(PdError::InvalidController)?;
 
         match node
             .data::<Device>()

--- a/espi-service/src/espi_service.rs
+++ b/espi-service/src/espi_service.rs
@@ -48,14 +48,12 @@ impl Service<'_> {
         }
 
         while length > 0 {
-            if offset >= offset_of!(ec_type::structure::ECMemory, ver)
-                && offset < offset_of!(ec_type::structure::ECMemory, ver) + size_of::<ec_type::structure::Version>()
-            {
-                // This is a read-only section. eSPI master should not write to it.
-                return Err(ec_type::Error::InvalidLocation);
-            } else if offset >= offset_of!(ec_type::structure::ECMemory, caps)
-                && offset
-                    < offset_of!(ec_type::structure::ECMemory, caps) + size_of::<ec_type::structure::Capabilities>()
+            if (offset >= offset_of!(ec_type::structure::ECMemory, ver)
+                && offset < offset_of!(ec_type::structure::ECMemory, ver) + size_of::<ec_type::structure::Version>())
+                || (offset >= offset_of!(ec_type::structure::ECMemory, caps)
+                    && offset
+                        < offset_of!(ec_type::structure::ECMemory, caps)
+                            + size_of::<ec_type::structure::Capabilities>())
             {
                 // This is a read-only section. eSPI master should not write to it.
                 return Err(ec_type::Error::InvalidLocation);

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -27,6 +27,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
         }
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     async fn get_hid_descriptor(&self) -> Result<hid::Descriptor, Error<B::Error>> {
         if self.descriptor.get().is_some() {
             return Ok(self.descriptor.get().unwrap());
@@ -67,6 +68,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
         Ok(self.buffer.reference().slice(0..len))
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn read_report_descriptor(&self) -> Result<SharedRef<'static, u8>, Error<B::Error>> {
         info!("Sending report descriptor");
 
@@ -85,6 +87,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
         Ok(self.buffer.reference().slice(0..len))
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn handle_input_report(&self) -> Result<SharedRef<'static, u8>, Error<B::Error>> {
         info!("Handling input report");
         let desc = self.get_hid_descriptor().await?;
@@ -102,6 +105,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
         Ok(self.buffer.reference().slice(0..desc.w_max_input_length as usize))
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn handle_command(
         &self,
         cmd: &hid::Command<'static>,

--- a/hid-service/src/i2c/host.rs
+++ b/hid-service/src/i2c/host.rs
@@ -41,6 +41,7 @@ impl<B: I2cSlaveAsync> Host<B> {
         }
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     async fn read_bus(&self, timeout_ms: u64, buffer: &mut [u8]) -> Result<(), Error<B::Error>> {
         let mut bus = self.bus.borrow_mut();
         let result = with_timeout(Duration::from_millis(timeout_ms), bus.respond_to_write(buffer)).await;
@@ -57,6 +58,7 @@ impl<B: I2cSlaveAsync> Host<B> {
         Ok(())
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     async fn write_bus(&self, timeout_ms: u64, buffer: &[u8]) -> Result<(), Error<B::Error>> {
         let mut bus = self.bus.borrow_mut();
         // Send response, timeout if the host doesn't read so we don't get stuck here
@@ -197,6 +199,7 @@ impl<B: I2cSlaveAsync> Host<B> {
     }
 
     /// Process a request from the host
+    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn wait_request(&self) -> Result<Access, Error<B::Error>> {
         // Wait for HID register address
         let mut bus = self.bus.borrow_mut();
@@ -223,6 +226,7 @@ impl<B: I2cSlaveAsync> Host<B> {
         }
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn send_response(&self) -> Result<(), Error<B::Error>> {
         if let Some(response) = self.response.wait().await {
             match response {

--- a/hid-service/src/i2c/passthrough/interrupt.rs
+++ b/hid-service/src/i2c/passthrough/interrupt.rs
@@ -57,6 +57,7 @@ impl<IN: Wait, OUT: OutputPin> InterruptSignal<IN, OUT> {
         self.signal.signal(());
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn process(&self) {
         let mut int_in = self.int_in.borrow_mut();
         let mut int_out = self.int_out.borrow_mut();

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -14,7 +14,7 @@ use embedded_services::power::policy::{self, PowerCapability};
 use embedded_services::type_c::controller::{self, Controller, ControllerStatus, PortStatus};
 use embedded_services::type_c::event::PortEventKind;
 use embedded_services::type_c::ControllerId;
-use embedded_services::{debug, info, trace, type_c};
+use embedded_services::{debug, trace, type_c};
 use embedded_usb_pd::pdinfo::PowerPathStatus;
 use embedded_usb_pd::pdo::{sink, source, Common, Rdo};
 use embedded_usb_pd::type_c::Current as TypecCurrent;


### PR DESCRIPTION
This PR addresses all `cargo clippy` warnings.

Resolves #247 