### PR TITLE
continued cargo vet audit for partition-manager

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -104,6 +104,11 @@ who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-run"
 version = "0.36.7"
 
+[[audits.serde_spanned]]
+who = "jerrysxie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.6.8"
+
 [[audits.tokio]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -247,6 +247,10 @@ criteria = "safe-to-deploy"
 version = "0.14.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.hashbrown]]
+version = "0.15.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.hashlink]]
 version = "0.9.1"
 criteria = "safe-to-deploy"
@@ -273,6 +277,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.log]]
 version = "0.4.27"
+criteria = "safe-to-deploy"
+
+[[exemptions.memchr]]
+version = "2.7.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.mimxrt600-fcb]]


### PR DESCRIPTION
* Audit serde_spanned as safe to deploy

* Exempt hashbrown 0.15.4 and memchr 2.7.4 for now as full audit for them will take some time due to complexity of the crate and lots of unsafe usage