### PR TITLE
type-c-service: Add integrated CFU support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
- "embedded-batteries-async 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embedded-batteries-async",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-services 0.1.0",
@@ -422,7 +422,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#4766cc6f9756b54bb2e25be5ba5276538ea4917b"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#4766cc6f9756b54bb2e25be5ba5276538ea4917b"
 dependencies = [
  "defmt 1.0.1",
  "log",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#4766cc6f9756b54bb2e25be5ba5276538ea4917b"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#3de660d4245062214b750d22c31b0fc0dbe82289"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#0cd2be9b9dc94b1dd50fb93edeee001c04313869"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -517,8 +517,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-sync"
-version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+version = "0.7.0"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "document-features",
 ]
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "embassy-executor",
  "heapless 0.8.0",
@@ -576,32 +576,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-batteries"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-batteries#410e2482d54b58c205a425c70d2ccf062e3ee3f3"
-dependencies = [
- "bitfield-struct",
- "embedded-hal 1.0.0",
-]
-
-[[package]]
 name = "embedded-batteries-async"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b35cd3052eaffa4d2914d07adda1b8631f9cb14300b62ce6b082b68ef926dd"
 dependencies = [
  "bitfield-struct",
- "embedded-batteries 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "embedded-hal 1.0.0",
-]
-
-[[package]]
-name = "embedded-batteries-async"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-batteries#410e2482d54b58c205a425c70d2ccf062e3ee3f3"
-dependencies = [
- "bitfield-struct",
- "embedded-batteries 0.1.0 (git+https://github.com/OpenDevicePartnership/embedded-batteries)",
+ "embedded-batteries",
  "embedded-hal 1.0.0",
 ]
 
@@ -687,7 +668,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
- "embedded-batteries-async 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-hal-async",
  "embedded-hal-nb",
