### PR TITLE
type-c: Add function to sync controller state

### DIFF
--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -219,6 +219,11 @@ impl<'a> Device<'a> {
         }
     }
 
+    /// Get the controller ID
+    pub fn id(&self) -> ControllerId {
+        self.id
+    }
+
     /// Send a command to this controller
     pub async fn send_command(&self, command: Command) -> Response {
         self.command.send(command).await;
@@ -302,6 +307,8 @@ pub trait Controller {
     /// Type of error returned by the bus
     type BusError;
 
+    /// Ensure software state is in sync with hardware state
+    fn sync_state(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
     /// Returns ports with pending events
     fn wait_port_event(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
     /// Returns and clears current events for the given port

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -96,6 +96,10 @@ mod test_controller {
     impl embedded_services::type_c::controller::Controller for Controller<'_> {
         type BusError = ();
 
+        async fn sync_state(&mut self) -> Result<(), Error<Self::BusError>> {
+            Ok(())
+        }
+
         async fn wait_port_event(&mut self) -> Result<(), Error<Self::BusError>> {
             trace!("Wait for port event");
             let events = self.state.events.wait().await;


### PR DESCRIPTION
Add a function to sync the state of the controller and its ports. If a charger is plugged in before reset then there won't be any interrupts to inform the EC that anything is connected. Add a function to sync the software state of the controller with the hardware state.