### PR TITLE
Implement initial thermal service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-fans"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5007eb97aabfe3606c0b02823b3120e861c748ed3560756aa4fd231ef9ebf0"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "embedded-fans-async"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead1e8f11de775cca5abff7537c3155a4c35d140ccf760d98eae88caa9bb4d3"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-fans",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +697,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "embedded-sensors-hal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971cd616a2326c63f660375e485e2f4573575b0bd293d228d7817c2b07be3475"
+dependencies = [
+ "defmt 0.3.100",
+]
+
+[[package]]
+name = "embedded-sensors-hal-async"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c524a78b2804eca0d9ec05154e51d9af948b40cd0a6bbcc4d5832ff7e47b5b"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-sensors-hal",
+ "paste",
 ]
 
 [[package]]
@@ -1336,6 +1375,24 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thermal-service"
+version = "0.1.0"
+dependencies = [
+ "defmt 0.3.100",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-sensors-hal-async",
+ "embedded-services 0.1.0",
+ "heapless 0.8.0",
+ "log",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "battery-service",
+    "thermal-service",
     "cfu-service",
     "embedded-service",
     "espi-service",
@@ -38,6 +39,8 @@ embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy" }
 embedded-batteries-async = "0.1.0"
+embedded-fans-async = "0.1.0"
+embedded-sensors-hal-async = "0.3.0"
 embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -468,6 +468,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-fans"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5007eb97aabfe3606c0b02823b3120e861c748ed3560756aa4fd231ef9ebf0"
+
+[[package]]
+name = "embedded-fans-async"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead1e8f11de775cca5abff7537c3155a4c35d140ccf760d98eae88caa9bb4d3"
+dependencies = [
+ "embedded-fans",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +545,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "embedded-sensors-hal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971cd616a2326c63f660375e485e2f4573575b0bd293d228d7817c2b07be3475"
+
+[[package]]
+name = "embedded-sensors-hal-async"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c524a78b2804eca0d9ec05154e51d9af948b40cd0a6bbcc4d5832ff7e47b5b"
+dependencies = [
+ "embedded-sensors-hal",
+ "paste",
 ]
 
 [[package]]
@@ -892,6 +923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,8 +1131,11 @@ dependencies = [
  "embassy-time-driver",
  "embedded-batteries-async",
  "embedded-cfu-protocol",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-mock",
+ "embedded-sensors-hal-async",
  "embedded-services",
  "embedded-usb-pd",
  "env_logger",
@@ -1103,6 +1143,7 @@ dependencies = [
  "log",
  "power-policy-service",
  "static_cell",
+ "thermal-service",
  "type-c-service",
 ]
 
@@ -1136,6 +1177,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thermal-service"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-sensors-hal-async",
+ "embedded-services",
+ "heapless 0.8.0",
+ "log",
 ]
 
 [[package]]

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -34,11 +34,16 @@ embedded-batteries-async = "0.1.0"
 battery-service = { path = "../../battery-service", features = ["log"] }
 type-c-service = { path = "../../type-c-service", features = ["log"] }
 
+embedded-sensors-hal-async = "0.3.0"
+embedded-fans-async = "0.1.0"
+thermal-service = { path = "../../thermal-service", features = ["log"] }
+
 env_logger = "0.9.0"
 log = "0.4.14"
 heapless = "0.8.0"
 static_cell = "2"
 embedded-hal-async = "1.0.0"
+embedded-hal = "1.0.0"
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 
 critical-section = { version = "1.1", features = ["std"] }

--- a/examples/std/src/bin/thermal.rs
+++ b/examples/std/src/bin/thermal.rs
@@ -1,0 +1,417 @@
+use embassy_executor::{Executor, Spawner};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use embassy_sync::once_lock::OnceLock;
+use embassy_time::Timer;
+use embedded_fans_async as fan;
+use embedded_hal::digital;
+use embedded_hal_async::digital as async_digital;
+use embedded_sensors_hal_async::sensor;
+use embedded_sensors_hal_async::temperature::{DegreesCelsius, TemperatureSensor, TemperatureThresholdSet};
+use embedded_services::comms;
+use log::info;
+use static_cell::StaticCell;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use thermal_service::{default_handler, mptf};
+
+// Mock host service
+mod host {
+    use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
+    use embedded_services::comms::{self, Endpoint, EndpointID, External, MailboxDelegate};
+    use log::{info, warn};
+    use thermal_service::{default_handler, mptf};
+
+    pub struct Host {
+        pub tp: Endpoint,
+        pub alert: Signal<NoopRawMutex, ()>,
+    }
+
+    impl Host {
+        pub fn new() -> Self {
+            Self {
+                tp: Endpoint::uninit(EndpointID::External(External::Host)),
+                alert: Signal::new(),
+            }
+        }
+
+        fn handle_response(&self, response: mptf::Response) {
+            match response {
+                Ok(mptf::ResponseData::GetTmp(tmp)) => {
+                    info!("Host received temperature: {} °C", thermal_service::utils::dk_to_c(tmp))
+                }
+                Ok(mptf::ResponseData::GetVar(uid, value)) => {
+                    if uid == default_handler::uid::FAN_CURRENT_RPM {
+                        info!("Host received fan RPM: {value}")
+                    } else {
+                        info!("Received GetVar response: {uid}: {value}")
+                    }
+                }
+                _ => info!("Received MPTF response: {response:?}"),
+            }
+        }
+
+        fn handle_notify(&self, notification: mptf::Notify) {
+            match notification {
+                mptf::Notify::Threshold => {
+                    warn!("Host received notification that temperature threshold exceeded!");
+                    self.alert.signal(());
+                }
+                _ => info!("Received notification: {notification:?}"),
+            }
+        }
+    }
+
+    impl MailboxDelegate for Host {
+        fn receive(&self, message: &comms::Message) -> Result<(), comms::MailboxDelegateError> {
+            if let Some(&response) = message.data.get::<mptf::Response>() {
+                self.handle_response(response);
+                Ok(())
+            } else if let Some(&notification) = message.data.get::<mptf::Notify>() {
+                self.handle_notify(notification);
+                Ok(())
+            } else {
+                Err(comms::MailboxDelegateError::MessageNotFound)
+            }
+        }
+    }
+}
+
+// A mock struct shared by MockSensor and MockAlertPin to sync on raw samples and thresholds
+struct MockBus {
+    samples: [f32; 35],
+    idx: AtomicUsize,
+    threshold_low: Mutex<NoopRawMutex, f32>,
+    threshold_high: Mutex<NoopRawMutex, f32>,
+}
+
+impl MockBus {
+    fn new() -> Self {
+        Self {
+            samples: [
+                20.0, 25.0, 30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0,
+                105.0, 100.0, 95.0, 90.0, 85.0, 80.0, 75.0, 70.0, 65.0, 60.0, 55.0, 50.0, 45.0, 40.0, 35.0, 30.0, 25.0,
+                20.0,
+            ],
+            idx: AtomicUsize::new(0),
+            threshold_low: Mutex::new(0.0),
+            threshold_high: Mutex::new(0.0),
+        }
+    }
+
+    // Return the current sample
+    fn sample(&self) -> f32 {
+        self.samples[self.idx.load(Ordering::SeqCst)]
+    }
+
+    // Return the current sample and move to next sample (wrapping around at end)
+    fn sample_and_next(&self) -> f32 {
+        self.samples[self
+            .idx
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |idx| {
+                Some((idx + 1) % self.samples.len())
+            })
+            .unwrap()]
+    }
+
+    async fn threshold_high(&self) -> f32 {
+        *self.threshold_high.lock().await
+    }
+
+    async fn set_threshold_low(&self, threshold: f32) {
+        *self.threshold_low.lock().await = threshold
+    }
+
+    async fn set_threshold_high(&self, threshold: f32) {
+        *self.threshold_high.lock().await = threshold
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct MockSensorError;
+impl sensor::Error for MockSensorError {
+    fn kind(&self) -> sensor::ErrorKind {
+        sensor::ErrorKind::Other
+    }
+}
+
+// A mock temperature sensor
+struct MockSensor {
+    bus: &'static MockBus,
+}
+
+impl MockSensor {
+    fn new(bus: &'static MockBus) -> Self {
+        Self { bus }
+    }
+}
+
+impl sensor::ErrorType for MockSensor {
+    type Error = MockSensorError;
+}
+
+impl TemperatureSensor for MockSensor {
+    async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
+        Ok(self.bus.sample_and_next())
+    }
+}
+
+impl TemperatureThresholdSet for MockSensor {
+    async fn set_temperature_threshold_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+        self.bus.set_threshold_low(threshold).await;
+        Ok(())
+    }
+
+    async fn set_temperature_threshold_high(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+        self.bus.set_threshold_high(threshold).await;
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct MockFanError;
+impl fan::Error for MockFanError {
+    fn kind(&self) -> embedded_fans_async::ErrorKind {
+        fan::ErrorKind::Other
+    }
+}
+
+// A mock fan
+struct MockFan {
+    rpm: u16,
+}
+
+impl MockFan {
+    fn new() -> Self {
+        Self { rpm: 0 }
+    }
+}
+
+impl fan::ErrorType for MockFan {
+    type Error = MockFanError;
+}
+
+impl fan::Fan for MockFan {
+    fn min_rpm(&self) -> u16 {
+        0
+    }
+
+    fn max_rpm(&self) -> u16 {
+        5000
+    }
+
+    fn min_start_rpm(&self) -> u16 {
+        1000
+    }
+
+    async fn set_speed_rpm(&mut self, rpm: u16) -> Result<u16, Self::Error> {
+        self.rpm = rpm;
+        Ok(rpm)
+    }
+}
+
+impl fan::RpmSense for MockFan {
+    async fn rpm(&mut self) -> Result<u16, Self::Error> {
+        Ok(self.rpm)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct MockAlertPinError;
+impl digital::Error for MockAlertPinError {
+    fn kind(&self) -> digital::ErrorKind {
+        digital::ErrorKind::Other
+    }
+}
+
+struct MockAlertPin {
+    bus: &'static MockBus,
+}
+
+impl MockAlertPin {
+    fn new(bus: &'static MockBus) -> Self {
+        Self { bus }
+    }
+}
+
+impl digital::ErrorType for MockAlertPin {
+    type Error = MockAlertPinError;
+}
+
+impl async_digital::Wait for MockAlertPin {
+    // Periodically wake up then check if the current sample exceeds the set high threshold
+    // This is to simulate an interrupt being generated on the GPIO pin by the physical sensor
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        loop {
+            Timer::after_millis(100).await;
+
+            let sample = self.bus.sample();
+            let threshold = self.bus.threshold_high().await;
+
+            if sample >= threshold {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    // These are unused for this demo
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+// Simulates host receiving requests from OSPM and forwarding to thermal service
+#[embassy_executor::task]
+async fn host() {
+    info!("Spawning host task");
+
+    static HOST: OnceLock<host::Host> = OnceLock::new();
+    let host = HOST.get_or_init(host::Host::new);
+    info!("Registering host endpoint");
+    comms::register_endpoint(host, &host.tp).await.unwrap();
+
+    let thermal_id = comms::EndpointID::Internal(comms::Internal::Thermal);
+
+    // Set thresholds to 100 °C (3731 deciKelvin)
+    host.tp
+        .send(thermal_id, &mptf::Request::SetThrs(0, 0, 0, 3731))
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Set Fan ON temp to 40 °C (3131 deciKelvin)
+    host.tp
+        .send(
+            thermal_id,
+            &mptf::Request::SetVar(default_handler::uid::FAN_ON_TEMP, 3131),
+        )
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Set Fan RAMP temp to 50 °C (3231 deciKelvin)
+    host.tp
+        .send(
+            thermal_id,
+            &mptf::Request::SetVar(default_handler::uid::FAN_RAMP_TEMP, 3231),
+        )
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Set Fan MAX temp to 80 °C (3531 deciKelvin)
+    host.tp
+        .send(
+            thermal_id,
+            &mptf::Request::SetVar(default_handler::uid::FAN_MAX_TEMP, 3531),
+        )
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Wait to receive MPTF notification that threshold exceeded, then request temperature and RPM
+    loop {
+        host.alert.wait().await;
+
+        info!("Host requesting temperature in response to threshold alert");
+        host.tp.send(thermal_id, &mptf::Request::GetTmp(0)).await.unwrap();
+
+        // Need to wait briefly before send is fixed to propagate errors and we can handle retries
+        Timer::after_millis(100).await;
+
+        info!("Host requesting fan RPM in response to threshold alert");
+        host.tp
+            .send(
+                thermal_id,
+                &mptf::Request::GetVar(default_handler::uid::FAN_CURRENT_RPM),
+            )
+            .await
+            .unwrap();
+    }
+}
+
+async fn init_sensor(spawner: Spawner) {
+    info!("Initializing mock bus");
+    static BUS: OnceLock<MockBus> = OnceLock::new();
+    let bus = BUS.get_or_init(MockBus::new);
+
+    info!("Initializing alert pin");
+    let mock_pin = MockAlertPin::new(bus);
+
+    info!("Initializing mock sensor");
+    let mock_sensor = MockSensor::new(bus);
+    static SENSOR: OnceLock<thermal_service::sensor::Sensor<MockSensor>> = OnceLock::new();
+    let sensor = SENSOR.get_or_init(|| thermal_service::sensor::Sensor::new(default_handler::SENSOR, mock_sensor));
+
+    thermal_service::register_sensor(sensor.device()).await.unwrap();
+    spawner.must_spawn(mock_sensor_task(sensor, mock_pin));
+
+    thermal_service::execute_sensor_request(
+        default_handler::SENSOR,
+        thermal_service::sensor::Request::SetSamplingPeriod(1000),
+    )
+    .await
+    .unwrap();
+}
+
+async fn init_fan(spawner: Spawner) {
+    info!("Initializing mock fan");
+    let mock_fan = MockFan::new();
+    static FAN: OnceLock<thermal_service::fan::Fan<MockFan>> = OnceLock::new();
+    let fan = FAN.get_or_init(|| thermal_service::fan::Fan::new(default_handler::FAN, mock_fan));
+
+    thermal_service::register_fan(fan.device()).await.unwrap();
+    spawner.must_spawn(mock_fan_task(fan));
+}
+
+async fn init_thermal(spawner: Spawner) {
+    info!("Initializing thermal service");
+
+    // Initialize the default MPTF handler, then initialize the thermal service with it
+    static HANDLER: StaticCell<thermal_service::default_handler::DefaultHandler> = StaticCell::new();
+    let handler = HANDLER.init(thermal_service::default_handler::DefaultHandler::new(
+        thermal_service::default_handler::Config::default(),
+    ));
+    thermal_service::init(spawner, handler).await;
+
+    init_sensor(spawner).await;
+    init_fan(spawner).await;
+
+    // TODO: Ideally move this into library, but depends on sensor and fan being registered first
+    handler.init().await.unwrap();
+    spawner.must_spawn(default_handler::task(spawner, handler));
+}
+
+#[embassy_executor::task]
+async fn run(spawner: Spawner) {
+    embedded_services::init().await;
+    init_thermal(spawner).await;
+    spawner.must_spawn(host());
+}
+
+fn main() {
+    env_logger::builder().filter_level(log::LevelFilter::Info).init();
+
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.must_spawn(run(spawner));
+    });
+}
+
+thermal_service::impl_sensor_task!(mock_sensor_task, MockSensor, MockAlertPin);
+thermal_service::impl_fan_task!(mock_fan_task, MockFan);

--- a/thermal-service/Cargo.toml
+++ b/thermal-service/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "thermal-service"
+version = "0.1.0"
+edition = "2021"
+description = "Thermal service implementation"
+repository = "https://github.com/OpenDevicePartnership/embedded-services"
+rust-version = "1.85"
+license = "MIT"
+
+[dependencies]
+defmt = { workspace = true, optional = true }
+embassy-executor.workspace = true
+embassy-futures.workspace = true
+embassy-sync.workspace = true
+embassy-time.workspace = true
+embedded-hal-async.workspace = true
+embedded-hal.workspace = true
+embedded-services.workspace = true
+embedded-sensors-hal-async.workspace = true
+embedded-fans-async.workspace = true
+heapless.workspace = true
+log = { workspace = true, optional = true }
+
+[features]
+default = []
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embassy-time/defmt",
+    "embassy-sync/defmt",
+    "embassy-executor/defmt",
+    "embedded-fans-async/defmt",
+    "embedded-sensors-hal-async/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "embassy-time/log",
+    "embassy-sync/log",
+    "embassy-executor/log",
+]

--- a/thermal-service/src/context.rs
+++ b/thermal-service/src/context.rs
@@ -1,0 +1,140 @@
+//! Thermal service context
+use crate::{fan, mptf, sensor, Request};
+use core::sync::atomic::{AtomicBool, Ordering};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::once_lock::OnceLock;
+use embedded_services::ipc::deferred as ipc;
+use embedded_services::{error, intrusive_list};
+
+struct Context {
+    /// Registered temperature sensors
+    sensors: intrusive_list::IntrusiveList,
+    /// Registered fans
+    fans: intrusive_list::IntrusiveList,
+    /// Comms channel
+    comms: Channel<NoopRawMutex, Request, 1>,
+    /// Channel for IPC requests and responses
+    ipc: ipc::Channel<NoopRawMutex, Request, mptf::Response>,
+}
+
+impl Context {
+    fn new() -> Self {
+        Self {
+            sensors: intrusive_list::IntrusiveList::new(),
+            fans: intrusive_list::IntrusiveList::new(),
+            comms: Channel::new(),
+            ipc: ipc::Channel::new(),
+        }
+    }
+}
+
+/// Singleton struct to give access to the thermal context
+pub(crate) struct ContextToken(());
+impl ContextToken {
+    /// Create a new context token, returning None if this function has been called before
+    pub(crate) fn create() -> Option<Self> {
+        static INIT: AtomicBool = AtomicBool::new(false);
+        if INIT.load(Ordering::SeqCst) {
+            return None;
+        }
+
+        INIT.store(true, Ordering::SeqCst);
+        CONTEXT.get_or_init(Context::new);
+        Some(ContextToken(()))
+    }
+
+    /// Wait for a request on the IPC channel
+    pub(crate) async fn wait_request(&self) -> ipc::Request<NoopRawMutex, Request, mptf::Response> {
+        CONTEXT.get().await.ipc.receive().await
+    }
+
+    /// Wait for a request via the comms service
+    pub(crate) async fn wait_comms_request(&self) -> Request {
+        CONTEXT.get().await.comms.receive().await
+    }
+
+    /// Transfer a request from the comms service
+    pub(crate) fn send_request_from_comms(&self, msg: Request) -> Result<(), ()> {
+        CONTEXT.try_get().ok_or(())?.comms.try_send(msg).map_err(|_| ())?;
+        Ok(())
+    }
+}
+
+// Just one instance of this context should be instantiated
+static CONTEXT: OnceLock<Context> = OnceLock::new();
+
+/// Send a request to the thermal service directly instead of through comms.
+pub async fn execute_service_request(request: Request) -> mptf::Response {
+    CONTEXT.get().await.ipc.execute(request).await
+}
+
+/// Register a sensor with the thermal service
+pub async fn register_sensor(sensor: &'static sensor::Device) -> Result<(), intrusive_list::Error> {
+    if get_sensor(sensor.id()).await.is_some() {
+        return Err(intrusive_list::Error::NodeAlreadyInList);
+    }
+
+    CONTEXT.get().await.sensors.push(sensor)
+}
+
+/// Provides access to the sensors list
+pub async fn sensors() -> &'static intrusive_list::IntrusiveList {
+    &CONTEXT.get().await.sensors
+}
+
+/// Find a sensor by its ID
+pub async fn get_sensor(id: sensor::DeviceId) -> Option<&'static sensor::Device> {
+    for sensor in &CONTEXT.get().await.sensors {
+        if let Some(data) = sensor.data::<sensor::Device>() {
+            if data.id() == id {
+                return Some(data);
+            }
+        } else {
+            error!("Non-device located in sensors list");
+        }
+    }
+
+    None
+}
+
+/// Send a request to a sensor through the thermal service instead of directly.
+pub async fn execute_sensor_request(id: sensor::DeviceId, request: sensor::Request) -> sensor::Response {
+    let sensor = get_sensor(id).await.ok_or(sensor::Error::InvalidRequest)?;
+    sensor.execute_request(request).await
+}
+
+/// Register a fan with the thermal service
+pub async fn register_fan(fan: &'static fan::Device) -> Result<(), intrusive_list::Error> {
+    if get_fan(fan.id()).await.is_some() {
+        return Err(intrusive_list::Error::NodeAlreadyInList);
+    }
+
+    CONTEXT.get().await.fans.push(fan)
+}
+
+/// Provides access to the fans list
+pub async fn fans() -> &'static intrusive_list::IntrusiveList {
+    &CONTEXT.get().await.fans
+}
+
+/// Find a fan by its ID
+pub async fn get_fan(id: fan::DeviceId) -> Option<&'static fan::Device> {
+    for fan in &CONTEXT.get().await.fans {
+        if let Some(data) = fan.data::<fan::Device>() {
+            if data.id() == id {
+                return Some(data);
+            }
+        } else {
+            error!("Non-device located in fan list");
+        }
+    }
+
+    None
+}
+
+/// Send a request to a fan through the thermal service instead of directly.
+pub async fn execute_fan_request(id: fan::DeviceId, request: fan::Request) -> fan::Response {
+    let fan = get_fan(id).await.ok_or(fan::Error::InvalidRequest)?;
+    fan.execute_request(request).await
+}

--- a/thermal-service/src/default_handler.rs
+++ b/thermal-service/src/default_handler.rs
@@ -1,0 +1,460 @@
+//! ODP default MPTF handler and fan control logic which OEMs can use as-is or as a reference
+use crate as thermal_service;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use embassy_time::Timer;
+use embedded_services::comms;
+use embedded_services::{error, info, warn};
+use heapless::FnvIndexMap;
+use mptf::Handler;
+use thermal_service::fan;
+use thermal_service::mptf;
+use thermal_service::sensor;
+use thermal_service::utils;
+
+pub const SENSOR: sensor::DeviceId = sensor::DeviceId(0);
+pub const FAN: fan::DeviceId = fan::DeviceId(0);
+
+/// MPTF Standard UIDs which the default service understands
+// TODO: Put these UIDs into the actual correct format according to spec
+pub mod uid {
+    use crate::mptf::Uid;
+    pub const CRT_TEMP: Uid = 0x218246e7baf645f1aa1307e4845256b8;
+    pub const PROC_HOT_TEMP: Uid = 0x22dc52d2fd0b47ab95b826552f9831a5;
+    pub const PROFILE_TYPE: Uid = 0x23b4a025cdfd4af9a41137a24c574615;
+    pub const FAN_ON_TEMP: Uid = 0xba17b567c36848d5bc6fa312a41583c1;
+    pub const FAN_RAMP_TEMP: Uid = 0x3a62688cd95b4d2dbacc90d7a5816bcd;
+    pub const FAN_MAX_TEMP: Uid = 0xdcb758b1f0fd4ec7b2c0ef1e2a547b76;
+    pub const FAN_MIN_RPM: Uid = 0xdb261c77934b45e29742256c62badb7a;
+    pub const FAN_MAX_RPM: Uid = 0x5cf839df8be742b99ac53403ca2c8a6a;
+    pub const FAN_CURRENT_RPM: Uid = 0xadf9549207764ffc84f3b6c8b5269683;
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FanState {
+    Off,
+    On,
+    Ramping,
+    Max,
+}
+
+#[derive(Debug, Clone)]
+struct State {
+    // Most recently sampled temperature
+    cur_temp: f32,
+    // Current fan state
+    fan_state: FanState,
+    // Low temperature threshold
+    threshold_low: f32,
+    // High temperature threshold
+    threshold_high: f32,
+    // Provides variable data lookup via UID
+    uid_table: FnvIndexMap<mptf::Uid, mptf::Dword, 16>,
+}
+
+impl State {
+    fn new(config: Config) -> Self {
+        let mut uid_table = FnvIndexMap::new();
+
+        // Unwraps used here because these are unrecoverable errors which represent a programming bug, so should panic
+        uid_table
+            .insert(uid::CRT_TEMP, utils::c_to_dk(config.crt_temp))
+            .unwrap();
+
+        uid_table
+            .insert(uid::PROC_HOT_TEMP, utils::c_to_dk(config.proc_hot_temp))
+            .unwrap();
+
+        // Maybe unused by default?
+        uid_table.insert(uid::PROFILE_TYPE, 0).unwrap();
+
+        uid_table
+            .insert(uid::FAN_ON_TEMP, utils::c_to_dk(config.fan_on_temp))
+            .unwrap();
+
+        uid_table
+            .insert(uid::FAN_RAMP_TEMP, utils::c_to_dk(config.fan_ramp_temp))
+            .unwrap();
+
+        uid_table
+            .insert(uid::FAN_MAX_TEMP, utils::c_to_dk(config.fan_max_temp))
+            .unwrap();
+
+        // Determined by init()
+        uid_table.insert(uid::FAN_MIN_RPM, 0).unwrap();
+
+        // Determined by init()
+        uid_table.insert(uid::FAN_MAX_RPM, 0).unwrap();
+
+        uid_table.insert(uid::FAN_CURRENT_RPM, 0).unwrap();
+
+        Self {
+            cur_temp: 0.0,
+            fan_state: FanState::Off,
+            threshold_low: config.threshold_low,
+            threshold_high: config.threshold_high,
+            uid_table,
+        }
+    }
+}
+
+/// Configure the default handler
+pub struct Config {
+    pub threshold_low: f32,
+    pub threshold_high: f32,
+    pub crt_temp: f32,
+    pub proc_hot_temp: f32,
+    pub fan_on_temp: f32,
+    pub fan_ramp_temp: f32,
+    pub fan_max_temp: f32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            threshold_low: 100.0,
+            threshold_high: 100.0,
+            crt_temp: 60.0,
+            proc_hot_temp: 80.0,
+            fan_on_temp: 30.0,
+            fan_ramp_temp: 35.0,
+            fan_max_temp: 40.0,
+        }
+    }
+}
+
+/// Default MPTF handler provided by ODP
+///
+/// Currently does not distinguish between separate thermal zones or cooling policies,
+/// instead treating entire paltform as single zone and following a single cooling policy.
+pub struct DefaultHandler {
+    state: Mutex<NoopRawMutex, State>,
+}
+
+impl DefaultHandler {
+    /// Create a new instance of the default MPTF handler
+    pub fn new(config: Config) -> Self {
+        Self {
+            state: Mutex::new(State::new(config)),
+        }
+    }
+
+    /// Initializes the default handler using values retrieved from previously registered hardware
+    pub async fn init(&self) -> Result<(), ()> {
+        // Request fan min and max RPM from device
+        let min_rpm = match thermal_service::execute_fan_request(FAN, fan::Request::GetMinRpm).await {
+            Ok(fan::ResponseData::Rpm(rpm)) => rpm,
+            _ => return Err(()),
+        };
+        let max_rpm = match thermal_service::execute_fan_request(FAN, fan::Request::GetMaxRpm).await {
+            Ok(fan::ResponseData::Rpm(rpm)) => rpm,
+            _ => return Err(()),
+        };
+
+        // Then update UID table with that info
+        self.state.lock().await.uid_table[&uid::FAN_MIN_RPM] = min_rpm as u32;
+        self.state.lock().await.uid_table[&uid::FAN_MAX_RPM] = max_rpm as u32;
+
+        // Ensure sensor is configured to generate alerts with initial threshold config
+        thermal_service::execute_sensor_request(
+            SENSOR,
+            sensor::Request::SetAlertLow(self.state.lock().await.threshold_low),
+        )
+        .await
+        .map_err(|_| ())?;
+
+        thermal_service::execute_sensor_request(
+            SENSOR,
+            sensor::Request::SetAlertHigh(self.state.lock().await.threshold_high),
+        )
+        .await
+        .map_err(|_| ())?;
+
+        Ok(())
+    }
+
+    // TODO: Make this possibly a callback so OEM can inject a custom ramp response but keep other boilerplate?
+    // TODO: Or make it a trait method? Investigate.
+    async fn fan_ramp_response(&self) -> fan::Response {
+        let state = self.state.lock().await;
+        let fan_ramp_tamp = utils::dk_to_c(state.uid_table[&uid::FAN_RAMP_TEMP]);
+        let fan_max_tamp = utils::dk_to_c(state.uid_table[&uid::FAN_MAX_TEMP]);
+
+        // Provide a linear fan response between its min and max RPM relative to temperature between ramp start and max temp
+        let rpm = if state.cur_temp <= fan_ramp_tamp {
+            state.uid_table[&uid::FAN_MIN_RPM]
+        } else if state.cur_temp >= fan_max_tamp {
+            state.uid_table[&uid::FAN_MAX_RPM]
+        } else {
+            let ratio = (state.cur_temp - fan_ramp_tamp) / (fan_max_tamp - fan_ramp_tamp);
+            let range = (state.uid_table[&uid::FAN_MAX_RPM] - state.uid_table[&uid::FAN_MIN_RPM]) as f32;
+            state.uid_table[&uid::FAN_MIN_RPM] + (ratio * range) as u32
+        };
+
+        thermal_service::execute_fan_request(FAN, fan::Request::SetRpm(rpm as u16)).await
+    }
+
+    async fn handle_fan_off_state(&self) -> fan::Response {
+        let mut state = self.state.lock().await;
+
+        // If temp rises above Fan Min On Temp, set fan to ON state
+        if state.cur_temp >= utils::dk_to_c(state.uid_table[&uid::FAN_ON_TEMP]) {
+            let _ = thermal_service::execute_fan_request(
+                FAN,
+                fan::Request::SetRpm(state.uid_table[&uid::FAN_MIN_RPM] as u16),
+            )
+            .await?;
+            state.fan_state = FanState::On;
+            info!("Fan transitioned to ON state from OFF state");
+        }
+
+        Ok(fan::ResponseData::Success)
+    }
+
+    async fn handle_fan_on_state(&self) -> fan::Response {
+        let mut state = self.state.lock().await;
+
+        // If temp rises above Fan Ramp Temp, set to RAMPING state
+        if state.cur_temp >= utils::dk_to_c(state.uid_table[&uid::FAN_RAMP_TEMP]) {
+            state.fan_state = FanState::Ramping;
+            info!("Fan transitioned to RAMPING state from ON state");
+
+        // If falls below on temp, set to OFF state
+        } else if state.cur_temp < utils::dk_to_c(state.uid_table[&uid::FAN_ON_TEMP]) {
+            let _ = thermal_service::execute_fan_request(FAN, fan::Request::SetRpm(0)).await?;
+            state.fan_state = FanState::Off;
+            info!("Fan transitioned to OFF state from ON state");
+        }
+
+        Ok(fan::ResponseData::Success)
+    }
+
+    async fn handle_fan_ramping_state(&self) -> fan::Response {
+        let mut state = self.state.lock().await;
+
+        // If temp falls below ramp temp, set to ON state
+        if state.cur_temp < utils::dk_to_c(state.uid_table[&uid::FAN_RAMP_TEMP]) {
+            let _ = thermal_service::execute_fan_request(
+                FAN,
+                fan::Request::SetRpm(state.uid_table[&uid::FAN_MIN_RPM] as u16),
+            )
+            .await?;
+            state.fan_state = FanState::On;
+            info!("Fan transitioned to ON state from RAMPING state");
+
+        // If temp rises above max, set to MAX state
+        } else if state.cur_temp >= utils::dk_to_c(state.uid_table[&uid::FAN_MAX_TEMP]) {
+            let _ = thermal_service::execute_fan_request(
+                FAN,
+                fan::Request::SetRpm(state.uid_table[&uid::FAN_MAX_RPM] as u16),
+            )
+            .await?;
+
+            state.fan_state = FanState::Max;
+            warn!("Fan transitioned to MAX state from RAMPING state");
+
+        // If temp stays between ramp temp and max temp, continue ramp response
+        } else {
+            drop(state); // Allow fan_ramp_response to acquire state
+            let _ = self.fan_ramp_response().await?;
+        }
+
+        Ok(fan::ResponseData::Success)
+    }
+
+    async fn handle_fan_max_state(&self) -> fan::Response {
+        let mut state = self.state.lock().await;
+
+        if state.cur_temp < utils::dk_to_c(state.uid_table[&uid::FAN_MAX_TEMP]) {
+            state.fan_state = FanState::Ramping;
+            info!("Fan transitioned to RAMPING state from MAX state");
+        }
+
+        Ok(fan::ResponseData::Success)
+    }
+
+    async fn handle_fan_state(&self) -> fan::Response {
+        let state = self.state.lock().await.fan_state;
+
+        match state {
+            FanState::Off => self.handle_fan_off_state().await,
+            FanState::On => self.handle_fan_on_state().await,
+            FanState::Ramping => self.handle_fan_ramping_state().await,
+            FanState::Max => self.handle_fan_max_state().await,
+        }
+    }
+
+    // This currently just polls temperature to check if above CRT and PROCHOT (interrupt alerts are reserved for THRS)
+    // TODO: Get more clarification on CRT and PROCHOT. Might not be necessary to notify?
+    async fn crt_prochot_check(&self) {
+        let state = self.state.lock().await;
+
+        // If temp rises above PROCHOT, notify Host
+        if state.cur_temp >= utils::dk_to_c(state.uid_table[&uid::PROC_HOT_TEMP]) {
+            thermal_service::send_service_msg(
+                comms::EndpointID::External(comms::External::Host),
+                &mptf::Notify::ProcHot,
+            )
+            .await;
+
+            warn!("Temperature exceeds PROCHOT!");
+        }
+
+        // If temp rises above CRT, notify Host and Power service
+        if state.cur_temp >= utils::dk_to_c(state.uid_table[&uid::CRT_TEMP]) {
+            thermal_service::send_service_msg(
+                comms::EndpointID::External(comms::External::Host),
+                &mptf::Notify::Critical,
+            )
+            .await;
+
+            thermal_service::send_service_msg(
+                comms::EndpointID::Internal(comms::Internal::Power),
+                &mptf::Notify::Critical,
+            )
+            .await;
+
+            warn!("Temperature exceeds CRT!");
+        }
+    }
+}
+
+impl Handler for DefaultHandler {
+    async fn get_tmp(&self, _tzid: mptf::TzId) -> mptf::Response {
+        Ok(mptf::ResponseData::GetTmp(utils::c_to_dk(
+            self.state.lock().await.cur_temp,
+        )))
+    }
+
+    async fn get_thrs(&self, _tzid: mptf::TzId) -> mptf::Response {
+        let low = utils::c_to_dk(self.state.lock().await.threshold_low);
+        let high = utils::c_to_dk(self.state.lock().await.threshold_high);
+        Ok(mptf::ResponseData::GetThrs(0, low, high))
+    }
+
+    async fn set_thrs(
+        &self,
+        _tzid: mptf::TzId,
+        _timeout: mptf::Dword,
+        low: mptf::DeciKelvin,
+        high: mptf::DeciKelvin,
+    ) -> mptf::Response {
+        // Currently default algorithm does not make use of timeout
+        let low = utils::dk_to_c(low);
+        let high = utils::dk_to_c(high);
+
+        // Set thresholds on physical sensors to make use of hardware interrupts
+        thermal_service::execute_sensor_request(SENSOR, sensor::Request::SetAlertLow(low))
+            .await
+            .map_err(|_| mptf::Error::HardwareError)?;
+        thermal_service::execute_sensor_request(SENSOR, sensor::Request::SetAlertHigh(high))
+            .await
+            .map_err(|_| mptf::Error::HardwareError)?;
+
+        // Then update state
+        self.state.lock().await.threshold_low = low;
+        self.state.lock().await.threshold_high = high;
+        Ok(mptf::ResponseData::SetThrs)
+    }
+
+    async fn set_scp(
+        &self,
+        _tzid: mptf::TzId,
+        _mode: mptf::Dword,
+        _acoustic_lim: mptf::Dword,
+        _power_lim: mptf::Dword,
+    ) -> mptf::Response {
+        // Currently default algorithm does not use distinct cooling policies
+        Ok(mptf::ResponseData::SetScp)
+    }
+
+    async fn get_var(&self, uid: mptf::Uid) -> mptf::Response {
+        self.state
+            .lock()
+            .await
+            .uid_table
+            .get(&uid)
+            .ok_or(mptf::Error::InvalidParameter)
+            .map(|&val| mptf::ResponseData::GetVar(uid, val))
+    }
+
+    async fn set_var(&self, uid: mptf::Uid, value: mptf::Dword) -> mptf::Response {
+        let uid_table = &mut self.state.lock().await.uid_table;
+
+        if let Some(inner_val) = uid_table.get_mut(&uid) {
+            *inner_val = value;
+            Ok(mptf::ResponseData::SetVar)
+        } else {
+            Err(mptf::Error::InvalidParameter)
+        }
+    }
+}
+
+/// Default fan control task which interfaces with the default MPTF Handler
+#[embassy_executor::task]
+pub async fn task(spawner: embassy_executor::Spawner, handler: &'static DefaultHandler) {
+    spawner.must_spawn(threshold_task());
+
+    info!("MPTF Default Handler Task Started");
+    loop {
+        // Fetch and cache most recent temperature from sensor
+        handler.state.lock().await.cur_temp =
+            match thermal_service::execute_sensor_request(SENSOR, sensor::Request::GetTemp).await {
+                Ok(sensor::ResponseData::Temp(temp)) => temp,
+                Ok(response) => {
+                    warn!("Received unexpected response from sensor: {:?}", response);
+                    handler.state.lock().await.cur_temp
+                }
+                Err(e) => {
+                    error!("Error reading temperature from sensor: {:?}", e);
+                    handler.state.lock().await.cur_temp
+                }
+            };
+
+        // Cache most recent fan RPM measurement
+        match thermal_service::execute_fan_request(FAN, fan::Request::GetRpm).await {
+            fan::Response::Ok(fan::ResponseData::Rpm(rpm)) => {
+                if let Err(e) = handler.set_var(uid::FAN_CURRENT_RPM, rpm as mptf::Dword).await {
+                    error!("Error caching fan RPM: {:?}", e);
+                }
+            }
+            Ok(response) => warn!("Received unexpected response from fan: {:?}", response),
+            Err(e) => error!("Error reading RPM from fan: {:?}", e),
+        }
+
+        // Check if the temperature exceeds CRT/PROCHOT and notify services if so
+        handler.crt_prochot_check().await;
+
+        // Handle fan state in response to temperature
+        if let Err(e) = handler.handle_fan_state().await {
+            error!("Error handling fan state: {:?}", e);
+        }
+
+        // Wait briefly
+        // TODO: Investigate setting sensor alert thresholds to minimum of all thresholds we are interested in as opposed to periodic polling
+        Timer::after_millis(1000).await;
+    }
+}
+
+// Waits for sensor to trigger threshold alert, then notifies host
+#[embassy_executor::task]
+async fn threshold_task() {
+    loop {
+        match thermal_service::get_sensor(SENSOR)
+            .await
+            .expect("Error: Invalid sensor in thermal service")
+            .wait_alert()
+            .await
+        {
+            // Notify SoC/Host high threshold was tripped
+            // TODO: Better understand notification format
+            sensor::Alert::ThresholdLow | sensor::Alert::ThresholdHigh => {
+                thermal_service::send_service_msg(
+                    comms::EndpointID::External(comms::External::Host),
+                    &mptf::Notify::Threshold,
+                )
+                .await
+            }
+        }
+    }
+}