@@ -707,7 +688,7 @@ dependencies = [
 [[package]]
 name = "embedded-services"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services#1ee7545bdcca3159893b85f5e1eac60d1c691bb4"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services#437a93233328685b57bd5a492a4263abd552f47d"
 dependencies = [
  "bitfield 0.17.0",
  "bitflags 2.9.0",
@@ -721,7 +702,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
- "embedded-batteries-async 0.1.0 (git+https://github.com/OpenDevicePartnership/embedded-batteries)",
+ "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-hal-async",
  "embedded-hal-nb",
@@ -1251,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.1"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services#1ee7545bdcca3159893b85f5e1eac60d1c691bb4"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services#437a93233328685b57bd5a492a4263abd552f47d"
 dependencies = [
  "embassy-executor",
  "embassy-sync",
@@ -1305,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#0ce23af6b698bdfa7ad5d7a6be4fb882d3690375"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x#5e910ad5f6d68beb7c71d6b4b90e5883ee2f00fa"
 dependencies = [
  "bincode",
  "bitfield 0.19.0",
@@ -1330,6 +1311,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
+ "embedded-cfu-protocol",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-io-async",

--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -20,6 +20,8 @@ pub enum Error {
     InvalidState(device::StateKind, device::StateKind),
     /// Invalid response
     InvalidResponse,
+    /// Busy, the device cannot respond to the request at this time
+    Busy,
     /// Timeout
     Timeout,
     /// Bus error

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -370,6 +370,23 @@ pub trait Controller {
     fn get_controller_status(
         &mut self,
     ) -> impl Future<Output = Result<ControllerStatus<'static>, Error<Self::BusError>>>;
+
+    // TODO: remove all these once we migrate to a generic FW update trait
+    // https://github.com/OpenDevicePartnership/embedded-services/issues/242
+    /// Get current FW version
+    fn get_active_fw_version(&self) -> impl Future<Output = Result<u32, Error<Self::BusError>>>;
+    /// Start a firmware update
+    fn start_fw_update(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
+    /// Abort a firmware update
+    fn abort_fw_update(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
+    /// Finalize a firmware update
+    fn finalize_fw_update(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
+    /// Write firmware update contents
+    fn write_fw_contents(
+        &mut self,
+        offset: usize,
+        data: &[u8],
+    ) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
 }
 
 /// Internal context for managing PD controllers

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -393,9 +393,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy#716160e9abe7591b171250a9029bad5ec656ac6d"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-sync",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "defmt 1.0.1",
 ]
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -487,8 +487,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-sync"
-version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+version = "0.7.0"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "document-features",
 ]
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#9409afb02e7fd46d0c3b2257a938a8bc88244f5b"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "embassy-executor",
  "heapless 0.8.0",
@@ -1165,6 +1165,7 @@ dependencies = [
  "embassy-imxrt",
  "embassy-sync",
  "embassy-time",
+ "embedded-cfu-protocol",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-services 0.1.0",
@@ -1327,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#0ce23af6b698bdfa7ad5d7a6be4fb882d3690375"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x#5e910ad5f6d68beb7c71d6b4b90e5883ee2f00fa"
 dependencies = [
  "bincode",
  "bitfield 0.19.0",
@@ -1351,6 +1352,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
+ "embedded-cfu-protocol",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-io-async",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -47,6 +47,7 @@ futures = { version = "0.3.30", default-features = false, features = [
 mimxrt600-fcb = "0.1.0"
 mimxrt685s-pac = { version = "*", features = ["rt", "critical-section"] }
 
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 embedded-services = { path = "../../embedded-service", features = ["defmt"] }
 power-button-service = { path = "../../power-button-service", features = [
     "defmt",

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -124,18 +124,18 @@ checksum = "f798d2d157e547aa99aab0967df39edd0b70307312b6f8bd2848e6abe40896e0"
 
 [[package]]
 name = "bitfield"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786e53b0c071573a28956cec19a92653e42de34c683e2f6e86c197a349fba318"
+checksum = "db1bcd90f88eabbf0cadbfb87a45bceeaebcd3b4bc9e43da379cd2ef0162590d"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07805405d3f1f3a55aab895718b488821d40458f9188059909091ae0935c344a"
+checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -361,7 +361,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embassy-executor"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#645883d8748995beb8b07f5cee93ac960f6d6a9f"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "critical-section",
  "document-features",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#645883d8748995beb8b07f5cee93ac960f6d6a9f"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#2bb9c0f10dd66f3fcc058897ade0e60415067449"
+source = "git+https://github.com/embassy-rs/embassy#b024d5e892618947f81efd72f2c4224ae830d891"
 dependencies = [
  "log",
 ]
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#645883d8748995beb8b07f5cee93ac960f6d6a9f"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#645883d8748995beb8b07f5cee93ac960f6d6a9f"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#645883d8748995beb8b07f5cee93ac960f6d6a9f"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "document-features",
 ]
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#645883d8748995beb8b07f5cee93ac960f6d6a9f"
+source = "git+https://github.com/embassy-rs/embassy#141c170db426404444a454c063c2eec07c74a1c3"
 dependencies = [
  "embassy-executor",
  "heapless 0.8.0",
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "embedded-cfu-protocol"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#2a08534a094aab2b0d4d223435e03c538d45384e"
+source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#e2734a2bf953d584b11bbaa5931919345df9bf7c"
 dependencies = [
  "embedded-io-async",
  "log",
@@ -593,7 +593,7 @@ name = "embedded-usb-pd"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#b8948c96b8c8e920c837307d30653cfd74cf80cd"
 dependencies = [
- "bitfield 0.19.0",
+ "bitfield 0.19.1",
  "embedded-hal-async",
 ]
 
@@ -787,9 +787,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1113,9 +1113,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1140,10 +1140,10 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#0ce23af6b698bdfa7ad5d7a6be4fb882d3690375"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x#5e910ad5f6d68beb7c71d6b4b90e5883ee2f00fa"
 dependencies = [
  "bincode",
- "bitfield 0.19.0",
+ "bitfield 0.19.1",
  "device-driver",
  "embassy-sync",
  "embassy-time",
@@ -1163,6 +1163,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
+ "embedded-cfu-protocol",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-io-async",
@@ -1355,18 +1356,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/type-c-service/Cargo.toml
+++ b/type-c-service/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [dependencies]
 bitfield.workspace = true
 defmt = { workspace = true, optional = true }
+embedded-cfu-protocol.workspace = true
 embassy-executor.workspace = true
 embassy-futures.workspace = true
 embassy-sync.workspace = true

--- a/type-c-service/src/wrapper/cfu.rs
+++ b/type-c-service/src/wrapper/cfu.rs
@@ -1,0 +1,287 @@
+//! CFU message bridge
+//! TODO: remove this once we have a more generic FW update implementation
+use embassy_futures::select::{select, Either};
+use embedded_cfu_protocol::protocol_definitions::*;
+use embedded_services::cfu::component::{InternalResponseData, RequestData};
+use embedded_services::type_c::controller::Controller;
+use embedded_services::{debug, error};
+
+use super::*;
+
+/// Current state of the firmware update process
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FwUpdateState {
+    /// None in progress
+    Idle,
+    /// Firmware update in progress
+    /// Contains number of ticks [`super::DEFAULT_FW_UPDATE_TICK_INTERVAL_MS`] that have passed
+    InProgress(u8),
+    /// Firmware update has failed and the device is in an unknown state
+    Recovery,
+}
+
+impl FwUpdateState {
+    /// Check if the firmware update is in progress
+    pub fn in_progress(&self) -> bool {
+        matches!(self, FwUpdateState::InProgress(_) | FwUpdateState::Recovery)
+    }
+}
+
+impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N, C, V> {
+    /// Create a new invalid FW version response
+    fn create_invalid_fw_version_response(&self) -> InternalResponseData {
+        let dev_inf = FwVerComponentInfo::new(FwVersion::new(0xffffffff), self.cfu_device.component_id());
+        let comp_info: [FwVerComponentInfo; MAX_CMPT_COUNT] = [dev_inf; MAX_CMPT_COUNT];
+        InternalResponseData::FwVersionResponse(GetFwVersionResponse {
+            header: GetFwVersionResponseHeader::new(1, GetFwVerRespHeaderByte3::NoSpecialFlags),
+            component_info: comp_info,
+        })
+    }
+
+    /// Process a GetFwVersion command
+    async fn process_get_fw_version(&self, target: &mut C) -> InternalResponseData {
+        let version = match target.get_active_fw_version().await {
+            Ok(v) => v,
+            Err(Error::Pd(e)) => {
+                error!("Failed to get active firmware version: {:?}", e);
+                return self.create_invalid_fw_version_response();
+            }
+            Err(Error::Bus(_)) => {
+                error!("Failed to get active firmware version, bus error");
+                return self.create_invalid_fw_version_response();
+            }
+        };
+
+        let dev_inf = FwVerComponentInfo::new(FwVersion::new(version), self.cfu_device.component_id());
+        let comp_info: [FwVerComponentInfo; MAX_CMPT_COUNT] = [dev_inf; MAX_CMPT_COUNT];
+        InternalResponseData::FwVersionResponse(GetFwVersionResponse {
+            header: GetFwVersionResponseHeader::new(1, GetFwVerRespHeaderByte3::NoSpecialFlags),
+            component_info: comp_info,
+        })
+    }
+
+    /// Create an offer rejection response
+    fn create_offer_rejection() -> InternalResponseData {
+        InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+            HostToken::Driver,
+            OfferRejectReason::InvalidComponent,
+            OfferStatus::Reject,
+        ))
+    }
+
+    /// Process a GiveOffer command
+    async fn process_give_offer(&self, target: &mut C, offer: &FwUpdateOffer) -> InternalResponseData {
+        if offer.component_info.component_id != self.cfu_device.component_id() {
+            return Self::create_offer_rejection();
+        }
+
+        let version = match target.get_active_fw_version().await {
+            Ok(v) => v,
+            Err(Error::Pd(e)) => {
+                error!("Failed to get active firmware version: {:?}", e);
+                return Self::create_offer_rejection();
+            }
+            Err(Error::Bus(_)) => {
+                error!("Failed to get active firmware version, bus error");
+                return Self::create_offer_rejection();
+            }
+        };
+
+        InternalResponseData::OfferResponse(self.fw_version_validator.validate(FwVersion::new(version), offer))
+    }
+
+    /// Process a GiveContent command
+    async fn process_give_content(
+        &self,
+        controller: &mut C,
+        state: &mut InternalState,
+        content: &FwUpdateContentCommand,
+    ) -> InternalResponseData {
+        let data = &content.data[0..content.header.data_length as usize];
+        debug!("Got content {:#?}", content);
+        if content.header.flags & FW_UPDATE_FLAG_FIRST_BLOCK != 0 {
+            debug!("Got first block");
+
+            // Need to start the update
+            state.fw_update_ticker.reset();
+            match controller.start_fw_update().await {
+                Ok(_) => {
+                    debug!("FW update started successfully");
+                }
+                Err(Error::Pd(e)) => {
+                    error!("Failed to start FW update: {:?}", e);
+                    state.fw_update_state = FwUpdateState::Recovery;
+                    return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                        content.header.sequence_num,
+                        CfuUpdateContentResponseStatus::ErrorPrepare,
+                    ));
+                }
+                Err(Error::Bus(_)) => {
+                    error!("Failed to start FW update, bus error");
+                    state.fw_update_state = FwUpdateState::Recovery;
+                    return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                        content.header.sequence_num,
+                        CfuUpdateContentResponseStatus::ErrorPrepare,
+                    ));
+                }
+            }
+
+            state.fw_update_state = FwUpdateState::InProgress(0);
+        }
+
+        match controller
+            .write_fw_contents(content.header.firmware_address as usize, data)
+            .await
+        {
+            Ok(_) => {
+                debug!("Block written successfully");
+            }
+            Err(Error::Pd(e)) => {
+                error!("Failed to write block: {:?}", e);
+                return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    content.header.sequence_num,
+                    CfuUpdateContentResponseStatus::ErrorWrite,
+                ));
+            }
+            Err(Error::Bus(_)) => {
+                error!("Failed to write block, bus error");
+                return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    content.header.sequence_num,
+                    CfuUpdateContentResponseStatus::ErrorWrite,
+                ));
+            }
+        }
+
+        if content.header.flags & FW_UPDATE_FLAG_LAST_BLOCK != 0 {
+            match controller.finalize_fw_update().await {
+                Ok(_) => {
+                    debug!("FW update finalized successfully");
+                    state.fw_update_state = FwUpdateState::Idle;
+                }
+                Err(Error::Pd(e)) => {
+                    error!("Failed to finalize FW update: {:?}", e);
+                    state.fw_update_state = FwUpdateState::Recovery;
+                    return Self::create_offer_rejection();
+                }
+                Err(Error::Bus(_)) => {
+                    error!("Failed to finalize FW update, bus error");
+                    state.fw_update_state = FwUpdateState::Recovery;
+                    return Self::create_offer_rejection();
+                }
+            }
+        }
+
+        InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+            content.header.sequence_num,
+            CfuUpdateContentResponseStatus::Success,
+        ))
+    }
+
+    /// Process a CFU tick
+    pub async fn process_cfu_tick(&self, controller: &mut C, state: &mut InternalState) {
+        match state.fw_update_state {
+            FwUpdateState::Idle => {
+                // No FW update in progress, nothing to do
+                return;
+            }
+            FwUpdateState::InProgress(ticks) => {
+                if ticks + 1 < DEFAULT_FW_UPDATE_TIMEOUT_TICKS {
+                    trace!("CFU tick: {}", ticks);
+                    state.fw_update_state = FwUpdateState::InProgress(ticks + 1);
+                    return;
+                } else {
+                    error!("FW update timed out after {} ticks", ticks);
+                }
+            }
+            FwUpdateState::Recovery => {
+                // Continue recovery process
+            }
+        };
+
+        // Update timed out, attempt to exit the FW update
+        state.fw_update_state = FwUpdateState::Recovery;
+        match controller.abort_fw_update().await {
+            Ok(_) => {
+                debug!("FW update aborted successfully");
+            }
+            Err(Error::Pd(e)) => {
+                error!("Failed to abort FW update: {:?}", e);
+                return;
+            }
+            Err(Error::Bus(_)) => {
+                error!("Failed to abort FW update, bus error");
+                return;
+            }
+        }
+
+        state.fw_update_state = FwUpdateState::Idle;
+    }
+
+    /// Process a CFU command
+    pub async fn process_cfu_command(
+        &self,
+        controller: &mut C,
+        state: &mut InternalState,
+        command: &RequestData,
+    ) -> InternalResponseData {
+        if state.fw_update_state == FwUpdateState::Recovery {
+            debug!("FW update in recovery state, rejecting command");
+            return InternalResponseData::ComponentBusy;
+        }
+
+        match command {
+            RequestData::FwVersionRequest => {
+                debug!("Got FwVersionRequest");
+                self.process_get_fw_version(controller).await
+            }
+            RequestData::GiveOffer(offer) => {
+                debug!("Got GiveOffer");
+                self.process_give_offer(controller, offer).await
+            }
+            RequestData::GiveContent(content) => {
+                debug!("Got GiveContent");
+                self.process_give_content(controller, state, content).await
+            }
+            RequestData::FinalizeUpdate => {
+                debug!("Got FinalizeUpdate");
+                InternalResponseData::ComponentPrepared
+            }
+            RequestData::PrepareComponentForUpdate => {
+                debug!("Got PrepareComponentForUpdate");
+                InternalResponseData::ComponentPrepared
+            }
+        }
+    }
+
+    /// Sends a CFU response to the command
+    pub async fn send_cfu_response(&self, response: InternalResponseData) {
+        self.cfu_device.send_response(response).await;
+    }
+
+    /// Wait for a CFU command
+    ///
+    /// Returns None if the FW update ticker has ticked
+    pub async fn wait_cfu_command(&self, state: &mut InternalState) -> Option<RequestData> {
+        match state.fw_update_state {
+            FwUpdateState::Idle => {
+                // No FW update in progress, just wait for a command
+                Some(self.cfu_device.wait_request().await)
+            }
+            FwUpdateState::InProgress(_) => {
+                match select(self.cfu_device.wait_request(), state.fw_update_ticker.next()).await {
+                    Either::First(command) => Some(command),
+                    Either::Second(_) => {
+                        debug!("FW update ticker ticked");
+                        None
+                    }
+                }
+            }
+            FwUpdateState::Recovery => {
+                // Recovery state, wait for the next attempt to recover the device
+                state.fw_update_ticker.next().await;
+                debug!("FW update ticker ticked");
+                None
+            }
+        }
+    }
+}

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -3,14 +3,17 @@
 use core::array::from_fn;
 use core::cell::{Cell, RefCell};
 
