### PR TITLE
type-c-service/tps6699x: Add `info` import

### DIFF
--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -14,7 +14,7 @@ use embedded_services::power::policy::{self, PowerCapability};
 use embedded_services::type_c::controller::{self, Controller, ControllerStatus, PortStatus};
 use embedded_services::type_c::event::PortEventKind;
 use embedded_services::type_c::ControllerId;
-use embedded_services::{debug, trace, type_c};
+use embedded_services::{debug, info, trace, type_c};
 use embedded_usb_pd::pdinfo::PowerPathStatus;
 use embedded_usb_pd::pdo::{sink, source, Common, Rdo};
 use embedded_usb_pd::type_c::Current as TypecCurrent;


### PR DESCRIPTION
This macro was previously unused and got removed as part of a general clean-up just as a commit that used it landed. Add it back in to fix the build breaking.