### PR TITLE
type-c-service: Move controller sync state functionality to external API

### DIFF
--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -156,6 +156,8 @@ pub enum InternalCommandData {
     Reset,
     /// Get controller status
     Status,
+    /// Sync controller state
+    SyncState,
 }
 
 /// PD controller command
@@ -681,6 +683,20 @@ impl ContextToken {
             .await?
         {
             InternalResponseData::Status(status) => Ok(status),
+            r => {
+                error!("Invalid response: expected controller status, got {:?}", r);
+                Err(PdError::InvalidResponse)
+            }
+        }
+    }
+
+    /// Sync controller state
+    pub async fn sync_controller_state(&self, controller_id: ControllerId) -> Result<(), PdError> {
+        match self
+            .send_controller_command(controller_id, InternalCommandData::SyncState)
+            .await?
+        {
+            InternalResponseData::Complete => Ok(()),
             r => {
                 error!("Invalid response: expected controller status, got {:?}", r);
                 Err(PdError::InvalidResponse)

--- a/embedded-service/src/type_c/external.rs
+++ b/embedded-service/src/type_c/external.rs
@@ -15,6 +15,8 @@ use super::{
 pub enum ControllerCommandData {
     /// Get controller status
     ControllerStatus,
+    /// Sync controller state
+    SyncState,
 }
 
 /// Controller-specific commands
@@ -31,6 +33,8 @@ pub struct ControllerCommand {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ControllerResponseData<'a> {
+    /// Command complete
+    Complete,
     /// Get controller status
     ControllerStatus(ControllerStatus<'a>),
 }
@@ -193,6 +197,19 @@ pub async fn port_set_rt_compliance(port: GlobalPortId) -> Result<(), PdError> {
     .await?
     {
         PortResponseData::Complete => Ok(()),
+        _ => Err(PdError::InvalidResponse),
+    }
+}
+
+/// Trigger a sync of the controller state
+pub async fn sync_controller_state(id: ControllerId) -> Result<(), PdError> {
+    match execute_external_controller_command(Command::Controller(ControllerCommand {
+        id,
+        data: ControllerCommandData::SyncState,
+    }))
+    .await?
+    {
+        ControllerResponseData::Complete => Ok(()),
         _ => Err(PdError::InvalidResponse),
     }
 }

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -213,6 +213,9 @@ async fn main(spawner: Spawner) {
         .await
         .unwrap();
 
+    // Sync our internal state with the hardware
+    type_c::external::sync_controller_state(CONTROLLER0_ID).await.unwrap();
+
     embassy_time::Timer::after_secs(10).await;
 
     let status = type_c::external::get_controller_status(CONTROLLER0_ID).await.unwrap();

--- a/examples/std/src/bin/type_c/basic.rs
+++ b/examples/std/src/bin/type_c/basic.rs
@@ -61,6 +61,10 @@ mod test_controller {
                         fw_version1: 0xdeadbeef,
                     }))
                 }
+                controller::InternalCommandData::SyncState => {
+                    info!("Sync controller state");
+                    Ok(controller::InternalResponseData::Complete)
+                }
             }
         }
 

--- a/type-c-service/src/task.rs
+++ b/type-c-service/src/task.rs
@@ -124,6 +124,15 @@ impl Service {
         external::Response::Controller(status.map(external::ControllerResponseData::ControllerStatus))
     }
 
+    /// Process external controller sync state command
+    async fn process_external_controller_sync_state(&self, controller: ControllerId) -> external::Response<'static> {
+        let status = self.context.sync_controller_state(controller).await;
+        if let Err(e) = status {
+            error!("Error getting controller sync state: {:#?}", e);
+        }
+        external::Response::Controller(status.map(|_| external::ControllerResponseData::Complete))
+    }
+
     /// Process external controller commands
     async fn process_external_controller_command(
         &self,
@@ -132,6 +141,7 @@ impl Service {
         debug!("Processing external controller command: {:#?}", command);
         match command.data {
             ControllerCommandData::ControllerStatus => self.process_external_controller_status(command.id).await,
+            ControllerCommandData::SyncState => self.process_external_controller_sync_state(command.id).await,
         }
     }
 

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -87,13 +87,6 @@ impl<'a, const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'
         }
     }
 
-    /// Ensure the software state is in sync with the hardware state
-    #[allow(clippy::await_holding_refcell_ref)]
-    async fn sync_state(&self) -> Result<(), Error<<C as Controller>::BusError>> {
-        let mut controller = self.controller.borrow_mut();
-        controller.sync_state().await
-    }
-
     /// Handle a plug event
     async fn process_plug_event(
         &self,
@@ -303,7 +296,6 @@ impl<'a, const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'
                 error!("Controller{}: Failed to register CFU device", self.pd_controller.id().0);
                 Error::Pd(PdError::Failed)
             })?;
-
-        self.sync_state().await
+        Ok(())
     }
 }

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -89,6 +89,14 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
                 let status = controller.get_controller_status().await;
                 controller::Response::Controller(status.map(InternalResponseData::Status).map_err(|_| PdError::Failed))
             }
+            controller::InternalCommandData::SyncState => {
+                let result = controller.sync_state().await;
+                controller::Response::Controller(
+                    result
+                        .map(|_| InternalResponseData::Complete)
+                        .map_err(|_| PdError::Failed),
+                )
+            }
             _ => controller::Response::Controller(Err(PdError::UnrecognizedCommand)),
         }
     }


### PR DESCRIPTION
PD controllers may maintain power and state independently of the EC. If
a port was attached prior to an EC reset then the PD controller might
not trigger an interrupt since nothing has changed on its end. Add a way
to force a sync of the PD controller state to handle this situation.