-use embassy_futures::select::{select3, select_array, Either3};
+use embassy_futures::select::{select4, select_array, Either4};
+use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferResponse, FwVersion};
+use embedded_services::cfu::component::CfuDevice;
 use embedded_services::power::policy::device::StateKind;
 use embedded_services::power::policy::{self, action};
 use embedded_services::type_c::controller::{self, Controller, PortStatus};
 use embedded_services::type_c::event::{PortEventFlags, PortEventKind};
-use embedded_services::{error, info, trace, warn};
+use embedded_services::{debug, error, info, trace, warn};
 use embedded_usb_pd::{Error, PdError, PortId as LocalPortId};
 
+mod cfu;
 mod pd;
 mod power;
 
@@ -18,31 +21,79 @@ mod power;
 /// This ensures we don't try to sink from something like a phone
 const DUAL_ROLE_CONSUMER_THRESHOLD_MW: u32 = 15000;
 
+/// Base interval for checking for FW update timeouts and recovery attempts
+pub const DEFAULT_FW_UPDATE_TICK_INTERVAL_MS: u64 = 5000;
+/// Default number of ticks before we consider a firmware update to have timed out
+/// 300 seconds at 5 seconds per tick
+pub const DEFAULT_FW_UPDATE_TIMEOUT_TICKS: u8 = 60;
+
+/// Internal wrapper state
+pub struct InternalState {
+    /// If we're currently doing a firmware update
+    pub fw_update_state: cfu::FwUpdateState,
+    /// FW update ticker used to check for timeouts and recovery attempts
+    fw_update_ticker: embassy_time::Ticker,
+}
+
+impl Default for InternalState {
+    fn default() -> Self {
+        Self {
+            fw_update_state: cfu::FwUpdateState::Idle,
+            fw_update_ticker: embassy_time::Ticker::every(embassy_time::Duration::from_millis(
+                DEFAULT_FW_UPDATE_TICK_INTERVAL_MS,
+            )),
+        }
+    }
+}
+
+/// Trait for validating firmware versions before applying an update
+// TODO: remove this once we have a better framework for OEM customization
+// See https://github.com/OpenDevicePartnership/embedded-services/issues/326
+pub trait FwOfferValidator {
+    /// Determine if we are accepting the firmware update offer, returns a CFU offer response
+    fn validate(&self, current: FwVersion, offer: &FwUpdateOffer) -> FwUpdateOfferResponse;
+}
+
 /// Takes an implementation of the `Controller` trait and wraps it with logic to handle
 /// message passing and power-policy integration.
