### PR TITLE
Add Platform Reset Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "platform-service"
 version = "0.1.0"
 dependencies = [
+ "cortex-m",
  "crc",
  "defmt 0.3.100",
  "embassy-executor",

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -160,6 +160,7 @@ name = "bq40z50"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/bq40z50#f6e1b5acb5cf38865af62b94187f60bdff9f0457"
 dependencies = [
+ "defmt 0.3.100",
  "device-driver",
  "embedded-batteries-async",
  "embedded-hal 1.0.0",
@@ -345,6 +346,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c424cfcc4a418769975185d1d9066ad07fa05cb343fda8ea0adf98a9e9d195d2"
 dependencies = [
+ "defmt 0.3.100",
  "device-driver-macros",
  "embedded-io",
  "embedded-io-async",
@@ -537,6 +539,7 @@ version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/embedded-batteries#1223e7093dea2c8ccdb72f8346b2b0a773eef97b"
 dependencies = [
  "bitfield-struct",
+ "defmt 0.3.100",
  "embedded-hal 1.0.0",
 ]
 
@@ -546,6 +549,7 @@ version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/embedded-batteries#1223e7093dea2c8ccdb72f8346b2b0a773eef97b"
 dependencies = [
  "bitfield-struct",
+ "defmt 0.3.100",
  "embedded-batteries",
  "embedded-hal 1.0.0",
 ]
@@ -599,6 +603,9 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+dependencies = [
+ "defmt 0.3.100",
+]
 
 [[package]]
 name = "embedded-io-async"
@@ -1118,6 +1125,7 @@ dependencies = [
  "embassy-imxrt",
  "embassy-sync",
  "embassy-time",
+ "embedded-batteries-async",
  "embedded-hal-async",
  "embedded-services 0.1.0",
  "espi-service",

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -1025,6 +1025,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "platform-service"
 version = "0.1.0"
 dependencies = [
+ "cortex-m",
  "crc",
  "defmt 0.3.100",
  "embassy-executor",

--- a/examples/rt685s-evk/src/bin/reset.rs
+++ b/examples/rt685s-evk/src/bin/reset.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+
+extern crate rt685s_evk_example;
+
+use platform_service::reset;
+use {defmt_rtt as _, panic_probe as _};
+
+async fn print_watcher_number() {
+    static CONTRIVED: embassy_sync::mutex::Mutex<embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex, usize> =
+        embassy_sync::mutex::Mutex::new(0);
+
+    // yes, this could be accomplished with atomics. But using a mutex here demonstrates async functionality
+    let watcher_num = {
+        let mut current_number = CONTRIVED.lock().await;
+        *current_number += 1;
+        *current_number
+    };
+
+    defmt::info!("Reset Watcher #{}", watcher_num);
+}
+
+#[embassy_executor::task(pool_size = 10)]
+async fn reset_watcher(blocker: &'static reset::Blocker) {
+    defmt::info!("reset::Blocker watch thread ticking...");
+
+    loop {
+        blocker
+            .wait_for_reset(async || {
+                print_watcher_number().await;
+            })
+            .await;
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: embassy_executor::Spawner) {
+    let _p = embassy_imxrt::init(Default::default());
+
+    static BLOCKERS: embassy_sync::lazy_lock::LazyLock<[reset::Blocker; 10]> =
+        embassy_sync::lazy_lock::LazyLock::new(|| [const { reset::Blocker::uninit() }; 10]);
+
+    embedded_services::init().await;
+
+    let blockers = BLOCKERS.get();
+
+    // spawn blocker threads
+    for blocker in blockers {
+        // register before spawning blocker threads to avoid potential scheduling issues
+        // when immediately calling reset below
+        blocker.register().await.expect("Infallible");
+
+        spawner.must_spawn(reset_watcher(blocker));
+    }
+
+    // perform reset
+    defmt::info!("Performing platform reset!");
+    reset::system_reset().await;
+}

--- a/platform-service/Cargo.toml
+++ b/platform-service/Cargo.toml
@@ -18,11 +18,13 @@ log = { workspace = true, optional = true }
 embassy-imxrt = { workspace = true, optional = true, features = [
     "unstable-pac",
 ] }
+cortex-m = { workspace = true, optional = true }
 
 [features]
 # TODO find method to unblock CI gate without requiring chip specification at library level
-imxrt = ["embassy-imxrt/mimxrt633s"]
-imxrt685 = ["embassy-imxrt/mimxrt685s"]
+imxrt = ["embassy-imxrt/mimxrt633s", "cortex-m"]
+imxrt685 = ["embassy-imxrt/mimxrt685s", "cortex-m"]
+cortex-m = ["dep:cortex-m"]
 
 defmt = [
     "dep:defmt",

--- a/platform-service/src/lib.rs
+++ b/platform-service/src/lib.rs
@@ -3,8 +3,11 @@
 /// NVRAM platform service abstraction
 pub mod nvram;
 
-// CRC service abstraction
+/// CRC service abstraction
 pub mod embedded_crc;
+
+/// Initiate a delayed MCU Reset
+pub mod reset;
 
 #[cfg(any(feature = "imxrt", feature = "imxrt685"))]
 pub mod imxrt;

--- a/platform-service/src/reset.rs
+++ b/platform-service/src/reset.rs
@@ -1,0 +1,72 @@
+//! API for managing software controlled CPU/MCU resets
+
+use core::future::Future;
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, lazy_lock::LazyLock, signal::Signal};
+
+use embedded_services::{intrusive_list, IntrusiveList, Node, NodeContainer};
+
+static BLOCKERS: LazyLock<IntrusiveList> = LazyLock::new(IntrusiveList::new);
+
+pub struct Blocker {
+    node: Node,
+    reset_pending: Signal<CriticalSectionRawMutex, ()>,
+    unblocked: Signal<CriticalSectionRawMutex, ()>,
+}
+
+impl NodeContainer for Blocker {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+impl Blocker {
+    /// allocate a Blocker, such that it could be used in a static
+    pub const fn uninit() -> Self {
+        Self {
+            node: Node::uninit(),
+            reset_pending: Signal::new(),
+            unblocked: Signal::new(),
+        }
+    }
+
+    /// call once on startup to be registered as a Reset handling blocker, forwards any error states (such as double registration) from intrusive_list
+    pub async fn register(&'static self) -> intrusive_list::Result<()> {
+        BLOCKERS.get().push(self)
+    }
+
+    /// waitable reset indicator, for handling resets
+    pub async fn wait_for_reset<F, Fut>(&self, before_reset: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        self.reset_pending.wait().await;
+        before_reset().await;
+        self.unblocked.signal(());
+    }
+}
+
+/// Signals and waits for all registered blockers to complete their async operations before performing a platform-specific reset, typically NVIC_RESET
+pub async fn system_reset() -> ! {
+    // signal and wait for completion as two separate events to allow for alternative scheduling algorithms to take effect
+    let blockers = BLOCKERS.get();
+
+    // 1. signal all events
+    for blocker in blockers.iter_only::<Blocker>() {
+        blocker.reset_pending.signal(());
+    }
+
+    // 2. wait for all events
+    for blocker in blockers.iter_only::<Blocker>() {
+        blocker.unblocked.wait().await;
+    }
+
+    // 3. perform platform reset
+    #[cfg(feature = "cortex-m")]
+    cortex_m::peripheral::SCB::sys_reset();
+
+    // no equivalent reset option for std environment
+    #[cfg(not(feature = "cortex-m"))]
+    panic!("Cannot reset without NVIC");
+}


### PR DESCRIPTION
Add an equivalent to NVIC_SystemReset(), that allows registration of pre-emptive blockers that can temporarily hold off the MCU platform reset.
