### PR TITLE
Battery service: add context config, async state getter, and remove autonomous state machine logic

### DIFF
--- a/battery-service/src/controller.rs
+++ b/battery-service/src/controller.rs
@@ -19,6 +19,8 @@ pub trait Controller: embedded_batteries_async::smart_battery::SmartBattery {
     fn get_device_event(&mut self) -> impl Future<Output = ControllerEvent>;
     fn ping(&mut self) -> impl Future<Output = Result<(), Self::ControllerError>>;
 
-    fn get_timeout(&self) -> Duration;
+    fn get_timeout(&self) -> Duration {
+        Duration::from_secs(60)
+    }
     fn set_timeout(&mut self, duration: Duration);
 }

--- a/battery-service/src/lib.rs
+++ b/battery-service/src/lib.rs
@@ -29,6 +29,14 @@ impl Service {
         }
     }
 
+    /// Create a new battery service instance with context configuration.
+    pub fn new_with_ctx_config(config: context::Config) -> Self {
+        Service {
+            endpoint: comms::Endpoint::uninit(comms::EndpointID::Internal(comms::Internal::Battery)),
+            context: context::Context::new_with_config(config),
+        }
+    }
+
     /// Main battery service processing function.
     pub async fn process(&self) {
         let event = self.context.wait_event().await;
@@ -94,6 +102,13 @@ pub async fn wait_for_battery_response() -> context::BatteryResponse {
     let service = SERVICE.get().await;
 
     service.context.wait_response().await
+}
+
+/// Asynchronously query the state from the state machine.
+pub async fn get_state() -> context::State {
+    let service = SERVICE.get().await;
+
+    service.context.get_state().await
 }
 
 /// Battery service task.

--- a/battery-service/src/wrapper.rs
+++ b/battery-service/src/wrapper.rs
@@ -17,6 +17,9 @@ pub struct Wrapper<'a, C: Controller> {
 impl<'a, C: Controller> Wrapper<'a, C> {
     /// Create a new fuel gauge wrapper.
     pub fn new(device: &'a Device, controller: C) -> Self {
+        // Set device timeout when constructing.
+        device.set_timeout(controller.get_timeout());
+
         Self {
             device,
             controller: RefCell::new(controller),


### PR DESCRIPTION
Changelog:
- add config to battery service context, allowing OEMs to tweak the inner workings of the battery service. More config features are planned as the state machine matures and locks down
- Add the ability to asynchronously query the state of the battery service
    - as a result, state is now a `Mutex` instead of a `RefCell`
- Remove state machine autonomously progressing through the states, meaning now the state machine needs to be explicitly sent commands to drive the state machine from one state to the next.  