### PR TITLE
cfu-service: Thread through extended offer requests

### DIFF
--- a/cfu-service/src/lib.rs
+++ b/cfu-service/src/lib.rs
@@ -78,6 +78,32 @@ impl CfuClient {
             RequestData::GiveOffer(_offer_cmd) => Ok(()),
             RequestData::PrepareComponentForUpdate => Ok(()),
             RequestData::FinalizeUpdate => Ok(()),
+            RequestData::GiveOfferExtended(_) => {
+                // Don't currently support extended offers
+                self.context
+                    .send_response(InternalResponseData::OfferResponse(
+                        FwUpdateOfferResponse::new_with_failure(
+                            HostToken::Driver,
+                            OfferRejectReason::InvalidComponent,
+                            OfferStatus::Reject,
+                        ),
+                    ))
+                    .await;
+                Ok(())
+            }
+            RequestData::GiveOfferInformation(_) => {
+                // Don't currently support information offers
+                self.context
+                    .send_response(InternalResponseData::OfferResponse(
+                        FwUpdateOfferResponse::new_with_failure(
+                            HostToken::Driver,
+                            OfferRejectReason::InvalidComponent,
+                            OfferStatus::Reject,
+                        ),
+                    ))
+                    .await;
+                Ok(())
+            }
         }
     }
 }

--- a/cfu-service/src/splitter.rs
+++ b/cfu-service/src/splitter.rs
@@ -183,6 +183,24 @@ impl<'a, C: Customization> Splitter<'a, C> {
                 trace!("Got PrepareComponentForUpdate");
                 InternalResponseData::ComponentPrepared
             }
+            RequestData::GiveOfferExtended(_) => {
+                trace!("Got GiveExtendedOffer");
+                // Extended offers are not currently supported
+                InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+                    HostToken::Driver,
+                    OfferRejectReason::InvalidComponent,
+                    OfferStatus::Reject,
+                ))
+            }
+            RequestData::GiveOfferInformation(_) => {
+                trace!("Got GiveOfferInformation");
+                // Offer information is not currently supported
+                InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+                    HostToken::Driver,
+                    OfferRejectReason::InvalidComponent,
+                    OfferStatus::Reject,
+                ))
+            }
         }
     }
 

--- a/embedded-service/src/cfu/component.rs
+++ b/embedded-service/src/cfu/component.rs
@@ -67,6 +67,10 @@ pub enum RequestData {
     GiveOffer(FwUpdateOffer),
     /// Contains bytes for an accepted fw offer
     GiveContent(FwUpdateContentCommand),
+    /// Contains an extended command offer for the component to evaluate
+    GiveOfferExtended(FwUpdateOfferExtended),
+    /// Contains an extended info offer for the component to evaluate
+    GiveOfferInformation(FwUpdateOfferInformation),
     /// Request for component to prepare itself for an update
     PrepareComponentForUpdate,
     /// Request for component to execute any logic needed to finalize update
@@ -278,6 +282,30 @@ impl<W: CfuWriterAsync> CfuComponentDefault<W> {
                     .map_err(|e| CfuError::ProtocolError(CfuProtocolError::WriterError(e)))?;
             }
             RequestData::FinalizeUpdate => {}
+            RequestData::GiveOfferExtended(_) => {
+                // Reject any extended offers
+                self.device
+                    .send_response(InternalResponseData::OfferResponse(
+                        FwUpdateOfferResponse::new_with_failure(
+                            HostToken::Driver,
+                            OfferRejectReason::InvalidComponent,
+                            OfferStatus::Reject,
+                        ),
+                    ))
+                    .await;
+            }
+            RequestData::GiveOfferInformation(_) => {
+                // Reject any information offers
+                self.device
+                    .send_response(InternalResponseData::OfferResponse(
+                        FwUpdateOfferResponse::new_with_failure(
+                            HostToken::Driver,
+                            OfferRejectReason::InvalidComponent,
+                            OfferStatus::Reject,
+                        ),
+                    ))
+                    .await;
+            }
         }
         Ok(())
     }

--- a/examples/std/src/bin/cfu_buffer.rs
+++ b/examples/std/src/bin/cfu_buffer.rs
@@ -101,6 +101,22 @@ mod mock {
                     trace!("Got PrepareComponentForUpdate");
                     InternalResponseData::ComponentPrepared
                 }
+                RequestData::GiveOfferExtended(_) => {
+                    trace!("Got GiveOfferExtended");
+                    InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+                        HostToken::Driver,
+                        OfferRejectReason::InvalidComponent,
+                        OfferStatus::Reject,
+                    ))
+                }
+                RequestData::GiveOfferInformation(_) => {
+                    trace!("Got GiveOfferInformation");
+                    InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+                        HostToken::Driver,
+                        OfferRejectReason::InvalidComponent,
+                        OfferStatus::Reject,
+                    ))
+                }
             }
         }
 

--- a/examples/std/src/bin/cfu_splitter.rs
+++ b/examples/std/src/bin/cfu_splitter.rs
@@ -121,6 +121,22 @@ mod mock {
                     trace!("Got PrepareComponentForUpdate");
                     InternalResponseData::ComponentPrepared
                 }
+                RequestData::GiveOfferExtended(_) => {
+                    trace!("Got GiveOfferExtended");
+                    InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+                        HostToken::Driver,
+                        OfferRejectReason::InvalidComponent,
+                        OfferStatus::Reject,
+                    ))
+                }
+                RequestData::GiveOfferInformation(_) => {
+                    trace!("Got GiveOfferInformation");
+                    InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+                        HostToken::Driver,
+                        OfferRejectReason::InvalidComponent,
+                        OfferStatus::Reject,
+                    ))
+                }
             }
         }
 

--- a/type-c-service/src/wrapper/cfu.rs
+++ b/type-c-service/src/wrapper/cfu.rs
@@ -294,6 +294,14 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
                 debug!("Got PrepareComponentForUpdate");
                 InternalResponseData::ComponentPrepared
             }
+            RequestData::GiveOfferExtended(_) => {
+                debug!("Got GiveExtendedOffer, rejecting");
+                Self::create_offer_rejection()
+            }
+            RequestData::GiveOfferInformation(_) => {
+                debug!("Got GiveOfferInformation, rejecting");
+                Self::create_offer_rejection()
+            }
         }
     }
 


### PR DESCRIPTION
* Introduce request data variants for extended and information offers
* Add more logging around buffering CFU requests