### PR TITLE
power-policy: Remove automatic provider upgrade logic

### DIFF
--- a/docs/power-policy.md
+++ b/docs/power-policy.md
@@ -28,9 +28,6 @@ stateDiagram-v2
     Idle --> Detached : NotifyDetach
 ```
 
-#### Device recovery
-Requests to a device can fail for any number of reasons (bus communication issues, deadlock in driver code, etc). In most cases this won't result in any issues as most failed requests result in the system being in a safe state. E.g. a failed transition from `Idle` to `ConnectedConsummer` will result in the system just not drawing power. However, a failed request in the `ConnectedProvider` state can leave the system providing more power than intended. The device state isn't enough to capture this situation as the device must be assumed to still be the in the `ConnectedProvider` state. The `Device` struct contains a `recovery` member to track this situation. The specifics of the recovery process are implementation defined.
-
 ### Policy Messages
 These messages are sent from a device to the power policy.
 

--- a/embedded-service/src/power/policy/action/policy.rs
+++ b/embedded-service/src/power/policy/action/policy.rs
@@ -55,7 +55,6 @@ impl<'a, S: Kind> Policy<'a, S> {
             .await?
             .complete_or_err()?;
         self.device.set_state(device::State::Idle).await;
-        self.device.exit_recovery().await;
         Ok(())
     }
 
@@ -159,7 +158,6 @@ impl<'a> Policy<'a, ConnectedProvider> {
     pub async fn disconnect_no_timeout(self) -> Result<Policy<'a, Idle>, Error> {
         if let Err(e) = self.disconnect_internal_no_timeout().await {
             error!("Error disconnecting device {}: {:?}", self.device.id().0, e);
-            self.device.enter_recovery().await;
             return Err(e);
         }
         Ok(Policy::new(self.device))

--- a/power-policy-service/src/config.rs
+++ b/power-policy-service/src/config.rs
@@ -6,8 +6,6 @@ use embedded_services::power::policy::PowerCapability;
 pub struct Config {
     /// Above this threshold, the system is in limited power mode
     pub limited_power_threshold_mw: u32,
-    /// Power capability of every provider in recovery mode
-    pub provider_recovery: PowerCapability,
     /// Power capability of every provider in normal power mode
     pub provider_unlimited: PowerCapability,
     /// Power capability of every provider in limited power mode
@@ -19,11 +17,6 @@ impl Default for Config {
         Self {
             // Type-C 5V@3A
             limited_power_threshold_mw: 15000,
-            // Type-C default, assume USB3 900mA as worst case scenario
-            provider_recovery: PowerCapability {
-                voltage_mv: 5000,
-                current_ma: 900,
-            },
             // Type-C 5V@3A
             provider_unlimited: PowerCapability {
                 voltage_mv: 5000,

--- a/power-policy-service/src/provider.rs
+++ b/power-policy-service/src/provider.rs
@@ -1,15 +1,9 @@
 //! This file implements logic to determine how much power to provide to each connected device.
 //! When total provided power is below [limited_power_threshold_mw](super::Config::limited_power_threshold_mw)
-//! the system is in unlimited power state. In this mode [provider_unlimited](super::Config::provider_unlimited)
+//! the system is in unlimited power state. In this mode up to [provider_unlimited](super::Config::provider_unlimited)
 //! is provided to each device. Above this threshold, the system is in limited power state.
 //! In this mode [provider_limited](super::Config::provider_limited) is provided to each device
-//! Lastly, the system can be in recovery mode. This mode is only entered when a connected provider fails to
-//! connect at a new power level. In this mode, all connected providers are set to
-//! [provider_recovery](super::Config::provider_recovery). While in this mode
-//! [attempt_provider_recovery](PowerPolicy::attempt_provider_recovery) is called periodically
-//! which attempts to disconnect all providers in recovery mode. If this succeeds, the system will
-//! return to normal operating mode.
-use embedded_services::{debug, trace, warn};
+use embedded_services::{debug, trace};
 
 use super::*;
 
@@ -17,8 +11,6 @@ use super::*;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PowerState {
-    /// Recovery mode, system is in the process of recovering from a fault on one or more ports
-    Recovery,
     /// System is capable of providing high power
     #[default]
     Unlimited,
@@ -34,185 +26,81 @@ pub(super) struct State {
 }
 
 impl PowerPolicy {
-    /// Computes the total requested power considering all current providers
-    async fn compute_total_provider_power(&self, new_request: bool) -> PowerState {
-        let mut num_providers = if new_request { 1 } else { 0 };
-
-        for device in self.context.devices().await {
-            let device = device.data::<device::Device>();
-            if device.is_none() {
-                // A non-power device somehow got into the list of devices, note it and move on
-                warn!("Found non-power device in devices list");
-                continue;
+    /// Attempt to connect the requester as a provider
+    pub(super) async fn connect_provider(&self, requester_id: DeviceId) {
+        trace!("Device{}: Attempting to connect provider", requester_id.0);
+        let requester = match self.context.get_device(requester_id).await {
+            Ok(device) => device,
+            Err(_) => {
+                error!("Device{}: Invalid device", requester_id.0);
+                return;
             }
-
-            let device = device.unwrap();
-            if device.is_in_recovery().await {
-                // If any device is in recovery mode, we need to recover
-                info!("Device {}: In recovery mode", device.id().0);
-                return PowerState::Recovery;
+        };
+        let requested_power_capability = match requester.requested_provider_capability().await {
+            Some(cap) => cap,
+            // Requester is no longer requesting power
+            _ => {
+                info!("Device{}: No-longer requesting power", requester.id().0);
+                return;
             }
-
-            if device.is_provider().await {
-                num_providers += 1;
-            }
-        }
-
-        let total_provided_power = num_providers * self.config.provider_unlimited.max_power_mw();
-        if total_provided_power > self.config.limited_power_threshold_mw {
-            PowerState::Limited
-        } else {
-            PowerState::Unlimited
-        }
-    }
-
-    /// Update the power capability of all connected providers
-    /// Returns true if we need to enter recovery mode
-    async fn update_provider_capability(&self, target_power: PowerCapability, exit_on_recovery: bool) -> bool {
-        let mut recovery = false;
-        for device in self.context.devices().await {
-            let device = device.data::<device::Device>();
-            if device.is_none() {
-                // A non-power device somehow got into the list of devices, note it and move on
-                warn!("Found non-power device in devices list");
-                continue;
-            }
-
-            let device = device.unwrap();
-            if let Ok(action) = self
-                .context
-                .try_policy_action::<action::ConnectedProvider>(device.id())
-                .await
-            {
-                if action.power_capability().await != target_power {
-                    // Attempt to connect at new capability. Don't exit early if this fails so
-                    // we can continue to attempt to connect other providers
-                    if action.connect_provider(target_power).await.is_err() {
-                        error!(
-                            "Device{}: Failed to connect provider, attempting to disconnect",
-                            device.id().0
-                        );
-
-                        if action.disconnect().await.is_err() {
-                            error!("Device{}: Failed to disconnect provider", device.id().0);
-
-                            // Early exit if that's what we want
-                            // This is used to avoid excessively switching power capabilities in the recovery flow
-                            if exit_on_recovery {
-                                return true;
-                            }
-
-                            recovery = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        recovery
-    }
-
-    /// Update the provider state of currently connected providers
-    pub(super) async fn update_providers(&self, new_provider: Option<DeviceId>) {
-        trace!("Updating providers");
+        };
         let mut state = self.state.lock().await;
-        let mut already_in_recovery = true;
+        let mut total_power_mw = 0;
 
-        if state.current_provider_state.state != PowerState::Recovery {
-            // Only update the power state if we're not in recovery mode
-            already_in_recovery = false;
-            state.current_provider_state.state = self.compute_total_provider_power(new_provider.is_some()).await;
+        // Determine total requested power draw
+        for device in self.context.devices().await.iter_only::<device::Device>() {
+            let target_provider_cap = if device.id() == requester_id {
+                // Use the requester's requested power capability
+                // this handles both new connections and upgrade requests
+                Some(requested_power_capability)
+            } else {
+                // Use the device's current working provider capability
+                device.provider_capability().await
+            };
+            total_power_mw += target_provider_cap.map_or(0, |cap| cap.max_power_mw());
+
+            if total_power_mw > self.config.limited_power_threshold_mw {
+                state.current_provider_state.state = PowerState::Limited;
+            } else {
+                state.current_provider_state.state = PowerState::Unlimited;
+            }
         }
+
         debug!("New power state: {:?}", state.current_provider_state.state);
 
         let target_power = match state.current_provider_state.state {
-            PowerState::Recovery => self.config.provider_recovery,
-            PowerState::Unlimited => self.config.provider_unlimited,
             PowerState::Limited => self.config.provider_limited,
-        };
-
-        let recovery = self.update_provider_capability(target_power, true).await;
-        if let Some(new_provider) = new_provider {
-            info!("Connecting new provider");
-            let connected = if let Ok(action) = self.context.try_policy_action::<action::Idle>(new_provider).await {
-                let target_power = if recovery {
-                    // We entered recovery mode so attempt to connect at the recovery power
-                    self.config.provider_recovery
+            PowerState::Unlimited => {
+                if requested_power_capability.max_power_mw() < self.config.provider_unlimited.max_power_mw() {
+                    // Don't auto upgrade to a higher contract
+                    requested_power_capability
                 } else {
-                    target_power
-                };
-                action.connect_provider(target_power).await.is_ok()
-            } else {
-                false
-            };
-
-            // Don't enter recovery mode if we can't connect the new provider.
-            // Since it's a new provider that hasn't been connected then it's
-            // not drawing power as far as we're concerned
-            if !connected {
-                error!("Device {}: Failed to connect provider", new_provider.0);
-            }
-        }
-
-        if recovery && !already_in_recovery {
-            // Entering recovery, set power capability on all responding providers to recovery limit
-            // Don't check return value of update_provider_capability here, if we've spontaneously recovered
-            // then it'll get caught by the next call of attempt_provider_recovery
-            info!("Entering recovery mode");
-            let _ = self
-                .update_provider_capability(self.config.provider_recovery, false)
-                .await;
-            state.current_provider_state.state = PowerState::Recovery;
-        }
-    }
-
-    /// Wait for the next provider recovery attempt, returns true if we should call `attempt_provider_recovery`
-    #[allow(clippy::await_holding_refcell_ref)]
-    pub(super) async fn wait_attempt_provider_recovery(&self) -> bool {
-        self.recovery_ticker.borrow_mut().next().await;
-        self.state.lock().await.current_provider_state.state == PowerState::Recovery
-    }
-
-    pub(super) async fn attempt_provider_recovery(&self) {
-        info!("Attempting provider recovery");
-        let mut recovered = true;
-        // Attempt to by disconnecting all providers in recovery
-        for device in self.context.devices().await {
-            let device = device.data::<device::Device>().ok_or(Error::InvalidDevice);
-            if device.is_err() {
-                // A non-power device somehow got into the list of devices, note it and move on
-                warn!("Found non-power device in devices list");
-                continue;
-            }
-
-            let device = device.unwrap();
-            if device.is_in_recovery().await {
-                if let Ok(action) = self
-                    .context
-                    .try_policy_action::<action::ConnectedProvider>(device.id())
-                    .await
-                {
-                    if action.disconnect().await.is_err() {
-                        error!("Device {}: Failed to recover", device.id().0);
-                        recovered = false;
-                    }
+                    self.config.provider_unlimited
                 }
             }
-        }
+        };
 
-        if !recovered {
-            info!("Failed to recover all providers, staying in recovery mode");
-            return;
-        }
+        info!("Device{}: Connecting new provider", requester.id().0);
+        let connected = if let Ok(action) = self.context.try_policy_action::<action::Idle>(requester.id()).await {
+            let _ = action.connect_provider(target_power).await;
+            Ok(())
+        } else if let Ok(action) = self
+            .context
+            .try_policy_action::<action::ConnectedProvider>(requester.id())
+            .await
+        {
+            let _ = action.connect_provider(target_power).await;
+            Ok(())
+        } else {
+            Err(Error::InvalidState(
+                device::StateKind::Idle,
+                requester.state().await.kind(),
+            ))
+        };
 
-        // Attempt to restart in the unlimited power state
-        self.state.lock().await.current_provider_state.state = PowerState::Unlimited;
-        self.update_providers(None).await;
-        if self.state.lock().await.current_provider_state.state == PowerState::Recovery {
-            info!("Failed to update providers, staying in recovery mode");
-            return;
+        // Don't need to do anything special, the device is responsible for attempting to reconnect
+        if let Err(e) = connected {
+            error!("Device{}: Failed to connect provider, {:#?}", requester.id().0, e);
         }
-
-        info!("Successfully recovered from provider recovery mode");
     }
 }


### PR DESCRIPTION
Remove logic to automatically upgrade a provider contract if power is available. This can result in a device receiving more power than needed while another device receives less. This is particularly a concern for TBT compliance testing. With this change devices will have to explicitly request a higher contract. This also removes the recovery logic which was only used in cases where we attempted to downgrade a contract. The new behavior does not attempt to downgrade contracts, so it's no longer needed.