### PR TITLE
Fix clippy workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,14 @@
 # This workflow runs whenever a PR is opened or updated, or a commit is pushed to main. It runs
 # several checks:
 # - fmt: checks that the code is formatted according to rustfmt
-# - clippy: checks that the code does not contain any clippy warnings
+# - semver: checks that the crate is following proper semantic versioning
 # - doc: checks that the code can be documented without errors
-# - hack: check combinations of feature flags
+# - hack: check combinations of feature flags for errors (including clippy warnings)
+# - deny: checks licenses, advisories, sources, and bans for our dependencies
+# - test: checks that unit tests pass and do not contain clippy warnings
 # - msrv: check that the msrv specified in the crate is correct
+# - clippy-arm-examples: checks that ARM examples contain no clippy warnings
+# - clippy-std-examples: checks that std examples contain no clippy warnings
 permissions:
   contents: read
 # This configuration allows maintainers of this repo to create a branch and pull request based on
@@ -35,32 +39,6 @@ jobs:
           components: rustfmt
       - name: cargo fmt --check
         run: cargo fmt --check
-
-  clippy:
-    runs-on: ubuntu-latest
-    name: ${{ matrix.toolchain }} / clippy
-    permissions:
-      contents: read
-      checks: write
-    strategy:
-      fail-fast: false
-      matrix:
-        # Get early warning of new lints which are regularly introduced in beta channels.
-        toolchain: [stable, beta]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          components: clippy
-      - name: cargo clippy
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-check'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Enable once we have a released crate
   # semver:
@@ -96,25 +74,33 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs
 
-  hack:
+  hack-clippy:
     # cargo-hack checks combinations of feature flags to ensure that features are all additive
     # which is required for feature unification
+    # additionally, replacing `check` with `clippy` ensures all combinations of features generate no clippy warnings
     runs-on: ubuntu-latest
-    name: ubuntu / stable / features
+    # The name is kept as 'stable / clippy' and `beta / clippy` to match required checks from repo settings
+    name: ${{ matrix.toolchain }} / clippy
     strategy:
       fail-fast: false
+      matrix:
+        # Get early warning of new lints which are regularly introduced in beta channels.
+        toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # --feature-powerset runs for every combination of features
       - name: cargo hack
-        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check --locked
+        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt clippy --locked -- -Dwarnings
 
   deny:
     # cargo-deny checks licenses, advisories, sources, and bans for
@@ -159,6 +145,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: cargo test
         run: cargo test --locked -p ${{ matrix.crate }}
+        # After ensuring tests pass, finally ensure the test code itself contains no clippy warnings
+      - name: cargo clippy
+        run: |
+          cargo clippy --locked --tests -p ${{ matrix.crate }} -- -Dwarnings
 
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
@@ -183,7 +173,6 @@ jobs:
           cargo check -F log --locked
           cargo check -F defmt --locked
 
-
   check-arm-examples:
     runs-on: ubuntu-latest
     # we use a matrix here just because env can't be used in job names
@@ -199,10 +188,10 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
-      - name: cargo check
+      - name: cargo clippy
         working-directory: ${{ matrix.example_directory }}
         run: |
-          cargo check --target thumbv8m.main-none-eabihf --locked
+          cargo clippy --target thumbv8m.main-none-eabihf --locked -- -Dwarnings
 
   check-std-examples:
     runs-on: ubuntu-latest
@@ -219,7 +208,7 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
-      - name: cargo check
+      - name: cargo clippy
         working-directory: ${{ matrix.example_directory }}
         run: |
-          cargo check --locked
+          cargo clippy --locked -- -Dwarnings


### PR DESCRIPTION
Updates the GitHub workflow to ensure clippy warnings cause the workflow to fail.

The explicit `clippy` job (which was nonfunctional and relied on `giraffate/clippy-action`) has been removed since we weren't using reviewdog to post reviews and thus had limited use. Instead, `check` in `cargo hack` was replaced with `clippy` to ensure we check all feature combinations. Similarly, examples were changed to use `clippy` instead of `check` as well.

Lastly, the `test` job also includes checking for clippy warnings on tests.

The repo settings will also likely need to be changed as it seems to be stuck waiting on jobs that no longer exist.

Depends on #360 getting merged (which I'll then rebase on) in order for the new checks to pass.