### PR TITLE
Add SyncCell type to support Sync fix in embassy upstream

### DIFF
--- a/embedded-service/src/activity.rs
+++ b/embedded-service/src/activity.rs
@@ -2,7 +2,7 @@
 
 use embassy_sync::once_lock::OnceLock;
 
-use crate::intrusive_list::*;
+use crate::{intrusive_list::*, sync_cell::SyncCell};
 
 /// potential activity service states
 #[derive(Copy, Clone, Debug)]
@@ -53,7 +53,7 @@ pub trait ActivitySubscriber {
 /// actual subscriber node instance for embedding within static or singleton type T
 pub struct Subscriber {
     node: Node,
-    instance: Cell<Option<&'static dyn ActivitySubscriber>>,
+    instance: SyncCell<Option<&'static dyn ActivitySubscriber>>,
 }
 
 impl Subscriber {
@@ -61,7 +61,7 @@ impl Subscriber {
     pub const fn uninit() -> Self {
         Self {
             node: Node::uninit(),
-            instance: Cell::new(None),
+            instance: SyncCell::new(None),
         }
     }
 

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -6,6 +6,8 @@
 pub mod intrusive_list;
 pub use intrusive_list::*;
 
+pub mod sync_cell;
+
 /// short-hand include all pre-baked services
 pub mod activity;
 pub mod buffer;

--- a/embedded-service/src/sync_cell.rs
+++ b/embedded-service/src/sync_cell.rs
@@ -66,7 +66,7 @@ impl<T: Default> SyncCell<T> {
 unsafe impl<T> Sync for SyncCell<T> {}
 
 // SAFETY: Can implement send here due to critical section without T being explicitly Send
-unsafe impl<T> Send for SyncCell<T> {}
+unsafe impl<T> Send for SyncCell<T> where T:Send {}
 
 impl<T: Copy> Clone for SyncCell<T> {
     #[inline]

--- a/embedded-service/src/sync_cell.rs
+++ b/embedded-service/src/sync_cell.rs
@@ -1,0 +1,114 @@
+//! # SyncCell: a cell-like API for static interior mutability scenarios
+use core::cell::UnsafeCell;
+
+/// A critical section backed Cell for sync scenarios where you want Cell behaviors, but need it to be thread safe (such as used in statics)
+pub struct SyncCell<T: Copy> {
+    inner: UnsafeCell<T>,
+}
+
+impl<T: Copy> SyncCell<T> {
+    /// Constructs a SyncCell, initializing it with initial_value
+    pub const fn new(initial_value: T) -> Self {
+        Self {
+            inner: UnsafeCell::new(initial_value),
+        }
+    }
+
+    /// Reads the cell's content (in a critical section) and returns a copy
+    pub fn get(&self) -> T {
+        critical_section::with(|_cs|
+            // SAFETY: safe as accessors (get/set) are always completed in a critical section
+            unsafe {
+            *self.inner.get()
+        })
+    }
+
+    /// Sets the cell's content in a critical section. Note that this accounts
+    /// for read/write conditions but does not automatically handle logical data
+    /// race conditions. It is still possible for a user to read a value but have
+    /// it change after they've performed the read. This just ensures data integrity:
+    /// SyncCell<T> will always contain a valid T, even if it's been read "late"
+    pub fn set(&self, value: T) {
+        critical_section::with(|_cs|
+            // SAFETY: safe as accessors (get/set) are always completed in a critical section
+            unsafe {
+                *self.inner.get() = value;
+        })
+    }
+
+    /// Unsafe: allows reads and writes without critical section guard, violating Sync guarantees.
+    /// # Safety
+    /// This may be used safely if and only if the pointer is held during a critical section, or
+    /// all accessors to this Cell are blocked until the pointer is released.
+    pub unsafe fn as_ptr(&self) -> *mut T {
+        self.inner.get()
+    }
+}
+
+// SAFETY: Sync is implemented here for SyncCell as T is only accessed via nestable critical sections
+unsafe impl<T: Copy> Sync for SyncCell<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let sc = SyncCell::<()>::new(());
+
+        assert_eq!(sc.get(), ());
+        sc.set(());
+        assert_eq!(sc.get(), ());
+    }
+
+    #[test]
+    fn test_primitive() {
+        let sc = SyncCell::new(0usize);
+
+        assert_eq!(sc.get(), 0);
+        sc.set(1);
+        assert_eq!(sc.get(), 1);
+    }
+
+    #[test]
+    fn test_struct() {
+        #[derive(Copy, Clone, PartialEq, Debug)]
+        struct Example {
+            a: u32,
+            b: u32,
+        }
+
+        let sc = SyncCell::new(Example { a: 0, b: 0 });
+
+        assert_eq!(sc.get(), Example { a: 0, b: 0 });
+        sc.set(Example { a: 1, b: 2 });
+        assert_eq!(sc.get(), Example { a: 1, b: 2 });
+    }
+
+    #[tokio::test]
+    async fn test_across_threads() {
+        static SC: SyncCell<bool> = SyncCell::new(false);
+        let scr = &SC;
+
+        let poller = tokio::spawn(async {
+            loop {
+                if scr.get() {
+                    break;
+                } else {
+                    let _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                }
+            }
+        });
+
+        let updater = tokio::spawn(async {
+            let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300));
+            scr.set(true);
+        });
+
+        let result = tokio::join!(poller, updater);
+        assert!(result.0.is_ok());
+        assert!(result.1.is_ok());
+
+        assert!(SC.get());
+    }
+}

--- a/embedded-service/src/sync_cell.rs
+++ b/embedded-service/src/sync_cell.rs
@@ -63,7 +63,10 @@ impl<T: Default> SyncCell<T> {
 }
 
 // SAFETY: Sync is implemented here for SyncCell as T is only accessed via nestable critical sections
-unsafe impl<T: ?Sized> Sync for SyncCell<T> {}
+unsafe impl<T> Sync for SyncCell<T> {}
+
+// SAFETY: Can implement send here due to critical section without T being explicitly Send
+unsafe impl<T> Send for SyncCell<T> {}
 
 impl<T: Copy> Clone for SyncCell<T> {
     #[inline]

--- a/embedded-service/src/sync_cell.rs
+++ b/embedded-service/src/sync_cell.rs
@@ -47,13 +47,12 @@ impl<T: Copy> SyncCell<T> {
 }
 
 impl<T: ?Sized> SyncCell<T> {
+    /// Return an address to the backing type
     /// Unsafe: allows reads and writes without critical section guard, violating Sync guarantees.
-    /// Note that this is marked unsafe, whereas as_ptr() over a standard Cell<> is safe. This is because
-    /// Cell<> implements !Sync, whereas we are implementing Sync.
     /// # Safety
     /// This may be used safely if and only if the pointer is held during a critical section, or
     /// all accessors to this Cell are blocked until the pointer is released.
-    pub const unsafe fn as_ptr(&self) -> *mut T {
+    pub const fn as_ptr(&self) -> *mut T {
         self.inner.as_ptr()
     }
 }


### PR DESCRIPTION
Embassy upstream recently fixed accidentally adding Sync to non-Sync types: https://github.com/embassy-rs/embassy/pull/4320

In preparation to fix #361, added a drop-in replacement for Cell where moving to a proper primitive usage such as embassy_sync::mutex::Mutex is untenable. This also refactors the intrusive_list to utilize this new SyncCell type, allowing it to be used directly without any containers.

Note that in most cases SyncCell is not the best solution. If it is possible, proper synchronization primitives should be leveraged.

A critical section was used as opposed to a blocking_mutex type, as blocking_mutex is non-re-entrant. This allows the most flexibility in supporting scenarios with SyncCell, and does not require permutated get and set implementations based on mutex backing type.

In short:
- New SyncCell type introduced to unblock ingesting embassy upstream Sync fix
- We should use it sparingly
- IntrusiveList was updated to use this new type, allowing it to be allocated statically without any errors