### PR TITLE
type-c-service: Make event processing more public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,11 +1402,13 @@ name = "type-c-service"
 version = "0.1.0"
 dependencies = [
  "bitfield 0.17.0",
+ "critical-section",
  "defmt 0.3.100",
  "embassy-executor",
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
+ "embassy-time-driver",
  "embedded-cfu-protocol",
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/type-c-service/Cargo.toml
+++ b/type-c-service/Cargo.toml
@@ -23,6 +23,17 @@ embedded-usb-pd.workspace = true
 log = { workspace = true, optional = true }
 tps6699x = { workspace = true, features = ["embassy"] }
 
+[dev-dependencies]
+embassy-sync = { workspace = true, features = ["std"] }
+critical-section = { workspace = true, features = ["std"] }
+embassy-time = { workspace = true, features = ["std"] }
+embassy-time-driver = { workspace = true }
+embassy-executor = { workspace = true, features = [
+    "arch-std",
+    "executor-thread",
+] }
+embassy-futures.workspace = true
+
 [features]
 default = []
 defmt = [


### PR DESCRIPTION
Refactor to expose events coming from the type-C service. External code can use a combination of `wait_event` and `process_event` to inject its own logic into the event loop. Port events are now produced as a stream instead of a combined blob of events.