### PR TITLE
Add minimal button tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +61,21 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "bare-metal"
@@ -600,6 +630,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-hal-mock"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a0f04f8886106faf281c47b6a0e4054a369baedaf63591fdb8da9761f3f379"
+dependencies = [
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-time",
+ "nb 1.1.0",
+ "void",
+]
+
+[[package]]
 name = "embedded-hal-nb"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-time"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a4b4d10ac48d08bfe3db7688c402baadb244721f30a77ce360bd24c3dffe58"
+dependencies = [
+ "num",
+]
+
+[[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#b8948c96b8c8e920c837307d30653cfd74cf80cd"
@@ -797,6 +851,12 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
@@ -897,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +983,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mimxrt600-fcb"
@@ -954,6 +1026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,12 +1050,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1037,7 +1180,9 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "embedded-hal-mock",
  "log",
+ "tokio",
 ]
 
 [[package]]
@@ -1104,6 +1249,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -1252,6 +1403,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tps6699x"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/tps6699x#7bd036665a51afaa9872d45890ac80d20a6f9802"
@@ -1344,6 +1517,70 @@ checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wyz"

--- a/examples/rt685s-evk/src/bin/power_button.rs
+++ b/examples/rt685s-evk/src/bin/power_button.rs
@@ -119,7 +119,7 @@ async fn main(spawner: Spawner) {
     // Create a power button instance
     let button_a = Input::new(p.PIO1_1, Pull::Up, Inverter::Disabled);
     // Create a debouncer instance
-    let debouncer = Debouncer::new(3, Duration::from_millis(10), ActiveState::ActiveLow);
+    let debouncer = Debouncer::new(3, 10, ActiveState::ActiveLow);
     // Create a custom button configuration instance
     let config_a = ButtonConfig::new(debouncer, Duration::from_millis(1000), Duration::from_millis(2000));
 

--- a/power-button-service/Cargo.toml
+++ b/power-button-service/Cargo.toml
@@ -13,3 +13,7 @@ embassy-time.workspace = true
 embedded-hal-async.workspace = true
 embedded-hal.workspace = true
 log = { workspace = true, optional = true }
+
+[dev-dependencies]
+embedded-hal-mock = { version = "0.11.1", features = ["eh1", "embedded-hal-async"] }
+tokio = { version = "1.45.0", features = ["rt", "macros"] }

--- a/power-button-service/src/button.rs
+++ b/power-button-service/src/button.rs
@@ -1,6 +1,6 @@
 //! Button Service Definitions
 
-use embassy_time::{with_timeout, Duration, Instant, TimeoutError, Timer};
+use embassy_time::{with_timeout, Delay, Duration, Instant, TimeoutError, Timer};
 use embedded_hal::digital::InputPin;
 use embedded_hal_async::digital::Wait;
 
@@ -48,7 +48,9 @@ impl<I: InputPin + Wait> Button<I> {
 
     /// Checks button state.
     pub async fn get_button_state(&mut self) -> ButtonState {
-        match self.config.debouncer.debounce(&mut self.gpio).await {
+        let mut delay = Delay;
+
+        match self.config.debouncer.debounce(&mut self.gpio, &mut delay).await {
             true => ButtonState::ButtonPressed(Instant::now()),
             false => ButtonState::ButtonReleased(Instant::now()),
         }

--- a/power-button-service/src/debounce.rs
+++ b/power-button-service/src/debounce.rs
@@ -1,7 +1,7 @@
 //! Debounce Module
 
-use embassy_time::{Duration, Timer};
 use embedded_hal::digital::InputPin;
+use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::digital::Wait;
 
 #[derive(Debug)]
@@ -18,14 +18,14 @@ pub enum ActiveState {
 pub struct Debouncer {
     integrator: u8,
     threshold: u8,
-    sample_interval: Duration,
+    sample_interval: u32,
     active_state: ActiveState,
     pressed: bool,
 }
 
 impl Debouncer {
     /// Creates a new Debouncer instance with the given threshold value, sampling interval and active state.
-    pub fn new(threshold: u8, sample_interval: Duration, active_state: ActiveState) -> Self {
+    pub fn new(threshold: u8, sample_interval: u32, active_state: ActiveState) -> Self {
         Self {
             integrator: 0,
             threshold,
@@ -36,34 +36,42 @@ impl Debouncer {
     }
 
     /// Debounces a button press using an integrator.
-    pub async fn debounce<I: InputPin + Wait>(&mut self, gpio: &mut I) -> bool {
+    pub async fn debounce<D: DelayNs, I: InputPin + Wait>(&mut self, gpio: &mut I, delay: &mut D) -> bool {
+        let previous_pressed = self.pressed;
+
         loop {
-            // Sample the button state
-            let is_pressed = match self.active_state {
-                ActiveState::ActiveLow => gpio.is_low().unwrap_or(false),
-                ActiveState::ActiveHigh => gpio.is_high().unwrap_or(false),
-            };
+            self.update(gpio);
 
-            // Check if the button is pressed and increment the integrator
-            if is_pressed {
-                if self.integrator < self.threshold {
-                    self.integrator += 1;
-                }
-            } else if self.integrator > 0 {
-                self.integrator -= 1;
-            }
-
-            // Check if the integrator has crossed the threshold and the button state has changed
-            if self.integrator >= self.threshold && !self.pressed {
-                self.pressed = true;
-                return true;
-            } else if self.integrator == 0 && self.pressed {
-                self.pressed = false;
-                return false;
+            if self.pressed != previous_pressed {
+                return self.pressed;
             }
 
             // Wait for the next sample interval
-            Timer::after(self.sample_interval).await;
+            delay.delay_ms(self.sample_interval).await;
+        }
+    }
+
+    fn update<I: InputPin>(&mut self, gpio: &mut I) {
+        // Sample the button state
+        let is_pressed = match self.active_state {
+            ActiveState::ActiveLow => gpio.is_low().unwrap_or(false),
+            ActiveState::ActiveHigh => gpio.is_high().unwrap_or(false),
+        };
+
+        // Check if the button is pressed and increment the integrator
+        if is_pressed {
+            if self.integrator < self.threshold {
+                self.integrator += 1;
+            }
+        } else if self.integrator > 0 {
+            self.integrator -= 1;
+        }
+
+        // Check if the integrator has crossed the threshold and the button state has changed
+        if self.integrator == self.threshold && !self.pressed {
+            self.pressed = true;
+        } else if self.integrator == 0 && self.pressed {
+            self.pressed = false;
         }
     }
 }
@@ -74,9 +82,297 @@ impl Default for Debouncer {
         Self {
             integrator: 0,
             threshold: 3,
-            sample_interval: Duration::from_millis(10),
+            sample_interval: 10,
             active_state: ActiveState::ActiveLow,
             pressed: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use embedded_hal_mock::eh1::{
+        delay::{CheckedDelay, Transaction as DelayTransation},
+        digital::{Mock, State, Transaction as PinTransaction},
+    };
+
+    #[test]
+    fn test_single_update_active_low_press() {
+        let mut d = Debouncer::default();
+
+        let gpio_expectations = [PinTransaction::get(State::Low)];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        d.update(&mut gpio);
+
+        assert_eq!(d.integrator, 1);
+        assert!(!d.pressed);
+
+        gpio.done();
+    }
+
+    #[test]
+    fn test_single_update_active_high_press() {
+        let mut d = Debouncer::default();
+        d.active_state = ActiveState::ActiveHigh;
+
+        let gpio_expectations = [PinTransaction::get(State::High)];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        d.update(&mut gpio);
+
+        assert_eq!(d.integrator, 1);
+        assert!(!d.pressed);
+
+        gpio.done();
+    }
+
+    #[test]
+    fn test_last_update_state_change() {
+        // Press, active high
+        let mut d = Debouncer::default();
+        d.integrator = d.threshold - 1;
+
+        let gpio_expectations = [PinTransaction::get(State::Low)];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        d.update(&mut gpio);
+
+        assert_eq!(d.integrator, d.threshold);
+        assert!(d.pressed);
+
+        gpio.done();
+
+        // Release, active high
+        d.integrator = 1;
+
+        let gpio_expectations = [PinTransaction::get(State::High)];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        d.update(&mut gpio);
+
+        assert_eq!(d.integrator, 0);
+        assert!(!d.pressed);
+
+        gpio.done();
+
+        // Press, active low
+        d.integrator = d.threshold - 1;
+        d.active_state = ActiveState::ActiveLow;
+
+        let gpio_expectations = [PinTransaction::get(State::Low)];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        d.update(&mut gpio);
+
+        assert_eq!(d.integrator, d.threshold);
+        assert!(d.pressed);
+
+        gpio.done();
+
+        // Release, active low
+        d.integrator = 1;
+        d.active_state = ActiveState::ActiveLow;
+
+        let gpio_expectations = [PinTransaction::get(State::High)];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        d.update(&mut gpio);
+
+        assert_eq!(d.integrator, 0);
+        assert!(!d.pressed);
+
+        gpio.done();
+    }
+
+    #[tokio::test]
+    async fn test_stable_first_press() {
+        let mut d = Debouncer::default();
+
+        let gpio_expectations = [
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::Low),
+        ];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        let delay_expectations = [
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            // Last iter: we return before delaying again
+        ];
+        let mut delay = CheckedDelay::new(&delay_expectations);
+
+        let pressed = d.debounce(&mut gpio, &mut delay).await;
+
+        assert!(pressed);
+        assert_eq!(d.integrator, d.threshold);
+        assert!(d.pressed);
+
+        gpio.done();
+        delay.done();
+    }
+
+    #[tokio::test]
+    async fn test_stable_first_release() {
+        let mut d = Debouncer::default();
+        d.pressed = true;
+        d.integrator = d.threshold;
+
+        let gpio_expectations = [
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::High),
+        ];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        let delay_expectations = [
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            // Last iter: we return before delaying again
+        ];
+        let mut delay = CheckedDelay::new(&delay_expectations);
+
+        let pressed = d.debounce(&mut gpio, &mut delay).await;
+
+        assert!(!pressed);
+        assert!(!d.pressed);
+        assert_eq!(d.integrator, 0);
+
+        gpio.done();
+        delay.done();
+    }
+
+    #[tokio::test]
+    async fn test_bounces_settle_press() {
+        let mut d = Debouncer::default();
+
+        let gpio_expectations = [
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::Low),
+        ];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        let delay_expectations = [
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            // Last iter: we return before delaying again
+        ];
+        let mut delay = CheckedDelay::new(&delay_expectations);
+
+        let pressed = d.debounce(&mut gpio, &mut delay).await;
+
+        assert!(pressed);
+        assert!(d.pressed);
+        assert_eq!(d.integrator, d.threshold);
+
+        gpio.done();
+        delay.done();
+    }
+
+    #[tokio::test]
+    async fn test_bounces_settle_released() {
+        let mut d = Debouncer::default();
+        d.integrator = d.threshold;
+        d.pressed = true;
+
+        let gpio_expectations = [
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::Low),
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::High),
+            PinTransaction::get(State::High),
+        ];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        let delay_expectations = [
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            // Last iter: we return before delaying again
+        ];
+        let mut delay = CheckedDelay::new(&delay_expectations);
+
+        let pressed = d.debounce(&mut gpio, &mut delay).await;
+
+        assert!(!pressed);
+        assert!(!d.pressed);
+        assert_eq!(d.integrator, 0);
+
+        gpio.done();
+        delay.done();
+    }
+
+    #[tokio::test]
+    async fn test_bounces_high_threshold() {
+        let mut d = Debouncer::default();
+        d.threshold = 10;
+
+        let gpio_expectations = [
+            PinTransaction::get(State::Low),  // 1
+            PinTransaction::get(State::High), // 0
+            PinTransaction::get(State::Low),  // 1
+            PinTransaction::get(State::Low),  // 2
+            PinTransaction::get(State::High), // 1
+            PinTransaction::get(State::High), // 0
+            PinTransaction::get(State::High), // 0
+            PinTransaction::get(State::Low),  // 1
+            PinTransaction::get(State::Low),  // 2
+            PinTransaction::get(State::Low),  // 3
+            PinTransaction::get(State::Low),  // 4
+            PinTransaction::get(State::Low),  // 5
+            PinTransaction::get(State::Low),  // 6
+            PinTransaction::get(State::Low),  // 7
+            PinTransaction::get(State::Low),  // 8
+            PinTransaction::get(State::Low),  // 9
+            PinTransaction::get(State::Low),  // 10
+        ];
+        let mut gpio = Mock::new(&gpio_expectations);
+
+        let delay_expectations = [
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            DelayTransation::delay_ms(10),
+            // final iter: we return before delaying again
+        ];
+        let mut delay = CheckedDelay::new(&delay_expectations);
+
+        let pressed = d.debounce(&mut gpio, &mut delay).await;
+
+        assert!(pressed);
+        assert!(d.pressed);
+        assert_eq!(d.integrator, d.threshold);
+
+        gpio.done();
+        delay.done();
     }
 }

--- a/power-button-service/src/lib.rs
+++ b/power-button-service/src/lib.rs
@@ -1,5 +1,5 @@
 //! Power Button Service
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 pub mod button;
 pub mod button_interpreter;

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,11 +1,57 @@
 
 # cargo-vet audits file
 
+[[audits.addr2line]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.24.2"
+notes = "Only used for testing as part of backtrace. Never used in production."
+
+[[audits.backtrace]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.3.75"
+notes = "Needed by tokio which is only used for testing. Not shipped in production."
+
+[[audits.embedded-hal-mock]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.11.1"
+
+[[audits.embedded-time]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.12.1"
+notes = "Needed for testing purposes, we never ship it in production. The crate just provides some useful traits implemented by embedded-hal-mock which is also marked safe-to-run."
+
+[[audits.embedded-time]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.12.1"
+notes = "Used by embedded-hal-mock for testing. Not shipped in production environment."
+
+[[audits.gimli]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.31.1"
+notes = "Only used in test environment as part of backtrace. Never shipped in production."
+
 [[audits.half]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "2.5.0 -> 2.6.0"
 notes = "Big change seems to be a change in the repo URL, but both the old and new URL resolve to the same place so it looks like the author is still in control."
+
+[[audits.libc]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.2.172"
+notes = "Only used in testing environment as part of backtrace. Never shipped in production."
+
+[[audits.memchr]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "2.7.4"
 
 [[audits.mimxrt633s-pac]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
@@ -17,8 +63,126 @@ who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.4.1"
 
+[[audits.mimxrt633s-pac]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+
+[[audits.mimxrt633s-pac]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+
+[[audits.miniz_oxide]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.8.8"
+notes = "Only used for testing purposes as a dependency to backtrace."
+
+[[audits.object]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.36.7"
+notes = "Crate is only used by tokio for testing purposes. Never shipped in production."
+
 [[trusted.anyhow]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-10-05"
 end = "2026-04-16"
+
+[[trusted.backtrace]]
+criteria = "safe-to-run"
+user-id = 539 # Josh Stone (cuviper)
+start = "2024-03-21"
+end = "2026-05-16"
+
+[[trusted.num]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2020-01-10"
+end = "2026-05-16"
+
+[[trusted.num-complex]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2019-06-10"
+end = "2026-05-16"
+
+[[trusted.num-iter]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2019-05-20"
+end = "2026-05-16"
+
+[[trusted.num-rational]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2019-06-11"
+end = "2026-05-16"
+
+[[trusted.tokio]]
+criteria = "safe-to-run"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2020-12-25"
+end = "2026-05-16"
+
+[[trusted.tokio-macros]]
+criteria = "safe-to-run"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2020-10-26"
+end = "2026-05-16"
+
+[[trusted.windows-targets]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-09"
+end = "2026-05-16"
+
+[[trusted.windows_aarch64_gnullvm]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-01"
+end = "2026-05-16"
+
+[[trusted.windows_aarch64_msvc]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-11-05"
+end = "2026-05-16"
+
+[[trusted.windows_i686_gnu]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-28"
+end = "2026-05-16"
+
+[[trusted.windows_i686_gnullvm]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2024-04-02"
+end = "2026-05-16"
+
+[[trusted.windows_i686_msvc]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-27"
+end = "2026-05-16"
+
+[[trusted.windows_x86_64_gnu]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-28"
+end = "2026-05-16"
+
+[[trusted.windows_x86_64_gnullvm]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-01"
+end = "2026-05-16"
+
+[[trusted.windows_x86_64_msvc]]
+criteria = "safe-to-run"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-27"
+end = "2026-05-16"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -15,12 +15,132 @@ user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
 
+[[publisher.num]]
+version = "0.3.1"
+when = "2020-11-03"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.num-complex]]
+version = "0.3.1"
+when = "2020-10-29"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.num-iter]]
+version = "0.1.45"
+when = "2024-05-04"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.num-rational]]
+version = "0.3.2"
+when = "2020-11-06"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.tokio]]
+version = "1.45.0"
+when = "2025-05-06"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
+[[publisher.tokio-macros]]
+version = "2.5.0"
+when = "2025-01-08"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
 [[publisher.unicode-segmentation]]
 version = "1.12.0"
 when = "2024-09-13"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
+
+[[publisher.windows-targets]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_msvc]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_gnu]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_msvc]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnu]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_msvc]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[audits.google.audits.adler2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+notes = '''
+This audit has been reviewed in https://crrev.com/c/5811890
+
+The crate is fairly easy to read thanks to its small size and rich comments.
+
+I've grepped for `-i cipher`, `-i crypto`, `\bfs\b`, `\bnet\b`, and
+`\bunsafe\b`.  There were no hits (except for a comment in `README.md`
+and `lib.rs` pointing out "Zero `unsafe`").
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.autocfg]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -209,6 +329,13 @@ criteria = "safe-to-deploy"
 delta = "1.0.0 -> 1.1.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.num-integer]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.46"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.num-traits]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
@@ -273,6 +400,23 @@ version = "0.6.4"
 notes = """
 For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustc-demangle]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.1.23"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustc-demangle]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.1.23 -> 0.1.24"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde]]


### PR DESCRIPTION
This commit adds a minimal set of tests for the button logic. Notice that this is, indeed, a breaking a change and coordination with dependent crates is required.