### PR TITLE
Only send `SRDY` after Sink Ready interrupt

### DIFF
--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -198,7 +198,8 @@ impl<'a, const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'
                 continue;
             }
 
-            if event.new_power_contract_as_consumer()
+            // Only notify power policy of a contract after Sink Ready event (always after explicit or implicit contract)
+            if event.sink_ready()
                 && self
                     .process_new_consumer_contract(controller, power, local_port_id, &status)
                     .await

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -38,10 +38,13 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
         info!("current power state: {:?}", current_state);
 
         // Recover if we're not in the correct state
-        if let action::device::AnyState::Detached(state) = power.device_action().await {
-            if let Err(e) = state.attach().await {
-                error!("Error attaching power device: {:?}", e);
-                return PdError::Failed.into();
+        if status.is_connected() {
+            if let action::device::AnyState::Detached(state) = power.device_action().await {
+                warn!("Power device is detached, attempting to attach");
+                if let Err(e) = state.attach().await {
+                    error!("Error attaching power device: {:?}", e);
+                    return PdError::Failed.into();
+                }
             }
         }
 
@@ -102,10 +105,13 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
         }
 
         // Recover if we're not in the correct state
-        if let action::device::AnyState::Detached(state) = power.device_action().await {
-            if let Err(e) = state.attach().await {
-                error!("Error attaching power device: {:?}", e);
-                return PdError::Failed.into();
+        if status.is_connected() {
+            if let action::device::AnyState::Detached(state) = power.device_action().await {
+                warn!("Power device is detached, attempting to attach");
+                if let Err(e) = state.attach().await {
+                    error!("Error attaching power device: {:?}", e);
+                    return PdError::Failed.into();
+                }
             }
         }
 


### PR DESCRIPTION
Previously, we sent `SRDY` when we received a new consumer contract, but this may fail if PD controller isn't ready to sink power from the provider. The controller indicates this with the Sink Ready interrupt, which is fired when an explicit or implicit contract has been established. As such, Sink Ready always implies a contract is available, and `type_c_service::driver::tps6699x::Tps6699x::update_port_status()` ensures that `PortStatus::available_sink_contract` is valid by the time that `type_c_service::wrapper::ControllerWrapper::process_event()` is called.

Now, we only notify power policy of the new sink contract after the Sink Ready interrupt. In turn, that notification becomes a request to send `SRDY` to the PD controller.

Fixes #338 

Also fixes a bug where we were incorrectly recovering a `power::policy::device::Device` found in an incorrect state.