### PR TITLE
Fix crash during copy to dst

### DIFF
--- a/espi-service/src/espi_service.rs
+++ b/espi-service/src/espi_service.rs
@@ -218,7 +218,7 @@ pub async fn espi_service(mut espi: espi::Espi<'static>, memory_map_buffer: &'st
 
                     match result {
                         Ok(dest_slice) => {
-                            dest_slice.copy_from_slice(src_slice);
+                            dest_slice[..src_slice.len()].copy_from_slice(src_slice);
                         }
                         Err(_e) => {
                             #[cfg(feature = "defmt")]


### PR DESCRIPTION
dest_slice will always be the max size and src_slice is a subset of this length. Must not copy beyond the src_slice.len otherwise will access invalid data and crash.