--- a/thermal-service/src/fan.rs
+++ b/thermal-service/src/fan.rs
@@ -1,0 +1,215 @@
+//! Fan Device
+use crate::utils::SampleBuf;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use embassy_time::Timer;
+use embedded_fans_async::{self as fan_traits, Error as HadrwareError};
+use embedded_services::error;
+use embedded_services::ipc::deferred as ipc;
+use embedded_services::{intrusive_list, Node};
+
+// RPM sample buffer size
+const BUFFER_SIZE: usize = 16;
+
+/// Convenience type for Fan response result
+pub type Response = Result<ResponseData, Error>;
+
+/// Fan error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Invalid request
+    InvalidRequest,
+    /// Device encountered a hardware failure
+    Hardware,
+}
+
+/// Fan request
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Request {
+    /// Most recent RPM measurement
+    GetRpm,
+    /// Average RPM measurement
+    GetAvgRpm,
+    /// Get Min RPM
+    GetMinRpm,
+    /// Get Max RPM
+    GetMaxRpm,
+    /// Set RPM
+    SetRpm(u16),
+    /// Set RPM sampling period (in ms)
+    SetSamplingPeriod(u64),
+}
+
+/// Fan response
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    /// Response for any request that is successful but does not require data
+    Success,
+    /// RPM
+    Rpm(u16),
+}
+
+/// Device ID new type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceId(pub u8);
+
+/// Fan device struct
+pub struct Device {
+    /// Intrusive list node allowing Device to be contained in a list
+    node: Node,
+    /// Device ID
+    id: DeviceId,
+    /// Channel for IPC requests and responses
+    ipc: ipc::Channel<NoopRawMutex, Request, Response>,
+}
+
+impl Device {
+    /// Create a new sensor device
+    pub fn new(id: DeviceId) -> Self {
+        Self {
+            node: Node::uninit(),
+            id,
+            ipc: ipc::Channel::new(),
+        }
+    }
+
+    /// Get the device ID
+    pub fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    /// Execute request and wait for response
+    pub async fn execute_request(&self, request: Request) -> Response {
+        self.ipc.execute(request).await
+    }
+}
+
+impl intrusive_list::NodeContainer for Device {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+// Internal fan state
+struct State {
+    samples: SampleBuf<u16, BUFFER_SIZE>,
+    period: u64,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            samples: SampleBuf::create(),
+            period: 200,
+        }
+    }
+}
+
+/// Fan struct containing device for comms and driver
+pub struct Fan<T: fan_traits::Fan + fan_traits::RpmSense> {
+    /// Underlying device
+    device: Device,
+    /// Underlying driver
+    driver: Mutex<NoopRawMutex, T>,
+    /// Underlying fan state
+    state: Mutex<NoopRawMutex, State>,
+}
+
+impl<T: fan_traits::Fan + fan_traits::RpmSense> Fan<T> {
+    /// New fan
+    pub fn new(id: DeviceId, driver: T) -> Self {
+        Self {
+            device: Device::new(id),
+            driver: Mutex::new(driver),
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    /// Retrieve a reference to underlying device for registration with services
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    /// Wait for fan to receive a request, process it, and send a response
+    pub async fn wait_and_process(&self) {
+        let request = self.wait_request().await;
+        let response = self.process_request(request.command).await;
+        request.respond(response);
+    }
+
+    /// Wait for fan to receive a request
+    pub async fn wait_request(&self) -> ipc::Request<'_, NoopRawMutex, Request, Response> {
+        self.device.ipc.receive().await
+    }
+
+    /// Process fan request
+    pub async fn process_request(&self, request: Request) -> Response {
+        match request {
+            Request::GetRpm => {
+                let rpm = self.state.lock().await.samples.recent();
+                Ok(ResponseData::Rpm(rpm))
+            }
+            Request::GetAvgRpm => {
+                let rpm = self.state.lock().await.samples.average();
+                Ok(ResponseData::Rpm(rpm))
+            }
+            Request::SetRpm(rpm) => {
+                self.driver
+                    .lock()
+                    .await
+                    .set_speed_rpm(rpm)
+                    .await
+                    .map_err(|_| Error::Hardware)?;
+                Ok(ResponseData::Success)
+            }
+            Request::GetMinRpm => {
+                let min_rpm = self.driver.lock().await.min_rpm();
+                Ok(ResponseData::Rpm(min_rpm))
+            }
+            Request::GetMaxRpm => {
+                let max_rpm = self.driver.lock().await.max_rpm();
+                Ok(ResponseData::Rpm(max_rpm))
+            }
+            Request::SetSamplingPeriod(period) => {
+                self.state.lock().await.period = period;
+                Ok(ResponseData::Success)
+            }
+        }
+    }
+
+    /// Waits for a IPC request, then processes it
+    pub async fn handle_rx(&self) {
+        loop {
+            self.wait_and_process().await;
+        }
+    }
+
+    /// Periodically samples RPM from physical fan and caches it
+    pub async fn handle_sampling(&self) {
+        loop {
+            match self.driver.lock().await.rpm().await {
+                Ok(rpm) => self.state.lock().await.samples.push(rpm),
+                Err(e) => error!("Error sampling rpm: {:?}", e.kind()),
+            }
+
+            let period = self.state.lock().await.period;
+            Timer::after_millis(period).await;
+        }
+    }
+}
+
+/// This is a helper macro for wrapping and spawning the various tasks since currently tasks cannot be generic
+#[macro_export]
+macro_rules! impl_fan_task {
+    ($fan_task_name:ident, $fan_type:ty) => {
+        #[embassy_executor::task]
+        pub async fn $fan_task_name(fan: &'static $crate::fan::Fan<$fan_type>) {
+            embedded_services::info!("Fan task started!");
+
+            let _ = embassy_futures::select::select(fan.handle_rx(), fan.handle_sampling()).await;
+        }
+    };
+}

--- a/thermal-service/src/lib.rs
+++ b/thermal-service/src/lib.rs
@@ -1,0 +1,140 @@
+//! Thermal service
+#![no_std]
+
+pub use context::*;
+use default_handler::DefaultHandler;
+use embassy_sync::once_lock::OnceLock;
+use embedded_services::{comms, error, info};
+
+mod context;
+pub mod default_handler;
+pub mod fan;
+pub mod mptf;
+pub mod sensor;
+pub mod utils;
+
+/// Request to the thermal service wrapping an MPTF request and sender ID
+#[derive(Debug, Clone, Copy)]
+pub struct Request {
+    pub mptf: mptf::Request,
+    pub from: Option<comms::EndpointID>,
+}
+
+impl Request {
+    /// Create new thermal service request
+    pub fn new(request: mptf::Request, from: Option<comms::EndpointID>) -> Self {
+        Self { mptf: request, from }
+    }
+}
+
+struct Service<M: mptf::Handler + 'static> {
+    context: context::ContextToken,
+    endpoint: comms::Endpoint,
+    mptf_handler: &'static M,
+}
+
+impl<M: mptf::Handler> Service<M> {
+    fn new(mptf_handler: &'static M) -> Option<Self> {
+        Some(Self {
+            context: context::ContextToken::create()?,
+            endpoint: comms::Endpoint::uninit(comms::EndpointID::Internal(comms::Internal::Thermal)),
+            mptf_handler,
+        })
+    }
+
+    async fn process_request(&self, request: mptf::Request) -> mptf::Response {
+        match request {
+            mptf::Request::GetTmp(tzid) => self.mptf_handler.get_tmp(tzid).await,
+            mptf::Request::GetThrs(tzid) => self.mptf_handler.get_thrs(tzid).await,
+            mptf::Request::SetThrs(tzid, timeout, low, high) => {
+                self.mptf_handler.set_thrs(tzid, timeout, low, high).await
+            }
+            mptf::Request::SetScp(tzid, mode, acoustic_lim, power_lim) => {
+                self.mptf_handler.set_scp(tzid, mode, acoustic_lim, power_lim).await
+            }
+            mptf::Request::GetVar(uid) => self.mptf_handler.get_var(uid).await,
+            mptf::Request::SetVar(uid, val) => self.mptf_handler.set_var(uid, val).await,
+        }
+    }
+
+    async fn wait_and_process(&self) {
+        let request = self.context.wait_request().await;
+        let response = self.process_request(request.command.mptf).await;
+        request.respond(response);
+    }
+
+    async fn wait_and_process_comms(&self) {
+        let request = self.context.wait_comms_request().await;
+
+        // Essentially convert a sync comms request into an async IPC request
+        let response = context::execute_service_request(request).await;
+
+        // And then route the response back to the service that made the request
+        let original_sender = request.from.expect("Request guaranteed to have from field");
+        send_service_msg(original_sender, &response).await
+    }
+}
+
+impl<M: mptf::Handler> comms::MailboxDelegate for Service<M> {
+    fn receive(&self, message: &comms::Message) -> Result<(), comms::MailboxDelegateError> {
+        // If standard MPTF request, send to comms channel for later async processing
+        if let Some(&msg) = message.data.get::<mptf::Request>() {
+            self.context
+                .send_request_from_comms(Request {
+                    mptf: msg,
+                    from: Some(message.from),
+                })
+                .map_err(|_| comms::MailboxDelegateError::BufferFull)
+        } else {
+            Err(comms::MailboxDelegateError::InvalidData)
+        }
+    }
+}
+
+// Just one instance of the service should be running
+// TODO: Use Macro to make this all generic over MPTF Handler and task
+static SERVICE: OnceLock<Service<DefaultHandler>> = OnceLock::new();
+
+/// This must be called to initialize the Thermal service and spawn additional tasks
+pub async fn init(spawner: embassy_executor::Spawner, handler: &'static DefaultHandler) {
+    info!("Starting thermal service task");
+    let service = SERVICE.get_or_init(|| Service::new(handler).expect("Thermal service singleton already initialized"));
+
+    if comms::register_endpoint(service, &service.endpoint).await.is_err() {
+        error!("Failed to register thermal service endpoint");
+        return;
+    }
+
+    // Spawn the tasks for receiving thermal messages
+    spawner.must_spawn(rx_task());
+    spawner.must_spawn(comms_rx_task());
+}
+
+/// Used to send messages to other services from the Thermal service,
+/// such as notifying the Host of thresholds crossed or the Power service if CRT TEMP is reached.
+pub async fn send_service_msg(to: comms::EndpointID, data: &impl embedded_services::Any) {
+    let service = SERVICE.get().await;
+
+    // TODO: When this gets updated to return error, handle retrying send on failure
+    service.endpoint.send(to, data).await.expect("Infallible");
+}
+
+// This task exists solely to listen for incoming requests and then process them appropriately
+#[embassy_executor::task]
+async fn rx_task() {
+    let service = SERVICE.get().await;
+
+    loop {
+        service.wait_and_process().await;
+    }
+}
+
+// This task exists solely to listen for incoming requests from comms service and then process them appropriately
+#[embassy_executor::task]
+async fn comms_rx_task() {
+    let service = SERVICE.get().await;
+
+    loop {
+        service.wait_and_process_comms().await;
+    }
+}

