### PR TITLE
Update CODEOWNERS to use EC team

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -202,7 +202,7 @@ jobs:
       - name: cargo check
         working-directory: ${{ matrix.example_directory }}
         run: |
-          cargo check --target thumbv8m.main-none-eabihf
+          cargo check --target thumbv8m.main-none-eabihf --locked
 
   check-std-examples:
     runs-on: ubuntu-latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @asasine @felipebalbi @jerrysxie @JamesHuard @madeleyneVaca @RobertZ2011 @tullom
+* @OpenDevicePartnership/ec-code-owners
 
 # Any changes in the supply-chain folder needs approval
 # from auditors as it relates to cargo vet


### PR DESCRIPTION
With growing number of repositories, having consistent and manageable list of codeowners becomes important. This PR updates the CODEOWNERS file to use the EC code owners team as the default codeowners for the repository.
This hardens the repository against stale permission issues down the line by tying the access to being part of the team rather than being explicitly granted permission to a repository.

This PR also adds `--locked` to a workflow check that was missed in the previous PRs.