-pub struct ControllerWrapper<'a, const N: usize, C: Controller> {
+pub struct ControllerWrapper<'a, const N: usize, C: Controller, V: FwOfferValidator> {
     /// PD controller to interface with PD service
     pd_controller: controller::Device<'a>,
     /// Power policy devices to interface with power policy service
     power: [policy::device::Device; N],
+    /// CFU device to interface with firmware update service
+    cfu_device: CfuDevice,
+    /// Internal state for the wrapper
+    state: RefCell<InternalState>,
     controller: RefCell<C>,
     active_events: [Cell<PortEventKind>; N],
+    /// Trait object for validating firmware versions
+    fw_version_validator: V,
 }
 
-impl<'a, const N: usize, C: Controller> ControllerWrapper<'a, N, C> {
+impl<'a, const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'a, N, C, V> {
     /// Create a new controller wrapper
-    pub fn new(pd_controller: controller::Device<'a>, power: [policy::device::Device; N], controller: C) -> Self {
+    pub fn new(
+        pd_controller: controller::Device<'a>,
+        power: [policy::device::Device; N],
+        cfu_device: CfuDevice,
+        controller: C,
+        fw_version_validator: V,
+    ) -> Self {
         Self {
             pd_controller,
             power,
+            cfu_device,
+            state: RefCell::new(Default::default()),
             controller: RefCell::new(controller),
             active_events: [const { Cell::new(PortEventKind::none()) }; N],
+            fw_version_validator,
         }
     }
 
     /// Ensure the software state is in sync with the hardware state
     #[allow(clippy::await_holding_refcell_ref)]
-    async fn sync_state(&self) -> Result<(), Error<C::BusError>> {
+    async fn sync_state(&self) -> Result<(), Error<<C as Controller>::BusError>> {
         let mut controller = self.controller.borrow_mut();
         controller.sync_state().await
     }
@@ -54,7 +105,7 @@ impl<'a, const N: usize, C: Controller> ControllerWrapper<'a, N, C> {
         power: &policy::device::Device,
         port: LocalPortId,
         status: &PortStatus,
-    ) -> Result<(), Error<C::BusError>> {
+    ) -> Result<(), Error<<C as Controller>::BusError>> {
         if port.0 > N as u8 {
             error!("Invalid port {}", port.0);
             return PdError::InvalidPort.into();
@@ -96,8 +147,14 @@ impl<'a, const N: usize, C: Controller> ControllerWrapper<'a, N, C> {
 
     /// Process port events
     /// None of the event processing functions return errors to allow processing to continue for other ports on a controller
-    async fn process_event(&self, controller: &mut C) {
+    async fn process_event(&self, controller: &mut C, state: &mut InternalState) {
         let mut port_events = PortEventFlags::none();
+
+        if state.fw_update_state.in_progress() {
+            // Don't process events while firmware update is in progress
+            debug!("Firmware update in progress, ignoring port events");
+            return;
+        }
 
         for port in 0..N {
             let local_port_id = LocalPortId(port as u8);
@@ -182,32 +239,46 @@ impl<'a, const N: usize, C: Controller> ControllerWrapper<'a, N, C> {
     #[allow(clippy::await_holding_refcell_ref)]
     pub async fn process(&self) {
         let mut controller = self.controller.borrow_mut();
-        match select3(
+        let mut state = self.state.borrow_mut();
+        match select4(
             controller.wait_port_event(),
             self.wait_power_command(),
             self.pd_controller.receive(),
+            self.wait_cfu_command(&mut state),
         )
         .await
         {
-            Either3::First(r) => match r {
-                Ok(_) => self.process_event(&mut controller).await,
+            Either4::First(r) => match r {
+                Ok(_) => self.process_event(&mut controller, &mut state).await,
                 Err(_) => error!("Error waiting for port event"),
             },
-            Either3::Second((request, port)) => {
+            Either4::Second((request, port)) => {
                 let response = self
-                    .process_power_command(&mut controller, port, &request.command)
+                    .process_power_command(&mut controller, &mut state, port, &request.command)
                     .await;
                 request.respond(response);
             }
-            Either3::Third(request) => {
-                let response = self.process_pd_command(&mut controller, &request.command).await;
+            Either4::Third(request) => {
+                let response = self
+                    .process_pd_command(&mut controller, &mut state, &request.command)
+                    .await;
                 request.respond(response);
             }
+            Either4::Fourth(request) => match request {
+                Some(request) => {
+                    let response = self.process_cfu_command(&mut controller, &mut state, &request).await;
+                    self.send_cfu_response(response).await;
+                }
+                None => {
+                    // FW Update tick, process timeouts and recovery attempts
+                    self.process_cfu_tick(&mut controller, &mut state).await;
+                }
+            },
         }
     }
 
     /// Register all devices with their respective services
-    pub async fn register(&'static self) -> Result<(), Error<C::BusError>> {
+    pub async fn register(&'static self) -> Result<(), Error<<C as Controller>::BusError>> {
         for device in &self.power {
             policy::register_device(device).await.map_err(|_| {
                 error!(
@@ -226,6 +297,14 @@ impl<'a, const N: usize, C: Controller> ControllerWrapper<'a, N, C> {
                     "Controller{}: Failed to register PD controller",
                     self.pd_controller.id().0
                 );
+                Error::Pd(PdError::Failed)
+            })?;
+
+        //TODO: Remove when we have a more general framework in place
+        embedded_services::cfu::register_device(&self.cfu_device)
+            .await
+            .map_err(|_| {
+                error!("Controller{}: Failed to register CFU device", self.pd_controller.id().0);
                 Error::Pd(PdError::Failed)
             })?;
 


### PR DESCRIPTION
This PR adds CFU support directly integrated within the existing type-C code. This is meant to get this functionality in for the moment while work on more general FW update support continues.