--- a/thermal-service/src/mptf.rs
+++ b/thermal-service/src/mptf.rs
@@ -1,0 +1,92 @@
+//! Definitions for standard MPTF messages the generic Thermal service can expect
+//!
+//! Transport services such as eSPI and SSH would need to ensure messages are sent to the Thermal service in this format.
+//!
+//! This interface is subject to change as the eSPI OOB service is developed
+use core::future::Future;
+
+/// Standard 32-bit DWORD
+pub type Dword = u32;
+
+/// Thermalzone ID
+pub type TzId = u8;
+
+/// Time in miliseconds
+pub type Miliseconds = Dword;
+
+/// MPTF expects temperatures in tenth Kelvins
+pub type DeciKelvin = Dword;
+
+/// UID underlying representation
+pub type Uid = u128;
+
+/// Helper MPTF Response type
+pub type Response = Result<ResponseData, Error>;
+
+/// Error codes expected by MPTF
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    InvalidParameter,
+    UnsupportedRevision,
+    HardwareError,
+}
+
+impl From<Error> for u8 {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::InvalidParameter => 1,
+            Error::UnsupportedRevision => 2,
+            Error::HardwareError => 3,
+        }
+    }
+}
+
+/// Standard MPTF requests expected by the thermal subsystem
+#[derive(Debug, Clone, Copy)]
+pub enum Request {
+    // EC_THM_GET_TMP
+    GetTmp(TzId),
+    // EC_THM_GET_THRS
+    GetThrs(TzId),
+    // EC_THM_SET_THRS
+    SetThrs(TzId, Miliseconds, DeciKelvin, DeciKelvin),
+    // EC_THM_SET_SCP
+    SetScp(TzId, Dword, Dword, Dword),
+    // EC_THM_GET_VAR
+    GetVar(Uid),
+    // EC_THM_SET_VAR
+    SetVar(Uid, Dword),
+}
+
+/// Data returned by thermal subsystem in response to MPTF requests  
+#[derive(Debug, Clone, Copy)]
+pub enum ResponseData {
+    // Standard command
+    GetTmp(DeciKelvin),
+    GetThrs(Miliseconds, DeciKelvin, DeciKelvin),
+    SetThrs,
+    SetScp,
+    GetVar(Uid, Dword),
+    SetVar,
+}
+
+/// Notifications to Host
+#[derive(Debug, Clone, Copy)]
+pub enum Notify {
+    Threshold,
+    Critical,
+    ProcHot,
+}
+
+/// Trait capturing the standard MPTF input/output interface for thermal subsystem
+pub trait Handler {
+    fn get_tmp(&self, tzid: TzId) -> impl Future<Output = Response>;
+    fn get_thrs(&self, tzid: TzId) -> impl Future<Output = Response>;
+    fn set_thrs(&self, tzid: TzId, timeout: Dword, low: DeciKelvin, high: DeciKelvin)
+        -> impl Future<Output = Response>;
+    fn set_scp(&self, tzid: TzId, mode: Dword, acoustic_lim: Dword, power_lim: Dword)
+        -> impl Future<Output = Response>;
+    fn get_var(&self, uid: Uid) -> impl Future<Output = Response>;
+    fn set_var(&self, uid: Uid, value: Dword) -> impl Future<Output = Response>;
+}

