### PR TITLE
Fix +beta clippy warnings

### DIFF
--- a/embedded-service/src/intrusive_list.rs
+++ b/embedded-service/src/intrusive_list.rs
@@ -134,7 +134,7 @@ impl IntrusiveList {
     }
 
     /// Iterate over the list as if it were items of type `T`, skipping any nodes that are of a different type.
-    pub fn iter_only<T: NodeContainer>(&self) -> OnlyT<T> {
+    pub fn iter_only<T: NodeContainer>(&self) -> OnlyT<'_, T> {
         OnlyT::new(self.into_iter())
     }
 }

--- a/embedded-service/src/power/policy/device.rs
+++ b/embedded-service/src/power/policy/device.rs
@@ -207,7 +207,7 @@ impl Device {
     }
 
     /// Try to provide access to the device actions for the given state
-    pub async fn try_device_action<S: action::Kind>(&self) -> Result<action::device::Device<S>, Error> {
+    pub async fn try_device_action<S: action::Kind>(&self) -> Result<action::device::Device<'_, S>, Error> {
         let state = self.state().await.kind();
         if S::kind() != state {
             return Err(Error::InvalidState(S::kind(), state));
@@ -216,7 +216,7 @@ impl Device {
     }
 
     /// Provide access to the current device state
-    pub async fn device_action(&self) -> action::device::AnyState {
+    pub async fn device_action(&self) -> action::device::AnyState<'_> {
         match self.state().await.kind() {
             StateKind::Detached => action::device::AnyState::Detached(action::device::Device::new(self)),
             StateKind::Idle => action::device::AnyState::Idle(action::device::Device::new(self)),
@@ -231,7 +231,7 @@ impl Device {
 
     /// Try to provide access to the policy actions for the given state
     /// Implemented here for lifetime reasons
-    pub(super) async fn try_policy_action<S: action::Kind>(&self) -> Result<action::policy::Policy<S>, Error> {
+    pub(super) async fn try_policy_action<S: action::Kind>(&self) -> Result<action::policy::Policy<'_, S>, Error> {
         let state = self.state().await.kind();
         if S::kind() != state {
             return Err(Error::InvalidState(S::kind(), state));
@@ -241,7 +241,7 @@ impl Device {
 
     /// Provide access to the current policy actions
     /// Implemented here for lifetime reasons
-    pub(super) async fn policy_action(&self) -> action::policy::AnyState {
+    pub(super) async fn policy_action(&self) -> action::policy::AnyState<'_> {
         match self.state().await.kind() {
             StateKind::Detached => action::policy::AnyState::Detached(action::policy::Policy::new(self)),
             StateKind::Idle => action::policy::AnyState::Idle(action::policy::Policy::new(self)),
@@ -255,7 +255,7 @@ impl Device {
     }
 
     /// Detach the device, this action is available in all states
-    pub async fn detach(&self) -> Result<action::device::Device<action::Detached>, Error> {
+    pub async fn detach(&self) -> Result<action::device::Device<'_, action::Detached>, Error> {
         match self.device_action().await {
             action::device::AnyState::Detached(state) => Ok(state),
             action::device::AnyState::Idle(state) => state.detach().await,

--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -58,7 +58,7 @@ impl PowerCapability {
 
 impl PartialOrd for PowerCapability {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.max_power_mw().cmp(&other.max_power_mw()))
+        Some(self.cmp(other))
     }
 }
 

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -243,12 +243,15 @@ impl ContextToken {
     }
 
     /// Try to provide access to the actions available to the policy for the given state and device
-    pub async fn try_policy_action<S: action::Kind>(&self, id: DeviceId) -> Result<action::policy::Policy<S>, Error> {
+    pub async fn try_policy_action<S: action::Kind>(
+        &self,
+        id: DeviceId,
+    ) -> Result<action::policy::Policy<'_, S>, Error> {
         self.get_device(id).await?.try_policy_action().await
     }
 
     /// Provide access to current policy actions
-    pub async fn policy_action(&self, id: DeviceId) -> Result<action::policy::AnyState, Error> {
+    pub async fn policy_action(&self, id: DeviceId) -> Result<action::policy::AnyState<'_>, Error> {
         Ok(self.get_device(id).await?.policy_action().await)
     }
 }

--- a/embedded-service/src/sync_cell.rs
+++ b/embedded-service/src/sync_cell.rs
@@ -143,9 +143,11 @@ mod tests {
     fn test_empty() {
         let sc = SyncCell::<()>::new(());
 
-        assert_eq!(sc.get(), ());
+        // Ensure get() always returns the same type as the type the SyncCell was initialized with
+        // This can be done statically at compile time
+        let _: () = sc.get();
         sc.set(());
-        assert_eq!(sc.get(), ());
+        let _: () = sc.get();
     }
 
     #[test]
@@ -188,7 +190,7 @@ mod tests {
         });
 
         let updater = tokio::spawn(async {
-            let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300));
+            let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
             scr.set(true);
         });
 

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -244,7 +244,7 @@ impl<'a> Device<'a> {
     }
 
     /// Send a command to this controller
-    pub async fn execute_command(&self, command: Command) -> Response {
+    pub async fn execute_command(&self, command: Command) -> Response<'_> {
         self.command.execute(command).await
     }
 
@@ -272,7 +272,7 @@ impl<'a> Device<'a> {
     }
 
     /// Create a command handler for this controller
-    pub async fn receive(&self) -> deferred::Request<NoopRawMutex, Command, Response<'static>> {
+    pub async fn receive(&self) -> deferred::Request<'_, NoopRawMutex, Command, Response<'static>> {
         self.command.receive().await
     }
 
@@ -707,7 +707,7 @@ impl ContextToken {
     /// Wait for an external command
     pub async fn wait_external_command(
         &self,
-    ) -> deferred::Request<NoopRawMutex, external::Command, external::Response<'static>> {
+    ) -> deferred::Request<'_, NoopRawMutex, external::Command, external::Response<'static>> {
         CONTEXT.get().await.external_command.receive().await
     }
 }

--- a/examples/std/src/bin/battery.rs
+++ b/examples/std/src/bin/battery.rs
@@ -50,7 +50,7 @@ mod espi_service {
 
             match msg {
                 BatteryMessage::CycleCount(cycles) => {
-                    info!("Bat cycles: {}", cycles);
+                    info!("Bat cycles: {cycles}");
                     Ok(())
                 }
                 _ => Err(comms::MailboxDelegateError::InvalidData),

--- a/examples/std/src/bin/buffer.rs
+++ b/examples/std/src/bin/buffer.rs
@@ -71,7 +71,7 @@ mod receiver {
 
             let borrow = data.borrow();
             let data: &[u8] = borrow.borrow();
-            info!("Received data: {:?}", data);
+            info!("Received data: {data:?}");
 
             Ok(())
         }

--- a/examples/std/src/bin/cfu_buffer.rs
+++ b/examples/std/src/bin/cfu_buffer.rs
@@ -72,7 +72,7 @@ mod mock {
                 }
                 RequestData::GiveContent(content) => {
                     if self.init.get() {
-                        trace!("Got GiveContent: {:#?}", content);
+                        trace!("Got GiveContent: {content:#?}");
                         // If the device is already initialized, accept the content
                         InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
                             content.header.sequence_num,
@@ -103,7 +103,7 @@ mod mock {
 
         pub async fn send_response(&self, response: InternalResponseData) {
             self.cfu_device.send_response(response).await;
-            trace!("Sent response: {:?}", response);
+            trace!("Sent response: {response:?}");
         }
     }
 
@@ -175,12 +175,12 @@ async fn run(spawner: Spawner) {
         .unwrap();
     let prev_version = match response {
         InternalResponseData::FwVersionResponse(response) => {
-            info!("Got version response: {:#?}", response);
+            info!("Got version response: {response:#?}");
             Into::<u32>::into(response.component_info[0].fw_version)
         }
         _ => panic!("Unexpected response"),
     };
-    info!("Got version: {:#x}", prev_version);
+    info!("Got version: {prev_version:#x}");
 
     info!("Giving offer");
     let offer = route_request(
@@ -195,7 +195,7 @@ async fn run(spawner: Spawner) {
     )
     .await
     .unwrap();
-    info!("Got response: {:?}", offer);
+    info!("Got response: {offer:?}");
 
     for i in 0..10 {
         let header = FwUpdateContentHeader {

--- a/examples/std/src/bin/cfu_client.rs
+++ b/examples/std/src/bin/cfu_client.rs
@@ -16,7 +16,7 @@ use crate::cfu::component::RequestData;
 async fn device_task0(component: &'static CfuComponentDefault<CfuWriterDefault>) {
     loop {
         if let Err(e) = component.process_request().await {
-            error!("Error processing request: {:?}", e);
+            error!("Error processing request: {e:?}");
         }
     }
 }
@@ -25,7 +25,7 @@ async fn device_task0(component: &'static CfuComponentDefault<CfuWriterDefault>)
 async fn device_task1(component: &'static CfuComponentDefault<CfuWriterDefault>) {
     loop {
         if let Err(e) = component.process_request().await {
-            error!("Error processing request: {:?}", e);
+            error!("Error processing request: {e:?}");
         }
     }
 }
@@ -74,18 +74,18 @@ async fn run(spawner: Spawner) {
 
     match cfu::route_request(1, RequestData::GiveOffer(dummy_offer0)).await {
         Ok(resp) => {
-            info!("got okay response to device0 update {:?}", resp);
+            info!("got okay response to device0 update {resp:?}");
         }
         Err(e) => {
-            error!("offer failed with error {:?}", e);
+            error!("offer failed with error {e:?}");
         }
     }
     match cfu::route_request(2, RequestData::GiveOffer(dummy_offer1)).await {
         Ok(resp) => {
-            info!("got okay response to device1 update {:?}", resp);
+            info!("got okay response to device1 update {resp:?}");
         }
         Err(e) => {
-            error!("device1 offer failed with error {:?}", e);
+            error!("device1 offer failed with error {e:?}");
         }
     }
 }

--- a/examples/std/src/bin/cfu_splitter.rs
+++ b/examples/std/src/bin/cfu_splitter.rs
@@ -29,7 +29,7 @@ mod mock {
     impl splitter::Customization for Customization {
         fn resolve_fw_versions(&self, versions: &[GetFwVersionResponse]) -> GetFwVersionResponse {
             for version in versions {
-                info!("Supplied FW version: {:?}", version);
+                info!("Supplied FW version: {version:?}");
             }
             // For simplicity, just return the first version
             versions[0]
@@ -37,7 +37,7 @@ mod mock {
 
         fn resolve_offer_response(&self, offer_responses: &[FwUpdateOfferResponse]) -> FwUpdateOfferResponse {
             for offer in offer_responses {
-                info!("Supplied Offer Response: {:?}", offer);
+                info!("Supplied Offer Response: {offer:?}");
                 if offer.status == OfferStatus::Reject {
                     // Exit on the first rejection
                     error!("Offer rejected: {:?}", offer.reject_reason);
@@ -51,7 +51,7 @@ mod mock {
 
         fn resolve_content_response(&self, content_responses: &[FwUpdateContentResponse]) -> FwUpdateContentResponse {
             for content in content_responses {
-                info!("Supplied Content Response: {:?}", content);
+                info!("Supplied Content Response: {content:?}");
                 if content.status != CfuUpdateContentResponseStatus::Success {
                     // Exit on the first failure
                     error!("Content response failed: {:?}", content.status);
@@ -202,12 +202,12 @@ async fn run(spawner: Spawner) {
         .unwrap();
     let prev_version = match response {
         InternalResponseData::FwVersionResponse(response) => {
-            info!("Got version response: {:#?}", response);
+            info!("Got version response: {response:#?}");
             Into::<u32>::into(response.component_info[0].fw_version)
         }
         _ => panic!("Unexpected response"),
     };
-    info!("Got version: {:#x}", prev_version);
+    info!("Got version: {prev_version:#x}");
 
     info!("Giving offer");
     let offer = route_request(
@@ -222,7 +222,7 @@ async fn run(spawner: Spawner) {
     )
     .await
     .unwrap();
-    info!("Got response: {:?}", offer);
+    info!("Got response: {offer:?}");
 
     let header = FwUpdateContentHeader {
         data_length: DEFAULT_DATA_LENGTH as u8,
@@ -239,7 +239,7 @@ async fn run(spawner: Spawner) {
     let response = route_request(CFU_SPLITTER_ID, RequestData::GiveContent(request))
         .await
         .unwrap();
-    info!("Got response: {:?}", response);
+    info!("Got response: {response:?}");
 }
 
 fn main() {

--- a/examples/std/src/bin/power_policy.rs
+++ b/examples/std/src/bin/power_policy.rs
@@ -63,7 +63,7 @@ impl policy::device::DeviceContainer for ExampleDevice {
 async fn device_task0(device: &'static ExampleDevice) {
     loop {
         if let Err(e) = device.process_request().await {
-            error!("Error processing request: {:?}", e);
+            error!("Error processing request: {e:?}");
         }
     }
 }
@@ -72,7 +72,7 @@ async fn device_task0(device: &'static ExampleDevice) {
 async fn device_task1(device: &'static ExampleDevice) {
     loop {
         if let Err(e) = device.process_request().await {
-            error!("Error processing request: {:?}", e);
+            error!("Error processing request: {e:?}");
         }
     }
 }

--- a/examples/std/src/bin/type_c/basic.rs
+++ b/examples/std/src/bin/type_c/basic.rs
@@ -24,7 +24,7 @@ mod test_controller {
     }
 
     impl controller::DeviceContainer for Controller<'_> {
-        fn get_pd_controller_device(&self) -> &controller::Device {
+        fn get_pd_controller_device(&self) -> &controller::Device<'_> {
             &self.controller
         }
     }
@@ -147,13 +147,13 @@ async fn task(spawner: Spawner) {
     info!("Reset port 1 done");
 
     let status = context.get_controller_status(CONTROLLER0).await.unwrap();
-    info!("Controller 0 status: {:#?}", status);
+    info!("Controller 0 status: {status:#?}");
 
     let status = context.get_port_status(PORT0).await.unwrap();
-    info!("Port 0 status: {:#?}", status);
+    info!("Port 0 status: {status:#?}");
 
     let status = context.get_port_status(PORT1).await.unwrap();
-    info!("Port 1 status: {:#?}", status);
+    info!("Port 1 status: {status:#?}");
 }
 
 fn main() {

--- a/examples/std/src/bin/type_c/external.rs
+++ b/examples/std/src/bin/type_c/external.rs
@@ -12,15 +12,15 @@ async fn task(_spawner: Spawner) {
 
     info!("Getting controller status");
     let controller_status = external::get_controller_status(ControllerId(0)).await.unwrap();
-    info!("Controller status: {:?}", controller_status);
+    info!("Controller status: {controller_status:?}");
 
     info!("Getting port status");
     let port_status = external::get_port_status(GlobalPortId(0)).await.unwrap();
-    info!("Port status: {:?}", port_status);
+    info!("Port status: {port_status:?}");
 
     info!("Getting retimer fw update status");
     let rt_fw_update_status = external::port_get_rt_fw_update_status(GlobalPortId(0)).await.unwrap();
-    info!("Get retimer fw update status: {:?}", rt_fw_update_status);
+    info!("Get retimer fw update status: {rt_fw_update_status:?}");
 
     info!("Setting retimer fw update state");
     external::port_set_rt_fw_update_state(GlobalPortId(0)).await.unwrap();

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -99,14 +99,14 @@ mod test_controller {
         async fn wait_port_event(&mut self) -> Result<(), Error<Self::BusError>> {
             trace!("Wait for port event");
             let events = self.state.events.wait().await;
-            trace!("Port event: {:#?}", events);
+            trace!("Port event: {events:#?}");
             self.events.set(events);
             Ok(())
         }
 
         async fn clear_port_events(&mut self, _port: LocalPortId) -> Result<PortEventKind, Error<Self::BusError>> {
             let events = self.events.get();
-            debug!("Clear port events: {:#?}", events);
+            debug!("Clear port events: {events:#?}");
             self.events.set(PortEventKind::none());
             Ok(events)
         }
@@ -117,7 +117,7 @@ mod test_controller {
         }
 
         async fn enable_sink_path(&mut self, _port: LocalPortId, enable: bool) -> Result<(), Error<Self::BusError>> {
-            debug!("Enable sink path: {}", enable);
+            debug!("Enable sink path: {enable}");
             Ok(())
         }
 

--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -18,7 +18,7 @@ pub struct State {
 
 impl PartialOrd for State {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.power_capability.cmp(&other.power_capability))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
Running `cargo +beta clippy` revealed several more clippy warnings. The original intention of our clippy CI workflow was to take these into account since beta features will become stable in the future and this helps us stay ahead of the curve.