### PR TITLE
Power Policy Charger Updates

### DIFF
--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -6,6 +6,8 @@ pub mod policy;
 
 pub use policy::{init, register_device};
 
+use crate::power::policy::charger::ChargerError;
+
 /// Error type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -26,6 +28,8 @@ pub enum Error {
     Timeout,
     /// Bus error
     Bus,
+    /// Charger specific error, underlying error should have more context
+    Charger(ChargerError),
     /// Generic failure
     Failed,
 }


### PR DESCRIPTION
Changelog:
- added Powered and Unpowered states
    - **Breaking Change** this change is made because an unpowered state is a valid state the charger can be in, specifically in dead battery scenarios where the charger power rail might not be turned on. Power-policy's `connect_new_consumer()` relies on being able to communicate with the charger but the charger needs to be powered, which doesn't happen until later in the function.
- added Check Ready command to transition from Unpowered to Powered state and vice-versa
    - **Breaking Change**
- Renamed ChargeController::BusError to ChargeControllerError and added a trait bound to impl From for charger::ChargerError
    - **Breaking change** but I believe this is needed since, with the more constrained need to convert the custom error type to a ChargerError, `BusError` is too limiting of a name. Receiving an error from the `ChargeController::init_charger()` trait method could be due to being in an invalid state rather than a bus error.
- Changed connect_new_consumer() to check for the charger being unpowered, and to skip the charger's PSU detach sequence if true. 