--- a/thermal-service/src/sensor.rs
+++ b/thermal-service/src/sensor.rs
@@ -1,0 +1,322 @@
+//! Sensor Device
+use crate::utils::SampleBuf;
+use core::sync::atomic::AtomicBool;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use embassy_sync::signal::Signal;
+use embassy_time::Timer;
+use embedded_sensors_hal_async::sensor::Error as HardwareError;
+use embedded_sensors_hal_async::temperature::{DegreesCelsius, TemperatureSensor, TemperatureThresholdSet};
+use embedded_services::error;
+use embedded_services::ipc::deferred as ipc;
+use embedded_services::{intrusive_list, Node};
+
+// Temperature sample buffer size
+const BUFFER_SIZE: usize = 16;
+
+/// Convenience type for Sensor response result
+pub type Response = Result<ResponseData, Error>;
+
+/// Sensor error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Invalid request
+    InvalidRequest,
+    /// Device encountered a hardware failure
+    Hardware,
+}
+
+/// Sensor request
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Request {
+    /// Most recent temperature measurement
+    GetTemp,
+    /// Average temperature measurement
+    GetAvgTemp,
+    /// Set low alert thresholds (in degrees Celsius)
+    SetAlertLow(DegreesCelsius),
+    /// Set high alert thresholds (in degrees Celsius)
+    SetAlertHigh(DegreesCelsius),
+    /// Set temperature sampling period (in ms)
+    SetSamplingPeriod(u64),
+    /// Enable sensor sampling
+    Enable,
+    /// Disable sensor sampling
+    Disable,
+}
+
+/// Sensor response
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    /// Response for any request that is successful but does not require data
+    Success,
+    /// Temperature (in degrees Celsisus)
+    Temp(DegreesCelsius),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Alert {
+    /// High threshold was crossed
+    ThresholdLow,
+    /// Low threshold was crossed
+    ThresholdHigh,
+}
+
+/// Device ID new type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceId(pub u8);
+
+/// Sensor device struct
+pub struct Device {
+    /// Intrusive list node allowing Device to be contained in a list
+    node: Node,
+    /// Device ID
+    id: DeviceId,
+    /// Channel for IPC requests and responses
+    ipc: ipc::Channel<NoopRawMutex, Request, Response>,
+    /// Signal for threshold alerts from this device
+    alert: Signal<NoopRawMutex, Alert>,
+    /// Signal for enable
+    enable: Signal<NoopRawMutex, ()>,
+}
+
+impl Device {
+    /// Create a new sensor device
+    pub fn new(id: DeviceId) -> Self {
+        Self {
+            node: Node::uninit(),
+            id,
+            ipc: ipc::Channel::new(),
+            alert: Signal::new(),
+            enable: Signal::new(),
+        }
+    }
+
+    /// Get the device ID
+    pub fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    /// Execute request and wait for response
+    pub async fn execute_request(&self, request: Request) -> Response {
+        self.ipc.execute(request).await
+    }
+
+    /// Wait for sensor to generate an alert
+    pub async fn wait_alert(&self) -> Alert {
+        self.alert.wait().await
+    }
+}
+
+impl intrusive_list::NodeContainer for Device {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+// Internal sensor state
+struct State {
+    samples: SampleBuf<DegreesCelsius, BUFFER_SIZE>,
+    period: u64,
+    enabled: AtomicBool,
+    alert_low: DegreesCelsius,
+    alert_high: DegreesCelsius,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            samples: SampleBuf::create(),
+            period: 200,
+            enabled: AtomicBool::new(true),
+            alert_low: DegreesCelsius::MAX,
+            alert_high: DegreesCelsius::MAX,
+        }
+    }
+}
+
+/// Wrapper binding a communication device, hardware driver, and additional state.
+pub struct Sensor<T: TemperatureSensor + TemperatureThresholdSet> {
+    /// Underlying device
+    device: Device,
+    /// Underlying driver
+    driver: Mutex<NoopRawMutex, T>,
+    /// Underlying sensor state
+    state: Mutex<NoopRawMutex, State>,
+}
+
+impl<T: TemperatureSensor + TemperatureThresholdSet> Sensor<T> {
+    /// New sensor wrapper
+    pub fn new(id: DeviceId, controller: T) -> Self {
+        Self {
+            device: Device::new(id),
+            driver: Mutex::new(controller),
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    /// Retrieve a reference to underlying device for registtation with services
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    // Enable sensor sampling
+    async fn enable(&self) {
+        self.state
+            .lock()
+            .await
+            .enabled
+            .store(true, core::sync::atomic::Ordering::SeqCst);
+
+        // Signal to wake sensor
+        self.device.enable.signal(());
+    }
+
+    // Disable sensor sampling
+    async fn disable(&self) {
+        self.state
+            .lock()
+            .await
+            .enabled
+            .store(false, core::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Wait for sensor to receive a request, process it, and send a response
+    async fn wait_and_process(&self) {
+        let request = self.wait_request().await;
+        let response = self.process_request(request.command).await;
+        request.respond(response);
+    }
+
+    /// Wait for sensor to receive a request
+    pub async fn wait_request(&self) -> ipc::Request<'_, NoopRawMutex, Request, Response> {
+        self.device.ipc.receive().await
+    }
+
+    /// Process sensor request
+    pub async fn process_request(&self, request: Request) -> Response {
+        match request {
+            Request::GetTemp => {
+                let temp = self.state.lock().await.samples.recent();
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::GetAvgTemp => {
+                let temp = self.state.lock().await.samples.average();
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::SetAlertLow(low) => {
+                self.driver
+                    .lock()
+                    .await
+                    .set_temperature_threshold_low(low)
+                    .await
+                    .map_err(|_| Error::Hardware)?;
+
+                self.state.lock().await.alert_low = low;
+                Ok(ResponseData::Success)
+            }
+            Request::SetAlertHigh(high) => {
+                self.driver
+                    .lock()
+                    .await
+                    .set_temperature_threshold_high(high)
+                    .await
+                    .map_err(|_| Error::Hardware)?;
+
+                self.state.lock().await.alert_high = high;
+                Ok(ResponseData::Success)
+            }
+            Request::SetSamplingPeriod(period) => {
+                self.state.lock().await.period = period;
+                Ok(ResponseData::Success)
+            }
+            Request::Enable => {
+                self.enable().await;
+                Ok(ResponseData::Success)
+            }
+            Request::Disable => {
+                self.disable().await;
+                Ok(ResponseData::Success)
+            }
+        }
+    }
+
+    pub async fn handle_rx(&self) {
+        loop {
+            self.wait_and_process().await;
+        }
+    }
+
+    /// Periodically samples temperature from physical sensor and caches it
+    pub async fn handle_sampling(&self) {
+        loop {
+            // Only sample temperature if enabled
+            if self
+                .state
+                .lock()
+                .await
+                .enabled
+                .load(core::sync::atomic::Ordering::SeqCst)
+            {
+                match self.driver.lock().await.temperature().await {
+                    Ok(temp) => self.state.lock().await.samples.push(temp),
+                    Err(e) => error!("Error sampling temperature: {:?}", e.kind()),
+                }
+
+                let period = self.state.lock().await.period;
+                Timer::after_millis(period).await;
+
+            // Otherwise sleep and wait to be re-enabled
+            } else {
+                self.device.enable.wait().await;
+            }
+        }
+    }
+
+    /// Waits for a temperature threshold interrupt to be generated then notifies alert channel
+    pub async fn handle_alert<A: embedded_hal_async::digital::Wait>(&self, mut alert_pin: A) {
+        loop {
+            if alert_pin.wait_for_falling_edge().await.is_err() {
+                error!("Error awaiting alert pin interrupt");
+            }
+
+            match self.driver.lock().await.temperature().await {
+                Ok(temp) => {
+                    let alert = if temp <= self.state.lock().await.alert_low {
+                        Alert::ThresholdLow
+                    } else {
+                        Alert::ThresholdHigh
+                    };
+
+                    self.device.alert.signal(alert);
+                }
+                Err(e) => error!("Error reading temperature after sensor alert: {:?}", e.kind()),
+            }
+        }
+    }
+}
+
+/// This is a helper macro for implementing the sensor task since tasks cannot be generic
+#[macro_export]
+macro_rules! impl_sensor_task {
+    ($sensor_task_name:ident, $sensor_type:ty, $alert_pin_type:ty) => {
+        #[embassy_executor::task]
+        pub async fn $sensor_task_name(
+            sensor: &'static $crate::sensor::Sensor<$sensor_type>,
+            mut alert_pin: $alert_pin_type,
+        ) {
+            embedded_services::info!("Sensor task started!");
+
+            let _ = embassy_futures::select::select3(
+                sensor.handle_rx(),
+                sensor.handle_sampling(),
+                sensor.handle_alert(alert_pin),
+            )
+            .await;
+        }
+    };
+}

--- a/thermal-service/src/utils.rs
+++ b/thermal-service/src/utils.rs
@@ -1,0 +1,52 @@
+//! Helpful utilities for the thermal service
+use crate::mptf;
+use heapless::Deque;
+
+/// Buffer for storing samples
+pub struct SampleBuf<T: Default + Copy + core::fmt::Debug, const N: usize> {
+    deque: Deque<T, N>,
+}
+
+impl<T: Default + Copy + core::fmt::Debug, const N: usize> SampleBuf<T, N> {
+    /// Create a new sample buffer
+    pub fn create() -> Self {
+        Self { deque: Deque::new() }
+    }
+
+    /// Insert a new sample into the buffer and evict the oldest
+    pub fn push(&mut self, sample: T) {
+        if self.deque.is_full() {
+            let _ = self.deque.pop_back();
+        }
+
+        // There will always be room in the buffer if we get here, so panic is not possible
+        self.deque.push_front(sample).expect("Will not panic");
+    }
+
+    /// Retrieve the most recent sample from the buffer
+    pub fn recent(&self) -> T {
+        *self.deque.front().unwrap_or(&T::default())
+    }
+}
+
+impl<const N: usize> SampleBuf<f32, N> {
+    pub fn average(&self) -> f32 {
+        self.deque.iter().copied().sum::<f32>() / (self.deque.len() as f32)
+    }
+}
+
+impl<const N: usize> SampleBuf<u16, N> {
+    pub fn average(&self) -> u16 {
+        self.deque.iter().copied().sum::<u16>() / (self.deque.len() as u16)
+    }
+}
+
+/// Convert deciKelvin to degrees Celsius
+pub const fn dk_to_c(dk: mptf::DeciKelvin) -> f32 {
+    (dk as f32 / 10.0) - 273.15
+}
+
+/// Convert degrees Celsius to deciKelvin
+pub const fn c_to_dk(c: f32) -> mptf::DeciKelvin {
+    ((c + 273.15) * 10.0) as mptf::DeciKelvin
+}


### PR DESCRIPTION
Initial thermal service providing:
- Abstraction over sensor and fan interfacing
- Handler for MPTF interface and default fan response logic
- Example demonstrating a simulated host sending and receiving information from the thermal service

Resolves #132 
Resolves #133 
Resolves #134 
Resolves #135 
Resolves #136 
Resolves #137 
Resolves #222 