### PR TITLE
Fix usbc charge fail issue

### DIFF
--- a/embedded-service/src/power/policy/action/device.rs
+++ b/embedded-service/src/power/policy/action/device.rs
@@ -69,7 +69,7 @@ impl<'a, S: Kind> Device<'a, S> {
         capability: Option<PowerCapability>,
     ) -> Result<(), Error> {
         info!(
-            "Device {} consume capability updated {:#?}",
+            "Device {} consume capability updated: {:#?}",
             self.device.id().0,
             capability
         );

--- a/embedded-service/src/power/policy/action/policy.rs
+++ b/embedded-service/src/power/policy/action/policy.rs
@@ -66,12 +66,12 @@ impl<'a, S: Kind> Policy<'a, S> {
         }
     }
 
-    /// Common connect provider function used by multiple states
-    async fn connect_provider_internal_no_timeout(&self, capability: PowerCapability) -> Result<(), Error> {
+    /// Common connect as provider function used by multiple states
+    async fn connect_as_provider_internal_no_timeout(&self, capability: PowerCapability) -> Result<(), Error> {
         info!("Device {} connecting provider", self.device.id().0);
 
         self.device
-            .execute_device_command(device::CommandData::ConnectProvider(capability))
+            .execute_device_command(device::CommandData::ConnectAsProvider(capability))
             .await?
             .complete_or_err()?;
 
@@ -84,7 +84,7 @@ impl<'a, S: Kind> Policy<'a, S> {
 
     /// Common connect provider function used by multiple states
     async fn connect_provider_internal(&self, capability: PowerCapability) -> Result<(), Error> {
-        match with_timeout(DEFAULT_TIMEOUT, self.connect_provider_internal_no_timeout(capability)).await {
+        match with_timeout(DEFAULT_TIMEOUT, self.connect_as_provider_internal_no_timeout(capability)).await {
             Ok(r) => r,
             Err(TimeoutError) => Err(Error::Timeout),
         }
@@ -96,14 +96,14 @@ impl Policy<'_, Detached> {}
 
 impl<'a> Policy<'a, Idle> {
     /// Connect this device as a consumer
-    pub async fn connect_consumer_no_timeout(
+    pub async fn connect_as_consumer_no_timeout(
         self,
         capability: PowerCapability,
     ) -> Result<Policy<'a, ConnectedConsumer>, Error> {
-        info!("Device {} connecting consumer", self.device.id().0);
+        info!("Device {} connecting as consumer", self.device.id().0);
 
         self.device
-            .execute_device_command(device::CommandData::ConnectConsumer(capability))
+            .execute_device_command(device::CommandData::ConnectAsConsumer(capability))
             .await?
             .complete_or_err()?;
 
@@ -115,7 +115,7 @@ impl<'a> Policy<'a, Idle> {
 
     /// Connect this device as a consumer
     pub async fn connect_consumer(self, capability: PowerCapability) -> Result<Policy<'a, ConnectedConsumer>, Error> {
-        match with_timeout(DEFAULT_TIMEOUT, self.connect_consumer_no_timeout(capability)).await {
+        match with_timeout(DEFAULT_TIMEOUT, self.connect_as_consumer_no_timeout(capability)).await {
             Ok(r) => r,
             Err(TimeoutError) => Err(Error::Timeout),
         }
@@ -126,7 +126,7 @@ impl<'a> Policy<'a, Idle> {
         self,
         capability: PowerCapability,
     ) -> Result<Policy<'a, ConnectedProvider>, Error> {
-        self.connect_provider_internal_no_timeout(capability)
+        self.connect_as_provider_internal_no_timeout(capability)
             .await
             .map(|_| Policy::new(self.device))
     }
@@ -176,7 +176,7 @@ impl<'a> Policy<'a, ConnectedProvider> {
         &self,
         capability: PowerCapability,
     ) -> Result<Policy<'a, ConnectedProvider>, Error> {
-        self.connect_provider_internal_no_timeout(capability)
+        self.connect_as_provider_internal_no_timeout(capability)
             .await
             .map(|_| Policy::new(self.device))
     }

--- a/embedded-service/src/power/policy/device.rs
+++ b/embedded-service/src/power/policy/device.rs
@@ -16,9 +16,9 @@ pub enum StateKind {
     Detached,
     /// Device is attached
     Idle,
-    /// Device is actively providing power
+    /// Device is actively providing power, source mode
     ConnectedProvider,
-    /// Device is actively consuming power
+    /// Device is actively consuming power, sink mode
     ConnectedConsumer,
 }
 
@@ -65,9 +65,9 @@ struct InternalState {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CommandData {
     /// Start consuming on this device
-    ConnectConsumer(PowerCapability),
-    /// Start providinig on this device
-    ConnectProvider(PowerCapability),
+    ConnectAsConsumer(PowerCapability),
+    /// Start providing power to port partner on this device
+    ConnectAsProvider(PowerCapability),
     /// Stop providing or consuming on this device
     Disconnect,
 }

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -347,25 +347,6 @@ pub trait Controller {
         port: LocalPortId,
         enable: bool,
     ) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
-    /// Enable or disable sourcing
-    fn set_sourcing(
-        &mut self,
-        port: LocalPortId,
-        enable: bool,
-    ) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
-    /// Set source current capability
-    fn set_source_current(
-        &mut self,
-        port: LocalPortId,
-        current: TypecCurrent,
-        signal_event: bool,
-    ) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
-    /// Initiate a power-role swap to the given role
-    fn request_pr_swap(
-        &mut self,
-        port: LocalPortId,
-        role: PowerRole,
-    ) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
     /// Get current controller status
     fn get_controller_status(
         &mut self,

--- a/embedded-service/src/type_c/event.rs
+++ b/embedded-service/src/type_c/event.rs
@@ -15,6 +15,10 @@ bitfield! {
     pub u8, new_power_contract_as_provider, set_new_power_contract_as_provider: 2, 2;
     /// New power contract as consumer
     pub u8, new_power_contract_as_consumer, set_new_power_contract_as_consumer: 3, 3;
+    /// Source Caps received
+    pub u8, source_caps_received, set_source_caps_received: 4, 4;
+    /// Sink ready
+    pub u8, sink_ready, set_sink_ready: 5, 5;
 }
 
 /// Type-safe wrapper for the raw port event kind
@@ -62,6 +66,26 @@ impl PortEventKind {
     /// Sets the new power contract as consumer event
     pub fn set_new_power_contract_as_consumer(&mut self, value: bool) {
         self.0.set_new_power_contract_as_consumer(value.into());
+    }
+
+    /// Returns true if a source caps msg received
+    pub fn source_caps_received(self) -> bool {
+        self.0.source_caps_received() != 0
+    }
+
+    /// Sets the source caps received event
+    pub fn set_source_caps_received(&mut self, value: bool) {
+        self.0.set_source_caps_received(value.into());
+    }
+
+    /// Returns true if a sink ready event triggered
+    pub fn sink_ready(self) -> bool {
+        self.0.sink_ready() != 0
+    }
+
+    /// Sets the sink ready event
+    pub fn set_sink_ready(&mut self, value: bool) {
+        self.0.set_sink_ready(value.into());
     }
 }
 

--- a/embedded-service/src/type_c/mod.rs
+++ b/embedded-service/src/type_c/mod.rs
@@ -99,7 +99,8 @@ impl From<type_c::Current> for policy::PowerCapability {
         policy::PowerCapability {
             voltage_mv: 5000,
             // Assume lower power for now
-            current_ma: current.to_ma(true),
+            // todo: follow G3, use 900 for now
+            current_ma: current.to_ma(false),
         }
     }
 }

--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -26,7 +26,7 @@ impl Ord for State {
 }
 
 impl PowerPolicy {
-    /// Iterate over all devices to determine what is now the highest-powered consumer
+    /// Iterate over all devices to determine what is best power port provides the highest power
     async fn find_highest_power_consumer(&self) -> Result<Option<State>, Error> {
         let mut best_consumer = None;
 
@@ -84,6 +84,7 @@ impl PowerPolicy {
                     "Device {}, disconnecting current consumer",
                     current_consumer.device_id.0
                 );
+                // disconnect current consumer and set idle
                 consumer.disconnect().await?;
             }
 
@@ -129,12 +130,12 @@ impl PowerPolicy {
         Ok(())
     }
 
-    /// Determines and connects the best consumer
+    /// Determines and connects the best power
     pub(super) async fn update_current_consumer(&self) -> Result<(), Error> {
         let mut guard = self.state.lock().await;
         let state = guard.deref_mut();
         info!(
-            "Selecting consumer, current consumer: {:#?}",
+            "Selecting power port, current power: {:#?}",
             state.current_consumer_state
         );
 

--- a/power-policy-service/src/provider.rs
+++ b/power-policy-service/src/provider.rs
@@ -3,7 +3,7 @@
 //! the system is in unlimited power state. In this mode up to [provider_unlimited](super::Config::provider_unlimited)
 //! is provided to each device. Above this threshold, the system is in limited power state.
 //! In this mode [provider_limited](super::Config::provider_limited) is provided to each device
-use embedded_services::{debug, trace};
+use embedded_services::trace;
 
 use super::*;
 
@@ -28,7 +28,7 @@ pub(super) struct State {
 impl PowerPolicy {
     /// Attempt to connect the requester as a provider
     pub(super) async fn connect_provider(&self, requester_id: DeviceId) {
-        trace!("Device{}: Attempting to connect provider", requester_id.0);
+        trace!("Device{}: Attempting to connect as provider", requester_id.0);
         let requester = match self.context.get_device(requester_id).await {
             Ok(device) => device,
             Err(_) => {
@@ -44,52 +44,16 @@ impl PowerPolicy {
                 return;
             }
         };
-        let mut state = self.state.lock().await;
-        let mut total_power_mw = 0;
 
-        // Determine total requested power draw
-        for device in self.context.devices().await.iter_only::<device::Device>() {
-            let target_provider_cap = if device.id() == requester_id {
-                // Use the requester's requested power capability
-                // this handles both new connections and upgrade requests
-                Some(requested_power_capability)
-            } else {
-                // Use the device's current working provider capability
-                device.provider_capability().await
-            };
-            total_power_mw += target_provider_cap.map_or(0, |cap| cap.max_power_mw());
-
-            if total_power_mw > self.config.limited_power_threshold_mw {
-                state.current_provider_state.state = PowerState::Limited;
-            } else {
-                state.current_provider_state.state = PowerState::Unlimited;
-            }
-        }
-
-        debug!("New power state: {:?}", state.current_provider_state.state);
-
-        let target_power = match state.current_provider_state.state {
-            PowerState::Limited => self.config.provider_limited,
-            PowerState::Unlimited => {
-                if requested_power_capability.max_power_mw() < self.config.provider_unlimited.max_power_mw() {
-                    // Don't auto upgrade to a higher contract
-                    requested_power_capability
-                } else {
-                    self.config.provider_unlimited
-                }
-            }
-        };
-
-        info!("Device{}: Connecting new provider", requester.id().0);
         let connected = if let Ok(action) = self.context.try_policy_action::<action::Idle>(requester.id()).await {
-            let _ = action.connect_provider(target_power).await;
+            let _ = action.connect_provider(requested_power_capability).await;
             Ok(())
         } else if let Ok(action) = self
             .context
             .try_policy_action::<action::ConnectedProvider>(requester.id())
             .await
         {
-            let _ = action.connect_provider(target_power).await;
+            let _ = action.connect_provider(requested_power_capability).await;
             Ok(())
         } else {
             Err(Error::InvalidState(
@@ -100,7 +64,7 @@ impl PowerPolicy {
 
         // Don't need to do anything special, the device is responsible for attempting to reconnect
         if let Err(e) = connected {
-            error!("Device{}: Failed to connect provider, {:#?}", requester.id().0, e);
+            error!("Device{}: Failed to connect as provider, {:#?}", requester.id().0, e);
         }
     }
 }

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -46,8 +46,7 @@ impl<'a, const N: usize, M: RawMutex, B: I2c> Tps6699x<'a, N, M, B> {
         tps6699x: &mut tps6699x::Tps6699x<'a, M, B>,
         port: LocalPortId,
     ) -> Result<PortEventKind, Error<B::Error>> {
-        let mut events = PortEventKind::none();
-        let previous_status = self.port_status[port.0 as usize].get();
+        let events = PortEventKind::none();
 
         let status = tps6699x.get_port_status(port).await?;
         trace!("Port{} status: {:#?}", port.0, status);
@@ -132,20 +131,6 @@ impl<'a, const N: usize, M: RawMutex, B: I2c> Tps6699x<'a, N, M, B> {
             debug!("Port{} power path: {:#?}", port.0, port_status.power_path);
         }
 
-        if port_status.available_sink_contract.is_some()
-            && port_status.available_sink_contract != previous_status.available_sink_contract
-        {
-            debug!("Port{}: new sink contract", port.0);
-            events.set_new_power_contract_as_consumer(true);
-        }
-
-        if port_status.available_source_contract.is_some()
-            && port_status.available_source_contract != previous_status.available_source_contract
-        {
-            debug!("Port{}: new source contract", port.0);
-            events.set_new_power_contract_as_provider(true);
-        }
-
         self.port_status[port.0 as usize].set(port_status);
         Ok(events)
     }
@@ -161,17 +146,28 @@ impl<'a, const N: usize, M: RawMutex, B: I2c> Tps6699x<'a, N, M, B> {
 
             let mut event = cell.get();
             if interrupt.plug_event() {
-                debug!("Plug event");
+                debug!("Event: Plug event");
                 event.set_plug_inserted_or_removed(true);
+            }
+            if interrupt.source_caps_received() {
+                debug!("Event: Source Caps received");
+                event.set_source_caps_received(true);
+            }
+
+            if interrupt.sink_ready() {
+                debug!("Event: Sink ready");
+                event.set_sink_ready(true);
             }
 
             if interrupt.new_consumer_contract() {
-                debug!("New consumer contract");
+                debug!("Event: New contract as consumer, PD controller act as Sink");
+                // Port is consumer and power negotiation is complete
                 event.set_new_power_contract_as_consumer(true);
             }
 
             if interrupt.new_provider_contract() {
-                debug!("New consumer contract");
+                debug!("Event: New contract as provider, PD controller act as source");
+                // Port is provider and power negotiation is complete
                 event.set_new_power_contract_as_provider(true);
             }
 
@@ -297,53 +293,6 @@ impl<const N: usize, M: RawMutex, B: I2c> Controller for Tps6699x<'_, N, M, B> {
             }
             rest => rest,
         }
-    }
-
-    #[allow(clippy::await_holding_refcell_ref)]
-    async fn set_sourcing(&mut self, port: LocalPortId, enable: bool) -> Result<(), Error<Self::BusError>> {
-        debug!("Port{} enable source: {}", port.0, enable);
-        let mut tps6699x = self.tps6699x.borrow_mut();
-        tps6699x.enable_source(port, enable).await
-    }
-
-    #[allow(clippy::await_holding_refcell_ref)]
-    async fn set_source_current(
-        &mut self,
-        port: LocalPortId,
-        current: TypecCurrent,
-        signal_event: bool,
-    ) -> Result<(), Error<Self::BusError>> {
-        debug!("Port{} set source current: {:?}", port.0, current);
-
-        let mut tps6699x = self.tps6699x.borrow_mut();
-        let mut port_control = tps6699x.get_port_control(port).await?;
-        port_control.set_typec_current(current.into());
-
-        tps6699x.set_port_control(port, port_control).await?;
-        if signal_event {
-            let mut event = PortEventKind::none();
-            event.set_new_power_contract_as_consumer(true);
-            self.signal_event(port, event);
-        }
-        Ok(())
-    }
-
-    #[allow(clippy::await_holding_refcell_ref)]
-    async fn request_pr_swap(
-        &mut self,
-        port: LocalPortId,
-        role: embedded_usb_pd::PowerRole,
-    ) -> Result<(), Error<Self::BusError>> {
-        debug!("Port{} request PR swap to {:?}", port.0, role);
-
-        let mut tps6699x = self.tps6699x.borrow_mut();
-        let mut control = tps6699x.get_port_control(port).await?;
-        match role {
-            PowerRole::Sink => control.set_initiate_swap_to_sink(true),
-            PowerRole::Source => control.set_initiate_swap_to_source(true),
-        }
-
-        tps6699x.set_port_control(port, control).await
     }
 
     #[allow(clippy::await_holding_refcell_ref)]

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -20,7 +20,7 @@ impl<const N: usize, C: Controller> ControllerWrapper<'_, N, C> {
         Ok(&self.power[port.0 as usize])
     }
 
-    /// Handle a new consumer contract
+    /// Handle a new contract as consumer
     pub(super) async fn process_new_consumer_contract(
         &self,
         controller: &mut C,
@@ -28,73 +28,66 @@ impl<const N: usize, C: Controller> ControllerWrapper<'_, N, C> {
         port: LocalPortId,
         status: &PortStatus,
     ) -> Result<(), Error<C::BusError>> {
-        info!("New consumer contract");
+        info!("Process new consumer contract");
 
-        if let Some(capability) = status.available_sink_contract {
-            if status.dual_power && capability.max_power_mw() <= DUAL_ROLE_CONSUMER_THRESHOLD_MW {
-                // Don't attempt to sink from a dual-role supply if the power capability is low
-                // This is to prevent sinking from a phone or similar device
-                // Do a PR swap to become the source instead
-                info!(
-                    "Port{}: Dual-role supply with low power capability, requesting PR swap",
-                    port.0
-                );
-                if controller.request_pr_swap(port, PowerRole::Source).await.is_err() {
-                    error!("Error requesting PR swap");
-                    return PdError::Failed.into();
-                }
-                return Ok(());
+        let current_state = power.state().await.kind();
+        info!("current power state: {:?}", current_state);
+
+        if let action::device::AnyState::ConnectedProvider(state) = power.device_action().await {
+            info!("ConnectedProvider");
+            if let Err(e) = state.detach().await {
+                info!("Error detaching power device: {:?}", e);
+                return PdError::Failed.into();
             }
         }
 
-        let current_state = power.state().await.kind();
-        // Don't update the available consumer contract if we're providing power
-        if current_state != StateKind::ConnectedProvider {
-            // Recover if we're not in the correct state
-            if let action::device::AnyState::Detached(state) = power.device_action().await {
-                if let Err(e) = state.attach().await {
-                    error!("Error attaching power device: {:?}", e);
-                    return PdError::Failed.into();
-                }
+        // Recover if we're not in the correct state
+        if let action::device::AnyState::Detached(state) = power.device_action().await {
+            if let Err(e) = state.attach().await {
+                error!("Error attaching power device: {:?}", e);
+                return PdError::Failed.into();
             }
+        }
 
-            if let Ok(state) = power.try_device_action::<action::Idle>().await {
-                if let Err(e) = state
-                    .notify_consumer_power_capability(status.available_sink_contract)
-                    .await
-                {
-                    error!("Error setting power contract: {:?}", e);
-                    return PdError::Failed.into();
-                }
-            } else if let Ok(state) = power.try_device_action::<action::ConnectedConsumer>().await {
-                if let Err(e) = state
-                    .notify_consumer_power_capability(status.available_sink_contract)
-                    .await
-                {
-                    error!("Error setting power contract: {:?}", e);
-                    return PdError::Failed.into();
-                }
-            } else {
-                error!("Power device not in detached state");
-                return PdError::InvalidMode.into();
+        if let Ok(state) = power.try_device_action::<action::Idle>().await {
+            if let Err(e) = state
+                .notify_consumer_power_capability(status.available_sink_contract)
+                .await
+            {
+                error!("Error setting power contract: {:?}", e);
+                return PdError::Failed.into();
             }
+        } else if let Ok(state) = power.try_device_action::<action::ConnectedConsumer>().await {
+            if let Err(e) = state
+                .notify_consumer_power_capability(status.available_sink_contract)
+                .await
+            {
+                error!("Error setting power contract: {:?}", e);
+                return PdError::Failed.into();
+            }
+        } else {
+            error!("Invalid mode");
+            return PdError::InvalidMode.into();
         }
 
         Ok(())
     }
 
-    /// Handle a new provider contract
+    /// Handle a new contract as provider
     pub(super) async fn process_new_provider_contract(
         &self,
         port: GlobalPortId,
         power: &policy::device::Device,
         status: &PortStatus,
     ) -> Result<(), Error<C::BusError>> {
+        info!("Process New provider contract");
+
         if port.0 > N as u8 {
             return PdError::InvalidPort.into();
         }
 
         let current_state = power.state().await.kind();
+        info!("current power state: {:?}", current_state);
         // Don't attempt to source if we're consuming power
         if current_state != StateKind::ConnectedConsumer {
             // Recover if we're not in the correct state
@@ -126,9 +119,11 @@ impl<const N: usize, C: Controller> ControllerWrapper<'_, N, C> {
                     }
                 }
             } else {
-                error!("Power device not in detached state");
+                error!("Invalid mode");
                 return PdError::InvalidMode.into();
             }
+        } else {
+            info!("Don't attempt to source if we're consuming power");
         }
 
         Ok(())
@@ -143,7 +138,7 @@ impl<const N: usize, C: Controller> ControllerWrapper<'_, N, C> {
     ) -> Result<(), Error<C::BusError>> {
         let state = power.state().await.kind();
         if state == StateKind::ConnectedConsumer {
-            info!("Port{}: Disconnect consumer", port.0);
+            info!("Port{}: Disconnect from ConnectedConsumer", port.0);
             if controller.enable_sink_path(port, false).await.is_err() {
                 error!("Error disabling sink path");
                 return PdError::Failed.into();
@@ -153,14 +148,14 @@ impl<const N: usize, C: Controller> ControllerWrapper<'_, N, C> {
         Ok(())
     }
 
-    /// Handle a connect consumer command
-    async fn process_connect_provider(
+    /// Handle a connect as provider command
+    async fn process_connect_as_provider(
         &self,
         port: LocalPortId,
         capability: PowerCapability,
         _controller: &mut C,
     ) -> Result<(), Error<C::BusError>> {
-        info!("Port{}: Connect provider: {:#?}", port.0, capability);
+        info!("Port{}: Connect as provider: {:#?}", port.0, capability);
         // TODO: double check explicit contract handling
         Ok(())
     }
@@ -196,16 +191,19 @@ impl<const N: usize, C: Controller> ControllerWrapper<'_, N, C> {
         };
 
         match command {
-            policy::device::CommandData::ConnectConsumer(capability) => {
-                info!("Port{}: Connect consumer: {:?}", port.0, capability);
+            policy::device::CommandData::ConnectAsConsumer(capability) => {
+                info!(
+                    "Port{}: Connect as consumer: {:?}, enable input switch",
+                    port.0, capability
+                );
                 if controller.enable_sink_path(port, true).await.is_err() {
                     error!("Error enabling sink path");
                     return Err(policy::Error::Failed);
                 }
             }
-            policy::device::CommandData::ConnectProvider(capability) => {
+            policy::device::CommandData::ConnectAsProvider(capability) => {
                 if self
-                    .process_connect_provider(port, *capability, controller)
+                    .process_connect_as_provider(port, *capability, controller)
                     .await
                     .is_err()
                 {


### PR DESCRIPTION
1. Add new event source_caps_received and sink_ready for future use.
2. Set default usb current to 900mA for now to follow G3.
3. Call set_new_power_contract_as_consumer/set_new_power_contract_as_provider only when there is int event indicating that power negotiation is complete.
4. Fix process_new_consumer_contract from ConnectedProvider state issue
5. Remove pr_swap and unused code.
6. Update some comments and function name for easy understanding.