### PR TITLE
Mark InstrusiveList::new() const to remove need for *Lock in statics

### DIFF
--- a/embedded-service/src/intrusive_list.rs
+++ b/embedded-service/src/intrusive_list.rs
@@ -93,7 +93,7 @@ impl Default for IntrusiveList {
 
 impl IntrusiveList {
     /// construct an empty intrusive list
-    pub fn new() -> IntrusiveList {
+    pub const fn new() -> IntrusiveList {
         IntrusiveList { head: Cell::new(None) }
     }
 


### PR DESCRIPTION
Reduce amount of code required to initialize and use an IntrusiveList by marking new const