### PR TITLE
Add timeout before updating charger settings and after connecting new power policy consumer

### DIFF
--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -111,6 +111,7 @@ impl PowerPolicy {
         {
             idle.connect_consumer(new_consumer.power_capability).await?;
             state.current_consumer_state = Some(new_consumer);
+            embassy_time::Timer::after_millis(800).await;
             for node in self.context.chargers().await {
                 let device = node.data::<ChargerDevice>().ok_or(Error::InvalidDevice)?;
                 device


### PR DESCRIPTION
FYI @sukomath @asasine @RobertZ2011 

Add timeout as a temporary quick fix to charger data race bug.

Will be reverted once a proper fix is in later this week.