### PR TITLE
Implement initial thermal service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-fans"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5007eb97aabfe3606c0b02823b3120e861c748ed3560756aa4fd231ef9ebf0"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "embedded-fans-async"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafd19dc3b6aaa5027856818e19ccbfe84ebfb094c8a0ecf84a20e75c3b8e959"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-fans",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +743,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "embedded-sensors-hal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971cd616a2326c63f660375e485e2f4573575b0bd293d228d7817c2b07be3475"
+dependencies = [
+ "defmt 0.3.100",
+]
+
+[[package]]
+name = "embedded-sensors-hal-async"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c524a78b2804eca0d9ec05154e51d9af948b40cd0a6bbcc4d5832ff7e47b5b"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-sensors-hal",
+ "paste",
 ]
 
 [[package]]
@@ -1420,6 +1459,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "thermal-service"
+version = "0.1.0"
+dependencies = [
+ "defmt 0.3.100",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-sensors-hal-async",
+ "embedded-services",
+ "heapless 0.8.0",
+ "log",
+ "uuid",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1621,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 
 [[package]]
 name = "vcell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ syn = "2.0"
 tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x" }
 tokio = { version = "1.42.0" }
 zerocopy = "0.8.26"
-uuid = { version = "1.17.0", default-features = false }
+uuid = { version = "=1.17.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "battery-service",
+    "thermal-service",
     "cfu-service",
     "embedded-service",
     "espi-service",
@@ -70,3 +71,4 @@ syn = "2.0"
 tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x" }
 tokio = { version = "1.42.0" }
 zerocopy = "0.8.26"
+uuid = { version = "1.17.0", default-features = false }

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -485,6 +485,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-fans"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5007eb97aabfe3606c0b02823b3120e861c748ed3560756aa4fd231ef9ebf0"
+
+[[package]]
+name = "embedded-fans-async"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafd19dc3b6aaa5027856818e19ccbfe84ebfb094c8a0ecf84a20e75c3b8e959"
+dependencies = [
+ "embedded-fans",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +562,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "embedded-sensors-hal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971cd616a2326c63f660375e485e2f4573575b0bd293d228d7817c2b07be3475"
+
+[[package]]
+name = "embedded-sensors-hal-async"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c524a78b2804eca0d9ec05154e51d9af948b40cd0a6bbcc4d5832ff7e47b5b"
+dependencies = [
+ "embedded-sensors-hal",
+ "paste",
 ]
 
 [[package]]
@@ -921,6 +952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,8 +1169,11 @@ dependencies = [
  "embassy-time-driver",
  "embedded-batteries-async",
  "embedded-cfu-protocol",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-mock",
+ "embedded-sensors-hal-async",
  "embedded-services",
  "embedded-usb-pd",
  "env_logger",
@@ -1141,6 +1181,7 @@ dependencies = [
  "log",
  "power-policy-service",
  "static_cell",
+ "thermal-service",
  "type-c-service",
 ]
 
@@ -1174,6 +1215,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thermal-service"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-fans-async",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-sensors-hal-async",
+ "embedded-services",
+ "heapless 0.8.0",
+ "log",
+ "uuid",
 ]
 
 [[package]]
@@ -1238,6 +1297,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 
 [[package]]
 name = "vcell"

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -1170,7 +1170,6 @@ dependencies = [
  "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-fans-async",
- "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-mock",
  "embedded-sensors-hal-async",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -49,7 +49,6 @@ log = "0.4.14"
 heapless = "0.8.0"
 static_cell = "2"
 embedded-hal-async = "1.0.0"
-embedded-hal = "1.0.0"
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 
 critical-section = { version = "1.1", features = ["std"] }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -40,11 +40,16 @@ embedded-batteries-async = "0.2.0"
 battery-service = { path = "../../battery-service", features = ["log"] }
 type-c-service = { path = "../../type-c-service", features = ["log"] }
 
+embedded-sensors-hal-async = "0.3.0"
+embedded-fans-async = "0.2.0"
+thermal-service = { path = "../../thermal-service", features = ["log"] }
+
 env_logger = "0.9.0"
 log = "0.4.14"
 heapless = "0.8.0"
 static_cell = "2"
 embedded-hal-async = "1.0.0"
+embedded-hal = "1.0.0"
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
 
 critical-section = { version = "1.1", features = ["std"] }

--- a/examples/std/src/bin/thermal.rs
+++ b/examples/std/src/bin/thermal.rs
@@ -1,0 +1,366 @@
+use embassy_executor::{Executor, Spawner};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::mutex::Mutex;
+use embassy_sync::once_lock::OnceLock;
+use embassy_time::Timer;
+use embedded_fans_async as fan;
+use embedded_sensors_hal_async::sensor;
+use embedded_sensors_hal_async::temperature::{DegreesCelsius, TemperatureSensor, TemperatureThresholdSet};
+use embedded_services::comms;
+use log::{info, warn};
+use static_cell::StaticCell;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use thermal_service as ts;
+use ts::mptf;
+
+// Mock host service
+mod host {
+    use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+    use embedded_services::comms::{self, Endpoint, EndpointID, External, MailboxDelegate};
+    use log::{info, warn};
+    use thermal_service as ts;
+    use ts::mptf;
+
+    pub struct Host {
+        pub tp: Endpoint,
+        pub alert: Signal<CriticalSectionRawMutex, ()>,
+    }
+
+    impl Host {
+        pub fn new() -> Self {
+            Self {
+                tp: Endpoint::uninit(EndpointID::External(External::Host)),
+                alert: Signal::new(),
+            }
+        }
+
+        fn handle_response(&self, response: mptf::Response) {
+            match response.data {
+                mptf::ResponseData::GetTmp(tmp) => {
+                    info!("Host received temperature: {} °C", ts::utils::dk_to_c(tmp))
+                }
+                mptf::ResponseData::GetVar(_status, value) => {
+                    info!("Host received fan RPM: {value}")
+                }
+                _ => info!("Received MPTF response: {response:?}"),
+            }
+        }
+    }
+
+    impl MailboxDelegate for Host {
+        fn receive(&self, message: &comms::Message) -> Result<(), comms::MailboxDelegateError> {
+            if let Some(&response) = message.data.get::<mptf::Response>() {
+                self.handle_response(response);
+                Ok(())
+            } else if let Some(&notification) = message.data.get::<mptf::Notify>() {
+                warn!("Received notification: {notification:?}");
+                self.alert.signal(());
+                Ok(())
+            } else {
+                Err(comms::MailboxDelegateError::MessageNotFound)
+            }
+        }
+    }
+}
+
+// A mock struct shared by MockSensor and MockAlertPin to sync on raw samples and thresholds
+struct MockBus {
+    samples: [f32; 35],
+    idx: AtomicUsize,
+    threshold_low: Mutex<CriticalSectionRawMutex, f32>,
+    threshold_high: Mutex<CriticalSectionRawMutex, f32>,
+}
+
+impl MockBus {
+    fn new() -> Self {
+        Self {
+            samples: [
+                20.0, 25.0, 30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0,
+                105.0, 100.0, 95.0, 90.0, 85.0, 80.0, 75.0, 70.0, 65.0, 60.0, 55.0, 50.0, 45.0, 40.0, 35.0, 30.0, 25.0,
+                20.0,
+            ],
+            idx: AtomicUsize::new(0),
+            threshold_low: Mutex::new(0.0),
+            threshold_high: Mutex::new(0.0),
+        }
+    }
+
+    // Return the current sample and move to next sample (wrapping around at end)
+    fn sample_and_next(&self) -> f32 {
+        self.samples[self
+            .idx
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |idx| {
+                Some((idx + 1) % self.samples.len())
+            })
+            .unwrap()]
+    }
+
+    async fn set_threshold_low(&self, threshold: f32) {
+        *self.threshold_low.lock().await = threshold
+    }
+
+    async fn set_threshold_high(&self, threshold: f32) {
+        *self.threshold_high.lock().await = threshold
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct MockSensorError;
+impl sensor::Error for MockSensorError {
+    fn kind(&self) -> sensor::ErrorKind {
+        sensor::ErrorKind::Other
+    }
+}
+
+// A mock temperature sensor
+struct MockSensor {
+    bus: &'static MockBus,
+}
+
+impl MockSensor {
+    fn new(bus: &'static MockBus) -> Self {
+        Self { bus }
+    }
+}
+
+impl sensor::ErrorType for MockSensor {
+    type Error = MockSensorError;
+}
+
+impl TemperatureSensor for MockSensor {
+    async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
+        Ok(self.bus.sample_and_next())
+    }
+}
+
+impl TemperatureThresholdSet for MockSensor {
+    async fn set_temperature_threshold_low(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+        self.bus.set_threshold_low(threshold).await;
+        Ok(())
+    }
+
+    async fn set_temperature_threshold_high(&mut self, threshold: DegreesCelsius) -> Result<(), Self::Error> {
+        self.bus.set_threshold_high(threshold).await;
+        Ok(())
+    }
+}
+
+impl ts::sensor::CustomRequestHandler for MockSensor {}
+impl ts::sensor::Controller for MockSensor {}
+
+#[derive(Copy, Clone, Debug)]
+struct MockFanError;
+impl fan::Error for MockFanError {
+    fn kind(&self) -> embedded_fans_async::ErrorKind {
+        fan::ErrorKind::Other
+    }
+}
+
+// A mock fan
+struct MockFan {
+    rpm: u16,
+}
+
+impl MockFan {
+    fn new() -> Self {
+        Self { rpm: 0 }
+    }
+}
+
+impl fan::ErrorType for MockFan {
+    type Error = MockFanError;
+}
+
+impl fan::Fan for MockFan {
+    fn min_rpm(&self) -> u16 {
+        1000
+    }
+
+    fn max_rpm(&self) -> u16 {
+        5000
+    }
+
+    fn min_start_rpm(&self) -> u16 {
+        1000
+    }
+
+    async fn set_speed_rpm(&mut self, rpm: u16) -> Result<u16, Self::Error> {
+        self.rpm = rpm;
+        Ok(rpm)
+    }
+}
+
+impl fan::RpmSense for MockFan {
+    async fn rpm(&mut self) -> Result<u16, Self::Error> {
+        Ok(self.rpm)
+    }
+}
+
+impl ts::fan::CustomRequestHandler for MockFan {}
+impl ts::fan::RampResponseHandler for MockFan {}
+impl ts::fan::Controller for MockFan {}
+
+// Simulates host receiving requests from OSPM and forwarding to thermal service
+#[embassy_executor::task]
+async fn host() {
+    info!("Spawning host task");
+
+    static HOST: OnceLock<host::Host> = OnceLock::new();
+    let host = HOST.get_or_init(host::Host::new);
+    info!("Registering host endpoint");
+    comms::register_endpoint(host, &host.tp).await.unwrap();
+
+    let thermal_id = comms::EndpointID::Internal(comms::Internal::Thermal);
+
+    // Set thresholds to 40 °C (3131 deciKelvin)
+    host.tp
+        .send(thermal_id, &mptf::Request::SetThrs(0, 0, 0, 3131))
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Set Fan ON temp to 40 °C (3131 deciKelvin)
+    host.tp
+        .send(
+            thermal_id,
+            &mptf::Request::SetVar(0, 4, mptf::uuid_standard::FAN_ON_TEMP, 3131),
+        )
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Set Fan RAMP temp to 50 °C (3231 deciKelvin)
+    host.tp
+        .send(
+            thermal_id,
+            &mptf::Request::SetVar(0, 4, mptf::uuid_standard::FAN_RAMP_TEMP, 3231),
+        )
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Set Fan MAX temp to 80 °C (3531 deciKelvin)
+    host.tp
+        .send(
+            thermal_id,
+            &mptf::Request::SetVar(0, 4, mptf::uuid_standard::FAN_MAX_TEMP, 3531),
+        )
+        .await
+        .unwrap();
+    Timer::after_millis(100).await;
+
+    // Wait to receive MPTF notification that threshold exceeded, then request temperature and RPM
+    loop {
+        host.alert.wait().await;
+
+        info!("Host requesting temperature in response to threshold alert");
+        host.tp.send(thermal_id, &mptf::Request::GetTmp(0)).await.unwrap();
+
+        // Need to wait briefly before send is fixed to propagate errors and we can handle retries
+        Timer::after_millis(100).await;
+
+        info!("Host requesting fan RPM in response to threshold alert");
+        host.tp
+            .send(
+                thermal_id,
+                &mptf::Request::GetVar(0, 4, mptf::uuid_standard::FAN_CURRENT_RPM),
+            )
+            .await
+            .unwrap();
+    }
+}
+
+async fn init_sensor(spawner: Spawner) {
+    info!("Initializing mock bus");
+    static BUS: OnceLock<MockBus> = OnceLock::new();
+    let bus = BUS.get_or_init(MockBus::new);
+
+    info!("Initializing mock sensor");
+    let mock_sensor = MockSensor::new(bus);
+    static SENSOR: OnceLock<ts::sensor::Sensor<MockSensor, 16>> = OnceLock::new();
+
+    let profile = ts::sensor::Profile {
+        warn_high_threshold: 40.0,
+        prochot_threshold: 50.0,
+        crt_threshold: 80.0,
+        ..Default::default()
+    };
+    let sensor = SENSOR.get_or_init(|| ts::sensor::Sensor::new(ts::sensor::DeviceId(0), mock_sensor, profile));
+
+    ts::register_sensor(sensor.device()).await.unwrap();
+    spawner.must_spawn(mock_sensor_task(sensor));
+}
+
+async fn init_fan(spawner: Spawner) {
+    info!("Initializing mock fan");
+    let mock_fan = MockFan::new();
+    static FAN: OnceLock<ts::fan::Fan<MockFan, 16>> = OnceLock::new();
+    let fan = FAN.get_or_init(|| ts::fan::Fan::new(ts::fan::DeviceId(0), mock_fan, ts::fan::Profile::default()));
+
+    ts::register_fan(fan.device()).await.unwrap();
+    spawner.must_spawn(mock_fan_task(fan));
+}
+
+async fn init_thermal(spawner: Spawner) {
+    info!("Initializing thermal service");
+    ts::init().await.unwrap();
+
+    init_sensor(spawner).await;
+    init_fan(spawner).await;
+}
+
+#[embassy_executor::task]
+async fn handle_alerts() {
+    loop {
+        match ts::wait_event().await {
+            ts::Event::ThresholdExceeded(ts::sensor::DeviceId(sensor_id), ts::sensor::ThresholdType::WarnHigh, _) => {
+                warn!("Sensor {sensor_id} exceeded WARN threshold");
+                ts::send_service_msg(comms::EndpointID::External(comms::External::Host), &mptf::Notify::Warn)
+                    .await
+                    .unwrap()
+            }
+            ts::Event::ThresholdExceeded(ts::sensor::DeviceId(sensor_id), ts::sensor::ThresholdType::Prochot, _) => {
+                warn!("Sensor {sensor_id} exceeded PROCHOT threshold");
+                ts::send_service_msg(
+                    comms::EndpointID::External(comms::External::Host),
+                    &mptf::Notify::ProcHot,
+                )
+                .await
+                .unwrap()
+            }
+            ts::Event::ThresholdExceeded(ts::sensor::DeviceId(sensor_id), ts::sensor::ThresholdType::Critical, _) => {
+                warn!("Sensor {sensor_id} exceeded CRITICAL threshold");
+                ts::send_service_msg(
+                    comms::EndpointID::External(comms::External::Host),
+                    &mptf::Notify::Critical,
+                )
+                .await
+                .unwrap()
+            }
+            event => warn!("Event: {event:?}"),
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn run(spawner: Spawner) {
+    embedded_services::init().await;
+    init_thermal(spawner).await;
+    spawner.must_spawn(host());
+    spawner.must_spawn(handle_alerts());
+    spawner.must_spawn(ts::mptf::handle_requests());
+}
+
+fn main() {
+    env_logger::builder().filter_level(log::LevelFilter::Trace).init();
+
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.must_spawn(run(spawner));
+    });
+}
+
+ts::impl_sensor_task!(mock_sensor_task, MockSensor, 16);
+ts::impl_fan_task!(mock_fan_task, MockFan, 16);

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -288,6 +288,6 @@ version = "0.8.26"
 
 [[trusted.anyhow]]
 criteria = "safe-to-deploy"
-user-id = 3618              # David Tolnay (dtolnay)
+user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-10-05"
 end = "2026-04-16"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -79,6 +79,29 @@ notes = "ODP crates are always trusted."
 who = "Matteo Tullo <matteotullo@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.2.1"
+
+[[audits.embedded-fans]]
+who = "Kurtis Dinelle <kdinelle@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "ODP crates are always trusted."
+
+[[audits.embedded-fans-async]]
+who = "Kurtis Dinelle <kdinelle@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "ODP crates are always trusted."
+
+[[audits.embedded-sensors-hal]]
+who = "Kurtis Dinelle <kdinelle@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "ODP crates are always trusted."
+
+[[audits.embedded-sensors-hal-async]]
+who = "Kurtis Dinelle <kdinelle@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
 notes = "ODP crates are always trusted."
 
 [[audits.gimli]]
@@ -265,6 +288,6 @@ version = "0.8.26"
 
 [[trusted.anyhow]]
 criteria = "safe-to-deploy"
-user-id = 3618 # David Tolnay (dtolnay)
+user-id = 3618              # David Tolnay (dtolnay)
 start = "2019-10-05"
 end = "2026-04-16"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -221,6 +221,11 @@ who = "jerrysxie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.22.26"
 
+[[audits.uuid]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.17.0"
+
 [[audits.windows-targets]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-run"

--- a/thermal-service/Cargo.toml
+++ b/thermal-service/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "thermal-service"
+version = "0.1.0"
+edition = "2024"
+description = "Thermal service implementation"
+repository = "https://github.com/OpenDevicePartnership/embedded-services"
+rust-version = "1.85"
+license = "MIT"
+
+[dependencies]
+defmt = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+embassy-executor.workspace = true
+embassy-futures.workspace = true
+embassy-sync.workspace = true
+embassy-time.workspace = true
+embedded-hal-async.workspace = true
+embedded-hal.workspace = true
+embedded-services.workspace = true
+heapless.workspace = true
+uuid.workspace = true
+embedded-fans-async = "0.2.0"
+embedded-sensors-hal-async = "0.3.0"
+
+[features]
+default = []
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embassy-time/defmt",
+    "embassy-sync/defmt",
+    "embassy-executor/defmt",
+    "embedded-fans-async/defmt",
+    "embedded-sensors-hal-async/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "embassy-time/log",
+    "embassy-sync/log",
+    "embassy-executor/log",
+]

--- a/thermal-service/src/context.rs
+++ b/thermal-service/src/context.rs
@@ -1,0 +1,124 @@
+//! Thermal service context
+use crate::mctp;
+use crate::mptf;
+use crate::{Error, Event, fan, sensor};
+use embassy_sync::channel::Channel;
+use embedded_services::GlobalRawMutex;
+use embedded_services::{error, intrusive_list};
+
+pub(crate) struct Context {
+    // Registered temperature sensors
+    sensors: intrusive_list::IntrusiveList,
+    // Registered fans
+    fans: intrusive_list::IntrusiveList,
+    // MPTF Request Queue
+    mptf: Channel<GlobalRawMutex, mptf::Request, 10>,
+    // Raw MCTP Payload Queue
+    mctp: Channel<GlobalRawMutex, mctp::Payload, 10>,
+    // Event queue
+    events: Channel<GlobalRawMutex, Event, 10>,
+}
+
+impl Context {
+    pub(crate) fn new() -> Self {
+        Self {
+            sensors: intrusive_list::IntrusiveList::new(),
+            fans: intrusive_list::IntrusiveList::new(),
+            mptf: Channel::new(),
+            mctp: Channel::new(),
+            events: Channel::new(),
+        }
+    }
+
+    pub(crate) async fn register_sensor(&self, sensor: &'static sensor::Device) -> Result<(), intrusive_list::Error> {
+        if self.get_sensor(sensor.id()).await.is_some() {
+            return Err(intrusive_list::Error::NodeAlreadyInList);
+        }
+
+        self.sensors.push(sensor)
+    }
+
+    pub(crate) async fn sensors(&self) -> &intrusive_list::IntrusiveList {
+        &self.sensors
+    }
+
+    pub(crate) async fn get_sensor(&self, id: sensor::DeviceId) -> Option<&'static sensor::Device> {
+        for sensor in &self.sensors {
+            if let Some(data) = sensor.data::<sensor::Device>() {
+                if data.id() == id {
+                    return Some(data);
+                }
+            } else {
+                error!("Non-device located in sensors list");
+            }
+        }
+
+        None
+    }
+
+    pub(crate) async fn execute_sensor_request(
+        &self,
+        id: sensor::DeviceId,
+        request: sensor::Request,
+    ) -> sensor::Response {
+        let sensor = self.get_sensor(id).await.ok_or(sensor::Error::InvalidRequest)?;
+        sensor.execute_request(request).await
+    }
+
+    pub(crate) async fn register_fan(&self, fan: &'static fan::Device) -> Result<(), intrusive_list::Error> {
+        if self.get_fan(fan.id()).await.is_some() {
+            return Err(intrusive_list::Error::NodeAlreadyInList);
+        }
+
+        self.fans.push(fan)
+    }
+
+    pub(crate) async fn fans(&self) -> &intrusive_list::IntrusiveList {
+        &self.fans
+    }
+
+    pub(crate) async fn get_fan(&self, id: fan::DeviceId) -> Option<&'static fan::Device> {
+        for fan in &self.fans {
+            if let Some(data) = fan.data::<fan::Device>() {
+                if data.id() == id {
+                    return Some(data);
+                }
+            } else {
+                error!("Non-device located in fan list");
+            }
+        }
+
+        None
+    }
+
+    pub(crate) async fn execute_fan_request(&self, id: fan::DeviceId, request: fan::Request) -> fan::Response {
+        let fan = self.get_fan(id).await.ok_or(fan::Error::InvalidRequest)?;
+        fan.execute_request(request).await
+    }
+
+    pub(crate) fn send_mptf_request(&self, msg: mptf::Request) -> Result<(), Error> {
+        self.mptf.try_send(msg).map_err(|_| Error)?;
+        Ok(())
+    }
+
+    pub(crate) async fn wait_mptf_request(&self) -> mptf::Request {
+        self.mptf.receive().await
+    }
+
+    pub(crate) fn send_mctp_payload(&self, msg: mctp::Payload) -> Result<(), Error> {
+        self.mctp.try_send(msg).map_err(|_| Error)?;
+        Ok(())
+    }
+
+    pub(crate) async fn wait_mctp_payload(&self) -> mctp::Payload {
+        self.mctp.receive().await
+    }
+
+    pub(crate) async fn send_event(&self, event: Event) {
+        self.events.send(event).await
+    }
+
+    pub(crate) async fn wait_event(&self) -> Event {
+        self.events.receive().await
+    }
+}

--- a/thermal-service/src/fan.rs
+++ b/thermal-service/src/fan.rs
@@ -1,0 +1,540 @@
+//! Fan Device
+use crate::utils::SampleBuf;
+use crate::{Event, send_event};
+use embassy_sync::mutex::Mutex;
+use embassy_sync::signal::Signal;
+use embassy_time::Timer;
+use embedded_fans_async::{self as fan_traits, Error as HardwareError};
+use embedded_sensors_hal_async::temperature::DegreesCelsius;
+use embedded_services::GlobalRawMutex;
+use embedded_services::ipc::deferred as ipc;
+use embedded_services::{Node, intrusive_list};
+use embedded_services::{error, trace};
+
+/// Convenience type for Fan response result
+pub type Response = Result<ResponseData, Error>;
+
+/// Allows OEM to implement custom requests
+///
+/// The default response is to return an error on unrecognized requests
+pub trait CustomRequestHandler {
+    fn handle_custom_request(&self, _request: Request) -> impl core::future::Future<Output = Response> {
+        async { Err(Error::InvalidRequest) }
+    }
+}
+
+/// Allows OEMs to override the default linear response ramp response of fan
+pub trait RampResponseHandler: fan_traits::Fan + fan_traits::RpmSense {
+    fn handle_ramp_response(
+        &mut self,
+        profile: &Profile,
+        temp: DegreesCelsius,
+    ) -> impl core::future::Future<Output = Result<(), Self::Error>> {
+        let fan_ramp_temp = profile.ramp_temp;
+        let fan_max_temp = profile.max_temp;
+        let min_rpm = self.min_start_rpm();
+        let max_rpm = self.max_rpm();
+
+        // Provide a linear fan response between its min and max RPM relative to temperature between ramp start and max temp
+        let rpm = if temp <= fan_ramp_temp {
+            min_rpm
+        } else if temp >= fan_max_temp {
+            max_rpm
+        } else {
+            let ratio = (temp - fan_ramp_temp) / (fan_max_temp - fan_ramp_temp);
+            let range = (max_rpm - min_rpm) as f32;
+            min_rpm + (ratio * range) as u16
+        };
+
+        async move {
+            self.set_speed_rpm(rpm).await?;
+            Ok(())
+        }
+    }
+}
+
+/// Ensures all necessary traits are implemented for the controlling driver
+pub trait Controller: RampResponseHandler + CustomRequestHandler {}
+
+/// Fan error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Invalid request
+    InvalidRequest,
+    /// Device encountered a hardware failure
+    Hardware,
+}
+
+/// Fan request
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Request {
+    /// Most recent RPM measurement
+    GetRpm,
+    /// Average RPM measurement
+    GetAvgRpm,
+    /// Get Min RPM
+    GetMinRpm,
+    /// Get Max RPM
+    GetMaxRpm,
+    /// Set RPM manually and disable temperature-based control
+    SetRpm(u16),
+    /// Set duty cycle manually (in percent) and disable temperature-based control
+    SetDuty(u8),
+    /// Stop the fan and disable temperature-based control
+    Stop,
+    /// Enable temperature-based control
+    EnableAutoControl,
+    /// Set RPM sampling period (in ms)
+    SetSamplingPeriod(u64),
+    /// Set speed update period
+    SetSpeedUpdatePeriod(u64),
+    /// Get temperature which fan will turn on to minimum RPM (in degrees Celsius)
+    GetOnTemp,
+    /// Get temperature which fan will begin ramping (in degrees Celsius)
+    GetRampTemp,
+    /// Get temperature which fan will reach its max RPM (in degrees Celsius)
+    GetMaxTemp,
+    /// Set temperature which fan will turn on to minimum RPM (in degrees Celsius)
+    SetOnTemp(DegreesCelsius),
+    /// Set temperature which fan will begin ramping (in degrees Celsius)
+    SetRampTemp(DegreesCelsius),
+    /// Set temperature which fan will reach its max RPM (in degrees Celsius)
+    SetMaxTemp(DegreesCelsius),
+    /// Set hysteresis value between fan on and fan off (in degrees Celsius)
+    SetHysteresis(DegreesCelsius),
+    /// Get the profile associated with this fan
+    GetProfile,
+    /// Set the profile associated with this fan
+    SetProfile(Profile),
+    /// Custom-implemented command
+    Custom(u8, &'static [u8]),
+}
+
+/// Fan response
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    /// Response for any request that is successful but does not require data
+    Success,
+    /// RPM
+    Rpm(u16),
+    /// Temperature
+    Temp(DegreesCelsius),
+    /// Profile
+    Profile(Profile),
+    /// Custom-implemented response
+    Custom(&'static [u8]),
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+enum FanState {
+    Off,
+    On,
+    Ramping,
+    Max,
+}
+
+/// Fan device ID new type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceId(pub u8);
+
+/// Fan device struct
+pub struct Device {
+    // Intrusive list node allowing Device to be contained in a list
+    node: Node,
+    // Device ID
+    id: DeviceId,
+    // Channel for IPC requests and responses
+    ipc: ipc::Channel<GlobalRawMutex, Request, Response>,
+    // Signal for auto-control enable
+    auto_control_enable: Signal<GlobalRawMutex, ()>,
+}
+
+impl Device {
+    /// Create a new fan device
+    pub fn new(id: DeviceId) -> Self {
+        Self {
+            node: Node::uninit(),
+            id,
+            ipc: ipc::Channel::new(),
+            auto_control_enable: Signal::new(),
+        }
+    }
+
+    /// Get the device ID
+    pub fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    /// Execute request and wait for response
+    pub async fn execute_request(&self, request: Request) -> Response {
+        self.ipc.execute(request).await
+    }
+}
+
+impl intrusive_list::NodeContainer for Device {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+/// Fan profile
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Profile {
+    /// Profile ID
+    pub id: usize,
+    /// ID of sensor this fan will query for auto control
+    pub sensor_id: crate::sensor::DeviceId,
+    /// Period (in ms) fan will sample its RPM
+    pub sample_period: u64,
+    /// Period (in ms) fan will update its state during auto control
+    pub update_period: u64,
+    /// Whether fan is under automatic temperature-based control or not
+    pub auto_control: bool,
+    /// Hysteresis value (in degrees Celsius) preventing fan from rapidly switching between states
+    pub hysteresis: DegreesCelsius,
+    /// Temperature (in degrees Celsius) at which fan will turn on
+    pub on_temp: DegreesCelsius,
+    /// Temperature (in degrees Celsius) at which fan will begin its ramp response
+    pub ramp_temp: DegreesCelsius,
+    /// Temperature (in degrees Celsius) at which fan will run at its max speed
+    pub max_temp: DegreesCelsius,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            sensor_id: crate::sensor::DeviceId(0),
+            sample_period: 1000,
+            update_period: 1000,
+            auto_control: true,
+            hysteresis: 2.0,
+            on_temp: 39.0,
+            ramp_temp: 40.0,
+            max_temp: 44.0,
+        }
+    }
+}
+
+/// Fan struct containing device for comms and driver
+pub struct Fan<T: Controller, const SAMPLE_BUF_LEN: usize> {
+    // Underlying device
+    device: Device,
+    // Underlying controller
+    controller: Mutex<GlobalRawMutex, T>,
+    // Fan profile
+    profile: Mutex<GlobalRawMutex, Profile>,
+    // RPM samples
+    samples: Mutex<GlobalRawMutex, SampleBuf<u16, SAMPLE_BUF_LEN>>,
+    // State
+    state: Mutex<GlobalRawMutex, FanState>,
+}
+
+impl<T: Controller, const SAMPLE_BUF_LEN: usize> Fan<T, SAMPLE_BUF_LEN> {
+    /// New fan
+    ///
+    /// Sample buffer length MUST be a power of two
+    pub fn new(id: DeviceId, controller: T, profile: Profile) -> Self {
+        Self {
+            device: Device::new(id),
+            controller: Mutex::new(controller),
+            profile: Mutex::new(profile),
+            samples: Mutex::new(SampleBuf::create()),
+            state: Mutex::new(FanState::Off),
+        }
+    }
+
+    /// Retrieve a reference to underlying device for registration with services
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    /// Retrieve a Mutex wrapping the underlying controller
+    ///
+    /// Should only be used to update OEM specific state
+    pub fn controller(&self) -> &Mutex<GlobalRawMutex, T> {
+        &self.controller
+    }
+
+    /// Wait for fan to receive a request
+    pub async fn wait_request(&self) -> ipc::Request<'_, GlobalRawMutex, Request, Response> {
+        self.device.ipc.receive().await
+    }
+
+    /// Process fan request
+    pub async fn process_request(&self, request: Request) -> Response {
+        match request {
+            Request::GetRpm => {
+                let rpm = self.samples.lock().await.recent();
+                Ok(ResponseData::Rpm(rpm))
+            }
+            Request::GetAvgRpm => {
+                let rpm = self.samples.lock().await.average();
+                Ok(ResponseData::Rpm(rpm))
+            }
+            Request::SetRpm(rpm) => {
+                self.controller
+                    .lock()
+                    .await
+                    .set_speed_rpm(rpm)
+                    .await
+                    .map_err(|_| Error::Hardware)?;
+                self.profile.lock().await.auto_control = false;
+                Ok(ResponseData::Success)
+            }
+            Request::SetDuty(percent) => {
+                self.controller
+                    .lock()
+                    .await
+                    .set_speed_percent(percent)
+                    .await
+                    .map_err(|_| Error::Hardware)?;
+                self.profile.lock().await.auto_control = false;
+                Ok(ResponseData::Success)
+            }
+            Request::Stop => {
+                self.change_state(FanState::Off).await?;
+                self.profile.lock().await.auto_control = false;
+                Ok(ResponseData::Success)
+            }
+            Request::GetMinRpm => {
+                let min_rpm = self.controller.lock().await.min_rpm();
+                Ok(ResponseData::Rpm(min_rpm))
+            }
+            Request::GetMaxRpm => {
+                let max_rpm = self.controller.lock().await.max_rpm();
+                Ok(ResponseData::Rpm(max_rpm))
+            }
+            Request::SetSamplingPeriod(period) => {
+                self.profile.lock().await.sample_period = period;
+                Ok(ResponseData::Success)
+            }
+            Request::EnableAutoControl => {
+                // Make sure we actually transition to a known state
+                // Next iteration of handle auto control would then put it in actual correct state
+                self.change_state(FanState::Off).await?;
+                self.profile.lock().await.auto_control = true;
+                self.device.auto_control_enable.signal(());
+                Ok(ResponseData::Success)
+            }
+            Request::SetSpeedUpdatePeriod(period) => {
+                self.profile.lock().await.update_period = period;
+                Ok(ResponseData::Success)
+            }
+            Request::GetOnTemp => {
+                let temp = self.profile.lock().await.on_temp;
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::GetRampTemp => {
+                let temp = self.profile.lock().await.ramp_temp;
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::GetMaxTemp => {
+                let temp = self.profile.lock().await.max_temp;
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::SetOnTemp(temp) => {
+                self.profile.lock().await.on_temp = temp;
+                Ok(ResponseData::Success)
+            }
+            Request::SetRampTemp(temp) => {
+                self.profile.lock().await.ramp_temp = temp;
+                Ok(ResponseData::Success)
+            }
+            Request::SetMaxTemp(temp) => {
+                self.profile.lock().await.max_temp = temp;
+                Ok(ResponseData::Success)
+            }
+            Request::SetHysteresis(temp) => {
+                self.profile.lock().await.hysteresis = temp;
+                Ok(ResponseData::Success)
+            }
+            Request::GetProfile => {
+                let profile = *self.profile.lock().await;
+                Ok(ResponseData::Profile(profile))
+            }
+            Request::SetProfile(profile) => {
+                *self.profile.lock().await = profile;
+                Ok(ResponseData::Success)
+            }
+            Request::Custom(_, _) => self.controller.lock().await.handle_custom_request(request).await,
+        }
+    }
+
+    /// Wait for fan to receive a request, process it, and send a response
+    pub async fn wait_and_process(&self) {
+        let request = self.wait_request().await;
+        let response = self.process_request(request.command).await;
+        request.respond(response);
+    }
+
+    /// Waits for a IPC request, then processes it
+    pub async fn handle_rx(&self) {
+        loop {
+            self.wait_and_process().await;
+        }
+    }
+
+    /// Periodically samples RPM from physical fan and caches it
+    pub async fn handle_sampling(&self) {
+        loop {
+            match self.controller.lock().await.rpm().await {
+                Ok(rpm) => self.samples.lock().await.push(rpm),
+                Err(e) => error!("Fan {} error sampling fan rpm: {:?}", self.device.id.0, e.kind()),
+            }
+
+            let period = self.profile.lock().await.sample_period;
+            Timer::after_millis(period).await;
+        }
+    }
+
+    pub async fn handle_auto_control(&self) {
+        loop {
+            if self.profile.lock().await.auto_control {
+                let temp = match crate::execute_sensor_request(
+                    self.profile.lock().await.sensor_id,
+                    crate::sensor::Request::GetTemp,
+                )
+                .await
+                {
+                    Ok(crate::sensor::ResponseData::Temp(temp)) => temp,
+                    _ => {
+                        error!(
+                            "Fan {} failed to get temperature, disabling auto control and setting speed to max",
+                            self.device.id.0
+                        );
+
+                        self.profile.lock().await.auto_control = false;
+                        if self.controller.lock().await.set_speed_max().await.is_err() {
+                            error!("Fan {} failed to set speed to max!", self.device.id.0);
+                        }
+
+                        send_event(Event::FanFailure(self.device.id, Error::Hardware)).await;
+                        continue;
+                    }
+                };
+
+                if let Err(e) = self.handle_fan_state(temp).await {
+                    send_event(Event::FanFailure(self.device.id, e)).await;
+                    error!("Fan {} error handling fan state transition: {:?}", self.device.id.0, e);
+                }
+
+                let sleep_duration = self.profile.lock().await.update_period;
+                Timer::after_millis(sleep_duration).await;
+
+            // Sleep until auto control is re-enabled
+            } else {
+                self.device.auto_control_enable.wait().await;
+            }
+        }
+    }
+
+    async fn handle_fan_off_state(&self, temp: DegreesCelsius) -> Result<(), Error> {
+        let profile = self.profile.lock().await;
+
+        if temp >= profile.on_temp {
+            self.change_state(FanState::On).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_fan_on_state(&self, temp: DegreesCelsius) -> Result<(), Error> {
+        let profile = self.profile.lock().await;
+
+        if temp < (profile.on_temp - profile.hysteresis) {
+            self.change_state(FanState::Off).await?;
+        } else if temp >= profile.ramp_temp {
+            self.change_state(FanState::Ramping).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_fan_ramping_state(&self, temp: DegreesCelsius) -> Result<(), Error> {
+        let profile = self.profile.lock().await;
+
+        if temp < (profile.ramp_temp - profile.hysteresis) {
+            self.change_state(FanState::On).await?;
+        } else if temp >= profile.max_temp {
+            self.change_state(FanState::Max).await?;
+        } else {
+            self.controller
+                .lock()
+                .await
+                .handle_ramp_response(&profile, temp)
+                .await
+                .map_err(|_| Error::Hardware)?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_fan_max_state(&self, temp: DegreesCelsius) -> Result<(), Error> {
+        let profile = self.profile.lock().await;
+
+        if temp < (profile.max_temp - profile.hysteresis) {
+            self.change_state(FanState::Ramping).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn change_state(&self, to: FanState) -> Result<(), Error> {
+        let mut controller = self.controller.lock().await;
+        match to {
+            FanState::Off => {
+                controller.stop().await.map_err(|_| Error::Hardware)?;
+            }
+            FanState::On => {
+                controller.start().await.map_err(|_| Error::Hardware)?;
+            }
+            FanState::Ramping => {
+                // Ramp state will continuously update RPM according to its ramp response function
+            }
+            FanState::Max => {
+                let max_rpm = controller.max_rpm();
+                let _ = controller.set_speed_rpm(max_rpm).await.map_err(|_| Error::Hardware)?;
+            }
+        }
+        drop(controller);
+
+        let state = *self.state.lock().await;
+        trace!(
+            "Fan {} transitioned to {:?} state from {:?} state",
+            self.device.id.0, to, state
+        );
+        *self.state.lock().await = to;
+
+        Ok(())
+    }
+
+    async fn handle_fan_state(&self, temp: DegreesCelsius) -> Result<(), Error> {
+        // Must copy state here, if attempt to dereference in match, mutex is still held in match arms
+        let state = *self.state.lock().await;
+        match state {
+            FanState::Off => self.handle_fan_off_state(temp).await,
+            FanState::On => self.handle_fan_on_state(temp).await,
+            FanState::Ramping => self.handle_fan_ramping_state(temp).await,
+            FanState::Max => self.handle_fan_max_state(temp).await,
+        }
+    }
+}
+
+/// This is a public helper macro for wrapping and spawning the various tasks since currently tasks cannot be generic
+#[macro_export]
+macro_rules! impl_fan_task {
+    ($fan_task_name:ident, $fan_type:ty, $sample_buf_len:expr) => {
+        #[embassy_executor::task]
+        pub async fn $fan_task_name(fan: &'static $crate::fan::Fan<$fan_type, $sample_buf_len>) {
+            let _ =
+                embassy_futures::join::join3(fan.handle_rx(), fan.handle_sampling(), fan.handle_auto_control()).await;
+        }
+    };
+}

--- a/thermal-service/src/lib.rs
+++ b/thermal-service/src/lib.rs
@@ -1,0 +1,154 @@
+//! Thermal service
+#![no_std]
+
+use embassy_sync::once_lock::OnceLock;
+use embedded_sensors_hal_async::temperature::DegreesCelsius;
+use embedded_services::{comms, error, info, intrusive_list};
+
+mod context;
+pub mod fan;
+pub mod mctp;
+pub mod mptf;
+pub mod sensor;
+pub mod utils;
+
+/// Thermal error
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Error;
+
+/// Thermal event
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Event {
+    /// Sensor sampled temperature exceeding a threshold
+    ThresholdExceeded(sensor::DeviceId, sensor::ThresholdType, DegreesCelsius),
+    /// Sensor is no longer exceeding a threshold
+    ThresholdCleared(sensor::DeviceId, sensor::ThresholdType),
+    /// Sensor encountered hardware failure
+    SensorFailure(sensor::DeviceId, sensor::Error),
+    /// Fan encountered hardware failure
+    FanFailure(fan::DeviceId, fan::Error),
+}
+
+struct Service {
+    context: context::Context,
+    endpoint: comms::Endpoint,
+}
+
+impl Service {
+    fn new() -> Self {
+        Self {
+            context: context::Context::new(),
+            endpoint: comms::Endpoint::uninit(comms::EndpointID::Internal(comms::Internal::Thermal)),
+        }
+    }
+}
+
+impl comms::MailboxDelegate for Service {
+    fn receive(&self, message: &comms::Message) -> Result<(), comms::MailboxDelegateError> {
+        // Queue for later processing
+        if let Some(&msg) = message.data.get::<mctp::Payload>() {
+            self.context
+                .send_mctp_payload(msg)
+                .map_err(|_| comms::MailboxDelegateError::BufferFull)
+        } else if let Some(&msg) = message.data.get::<mptf::Request>() {
+            self.context
+                .send_mptf_request(msg)
+                .map_err(|_| comms::MailboxDelegateError::BufferFull)
+        } else {
+            Err(comms::MailboxDelegateError::InvalidData)
+        }
+    }
+}
+
+// Just one instance of the service should be running
+static SERVICE: OnceLock<Service> = OnceLock::new();
+
+/// This must be called to initialize the Thermal service
+pub async fn init() -> Result<(), Error> {
+    info!("Starting thermal service task");
+    let service = SERVICE.get_or_init(Service::new);
+
+    if comms::register_endpoint(service, &service.endpoint).await.is_err() {
+        error!("Failed to register thermal service endpoint");
+        Err(Error)
+    } else {
+        Ok(())
+    }
+}
+
+// TODO: Don't like the code duplication from all these wrappers, consider better approach
+
+/// Used to send messages to other services from the Thermal service,
+/// such as notifying the Host of thresholds crossed or the Power service if CRT TEMP is reached.
+pub async fn send_service_msg(to: comms::EndpointID, data: &impl embedded_services::Any) -> Result<(), Error> {
+    // TODO: When this gets updated to return error, handle retrying send on failure
+    SERVICE.get().await.endpoint.send(to, data).await.map_err(|_| Error)?;
+    Ok(())
+}
+
+/// Send a MPTF request
+pub async fn queue_mptf_request(msg: mptf::Request) -> Result<(), Error> {
+    SERVICE.get().await.context.send_mptf_request(msg)
+}
+
+/// Wait for a MPTF request
+pub async fn wait_mptf_request() -> mptf::Request {
+    SERVICE.get().await.context.wait_mptf_request().await
+}
+
+/// Wait for a MCTP payload
+pub async fn wait_mctp_payload() -> mctp::Payload {
+    SERVICE.get().await.context.wait_mctp_payload().await
+}
+
+/// Send a thermal event
+pub async fn send_event(event: Event) {
+    SERVICE.get().await.context.send_event(event).await
+}
+
+/// Wait for a thermal event
+pub async fn wait_event() -> Event {
+    SERVICE.get().await.context.wait_event().await
+}
+
+/// Register a sensor with the thermal service
+pub async fn register_sensor(sensor: &'static sensor::Device) -> Result<(), intrusive_list::Error> {
+    SERVICE.get().await.context.register_sensor(sensor).await
+}
+
+/// Provides access to the sensors list
+pub async fn sensors() -> &'static intrusive_list::IntrusiveList {
+    SERVICE.get().await.context.sensors().await
+}
+
+/// Find a sensor by its ID
+pub async fn get_sensor(id: sensor::DeviceId) -> Option<&'static sensor::Device> {
+    SERVICE.get().await.context.get_sensor(id).await
+}
+
+/// Send a request to a sensor through the thermal service instead of directly.
+pub async fn execute_sensor_request(id: sensor::DeviceId, request: sensor::Request) -> sensor::Response {
+    SERVICE.get().await.context.execute_sensor_request(id, request).await
+}
+
+/// Register a fan with the thermal service
+pub async fn register_fan(fan: &'static fan::Device) -> Result<(), intrusive_list::Error> {
+    SERVICE.get().await.context.register_fan(fan).await
+}
+
+/// Provides access to the fans list
+pub async fn fans() -> &'static intrusive_list::IntrusiveList {
+    SERVICE.get().await.context.fans().await
+}
+
+/// Find a fan by its ID
+pub async fn get_fan(id: fan::DeviceId) -> Option<&'static fan::Device> {
+    SERVICE.get().await.context.get_fan(id).await
+}
+
+/// Send a request to a fan through the thermal service instead of directly.
+pub async fn execute_fan_request(id: fan::DeviceId, request: fan::Request) -> fan::Response {
+    SERVICE.get().await.context.execute_fan_request(id, request).await
+}

--- a/thermal-service/src/mctp.rs
+++ b/thermal-service/src/mctp.rs
@@ -1,0 +1,167 @@
+use crate::mptf::*;
+
+pub const CURRENT_VERSION: u8 = 1;
+
+/// Raw MCTP Payload
+pub type Payload = ([u8; 69], usize);
+
+/// MCTP Payload Error
+pub struct PayloadError {
+    command: u8,
+    error: Status,
+}
+
+impl PayloadError {
+    fn new(command: u8, error: Status) -> Self {
+        Self { command, error }
+    }
+}
+
+impl TryFrom<Payload> for Request {
+    type Error = PayloadError;
+    fn try_from(payload: Payload) -> Result<Self, Self::Error> {
+        let payload_len = payload.1;
+        let (version, _rsvd, _status, command, data) = (
+            payload.0[0],
+            payload.0[1],
+            payload.0[2],
+            payload.0[3],
+            &payload.0[4..payload_len],
+        );
+        if version != CURRENT_VERSION {
+            return Err(PayloadError::new(command, Status::UnsupportedRevision));
+        }
+
+        match command {
+            1 => Ok(Request::GetTmp(data[0])),
+
+            2 => Ok(Request::SetThrs(
+                data[0],
+                Milliseconds::from_le_bytes(
+                    data[1..5]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+                DeciKelvin::from_le_bytes(
+                    data[5..9]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+                DeciKelvin::from_le_bytes(
+                    data[9..13]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+            )),
+
+            3 => Ok(Request::GetThrs(data[0])),
+
+            4 => Ok(Request::SetScp(
+                data[0],
+                Dword::from_le_bytes(
+                    data[1..5]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+                Dword::from_le_bytes(
+                    data[5..9]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+                Dword::from_le_bytes(
+                    data[9..13]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+            )),
+
+            5 => Ok(Request::GetVar(
+                data[0],
+                VarLen::from_le_bytes(
+                    data[1..3]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+                data[3..19]
+                    .try_into()
+                    .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+            )),
+
+            6 => Ok(Request::SetVar(
+                data[0],
+                VarLen::from_le_bytes(
+                    data[1..3]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+                data[3..19]
+                    .try_into()
+                    .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                Dword::from_le_bytes(
+                    data[19..23]
+                        .try_into()
+                        .map_err(|_| PayloadError::new(command, Status::InvalidParameter))?,
+                ),
+            )),
+
+            _ => Err(PayloadError::new(command, Status::InvalidParameter)),
+        }
+    }
+}
+
+impl From<Response> for Payload {
+    fn from(response: Response) -> Self {
+        let mut payload = [0; 69];
+        payload[0] = CURRENT_VERSION; // Version
+        payload[1] = 0; // Reserved
+        payload[2] = u8::from(response.status); // Status
+        payload[3] = response.data.into(); // Command
+
+        let (header, data) = payload.split_at_mut(4);
+        let header_len = header.len();
+
+        let data_len = match response.data {
+            ResponseData::GetTmp(temp) => {
+                data[0..4].copy_from_slice(&temp.to_le_bytes());
+                4
+            }
+            ResponseData::SetThrs(status) => {
+                data[0..4].copy_from_slice(&u32::from(status).to_le_bytes());
+                4
+            }
+            ResponseData::GetThrs(status, timeout, low_dk, high_dk) => {
+                data[0..4].copy_from_slice(&u32::from(status).to_le_bytes());
+                data[4..8].copy_from_slice(&timeout.to_le_bytes());
+                data[8..12].copy_from_slice(&low_dk.to_le_bytes());
+                data[12..16].copy_from_slice(&high_dk.to_le_bytes());
+                16
+            }
+            ResponseData::SetScp(status) => {
+                data[0..4].copy_from_slice(&u32::from(status).to_le_bytes());
+                4
+            }
+            ResponseData::GetVar(status, value) => {
+                data[0..4].copy_from_slice(&u32::from(status).to_le_bytes());
+                data[4..8].copy_from_slice(&value.to_le_bytes());
+                8
+            }
+            ResponseData::SetVar(status) => {
+                data[0..4].copy_from_slice(&u32::from(status).to_le_bytes());
+                4
+            }
+        };
+
+        (payload, header_len + data_len)
+    }
+}
+
+impl From<PayloadError> for Payload {
+    fn from(mctp_error: PayloadError) -> Self {
+        let mut payload = [0; 69];
+        payload[0] = CURRENT_VERSION; // Version
+        payload[1] = 0; // Reserved
+        payload[2] = u8::from(mctp_error.error); // Status
+        payload[3] = mctp_error.command; // Command
+        (payload, 4)
+    }
+}

--- a/thermal-service/src/mptf.rs
+++ b/thermal-service/src/mptf.rs
@@ -362,10 +362,13 @@ pub async fn handle_requests() {
                     // Packet is OK
                     Ok(request) => {
                         let response = process_request(request).await;
-                        mctp::Payload::from(response)
+                        mctp::AcpiMsgComms::from(response)
                     }
                     // Packet is malformed
-                    Err(payload_error) => mctp::Payload::from(payload_error),
+                    Err(payload_error) => {
+                        error!("Thermal received malformed packet");
+                        mctp::AcpiMsgComms::from(payload_error)
+                    }
                 };
                 ts::send_service_msg(comms::EndpointID::External(comms::External::Host), &response).await
             }

--- a/thermal-service/src/mptf.rs
+++ b/thermal-service/src/mptf.rs
@@ -1,0 +1,378 @@
+//! Definitions for standard MPTF messages the generic Thermal service can expect
+//!
+//! Transport services such as eSPI and SSH would need to ensure messages are sent to the Thermal service in this format.
+//!
+//! This interface is subject to change as the eSPI OOB service is developed
+use crate::mctp;
+use crate::{self as ts, fan, sensor, utils};
+use embassy_futures::select::Either;
+use embedded_services::{comms, error};
+
+/// MPTF Standard UUIDs which the thermal service understands
+pub mod uuid_standard {
+    pub const CRT_TEMP: uuid::Bytes = uuid::uuid!("218246e7-baf6-45f1-aa13-07e4845256b8").to_bytes_le();
+    pub const PROC_HOT_TEMP: uuid::Bytes = uuid::uuid!("22dc52d2-fd0b-47ab-95b8-26552f9831a5").to_bytes_le();
+    pub const PROFILE_TYPE: uuid::Bytes = uuid::uuid!("23b4a025-cdfd-4af9-a411-37a24c574615").to_bytes_le();
+    pub const FAN_ON_TEMP: uuid::Bytes = uuid::uuid!("ba17b567-c368-48d5-bc6f-a312a41583c1").to_bytes_le();
+    pub const FAN_RAMP_TEMP: uuid::Bytes = uuid::uuid!("3a62688c-d95b-4d2d-bacc-90d7a5816bcd").to_bytes_le();
+    pub const FAN_MAX_TEMP: uuid::Bytes = uuid::uuid!("dcb758b1-f0fd-4ec7-b2c0-ef1e2a547b76").to_bytes_le();
+    pub const FAN_MIN_RPM: uuid::Bytes = uuid::uuid!("db261c77-934b-45e2-9742-256c62badb7a").to_bytes_le();
+    pub const FAN_MAX_RPM: uuid::Bytes = uuid::uuid!("5cf839df-8be7-42b9-9ac5-3403ca2c8a6a").to_bytes_le();
+    pub const FAN_CURRENT_RPM: uuid::Bytes = uuid::uuid!("adf95492-0776-4ffc-84f3-b6c8b5269683").to_bytes_le();
+}
+
+/// Standard 32-bit DWORD
+pub type Dword = u32;
+
+/// 16-bit variable length
+pub type VarLen = u16;
+
+/// Instance ID
+pub type InstanceId = u8;
+
+/// Time in milliseconds
+pub type Milliseconds = Dword;
+
+/// MPTF expects temperatures in tenth Kelvins
+pub type DeciKelvin = Dword;
+
+/// MPTF Response
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Response {
+    // Status code (not necessarily related to Status code in response)
+    // This is used because some commands can fail but don't contain Status output as part of MPTF spec
+    pub status: Status,
+    // Response data
+    pub data: ResponseData,
+}
+
+impl Response {
+    fn new(status: Status, data: ResponseData) -> Self {
+        Self { status, data }
+    }
+}
+
+/// MPTF Status
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Status {
+    /// Success
+    Success,
+    /// Invalid parameter was used
+    InvalidParameter,
+    /// Revision is not supported
+    UnsupportedRevision,
+    /// A hardware error occurred
+    HardwareError,
+}
+
+impl From<Status> for u32 {
+    fn from(status: Status) -> Self {
+        match status {
+            Status::Success => 0,
+            Status::InvalidParameter => 1,
+            Status::UnsupportedRevision => 2,
+            Status::HardwareError => 3,
+        }
+    }
+}
+
+impl From<Status> for u8 {
+    fn from(status: Status) -> Self {
+        u32::from(status) as u8
+    }
+}
+
+/// Standard MPTF requests expected by the thermal subsystem
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Request {
+    /// EC_THM_GET_TMP = 0x1
+    GetTmp(InstanceId),
+    /// EC_THM_SET_THRS = 0x2
+    SetThrs(InstanceId, Milliseconds, DeciKelvin, DeciKelvin),
+    /// EC_THM_GET_THRS = 0x3
+    GetThrs(InstanceId),
+    /// EC_THM_SET_SCP = 0x4
+    SetScp(InstanceId, Dword, Dword, Dword),
+    /// EC_THM_GET_VAR = 0x5
+    GetVar(InstanceId, VarLen, uuid::Bytes),
+    /// EC_THM_SET_VAR = 0x6
+    SetVar(InstanceId, VarLen, uuid::Bytes, Dword),
+}
+
+impl From<Request> for u8 {
+    fn from(request: Request) -> Self {
+        match request {
+            Request::GetTmp(_) => 1,
+            Request::SetThrs(_, _, _, _) => 2,
+            Request::GetThrs(_) => 3,
+            Request::SetScp(_, _, _, _) => 4,
+            Request::GetVar(_, _, _) => 5,
+            Request::SetVar(_, _, _, _) => 6,
+        }
+    }
+}
+
+/// Data returned by thermal subsystem in response to MPTF requests  
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    /// EC_THM_GET_TMP = 0x1
+    GetTmp(DeciKelvin),
+    /// EC_THM_SET_THRS = 0x2
+    SetThrs(Status),
+    /// EC_THM_GET_THRS = 0x3
+    GetThrs(Status, Milliseconds, DeciKelvin, DeciKelvin),
+    /// EC_THM_SET_SCP = 0x4
+    SetScp(Status),
+    /// EC_THM_GET_VAR = 0x5
+    GetVar(Status, Dword),
+    /// EC_THM_SET_VAR = 0x6
+    SetVar(Status),
+}
+
+impl From<ResponseData> for u8 {
+    fn from(response: ResponseData) -> Self {
+        match response {
+            ResponseData::GetTmp(_) => 1,
+            ResponseData::SetThrs(_) => 2,
+            ResponseData::GetThrs(_, _, _, _) => 3,
+            ResponseData::SetScp(_) => 4,
+            ResponseData::GetVar(_, _) => 5,
+            ResponseData::SetVar(_) => 6,
+        }
+    }
+}
+
+/// Notifications to Host
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Notify {
+    /// Warn threshold was exceeded
+    Warn,
+    /// Prochot threshold was exceeded
+    ProcHot,
+    /// Critical threshold was exceeded
+    Critical,
+}
+
+async fn sensor_get_tmp(tzid: InstanceId) -> Response {
+    match ts::execute_sensor_request(sensor::DeviceId(tzid), sensor::Request::GetTemp).await {
+        Ok(ts::sensor::ResponseData::Temp(temp)) => {
+            Response::new(Status::Success, ResponseData::GetTmp(utils::c_to_dk(temp)))
+        }
+        _ => Response::new(Status::HardwareError, ResponseData::GetTmp(0)),
+    }
+}
+
+async fn sensor_get_warn_thrs(tzid: InstanceId) -> Response {
+    let low = ts::execute_sensor_request(
+        sensor::DeviceId(tzid),
+        sensor::Request::GetThreshold(sensor::ThresholdType::WarnLow),
+    )
+    .await;
+    let high = ts::execute_sensor_request(
+        sensor::DeviceId(tzid),
+        sensor::Request::GetThreshold(sensor::ThresholdType::WarnHigh),
+    )
+    .await;
+
+    match (low, high) {
+        (Ok(sensor::ResponseData::Threshold(low)), Ok(sensor::ResponseData::Threshold(high))) => Response::new(
+            Status::Success,
+            ResponseData::GetThrs(Status::Success, 0, utils::c_to_dk(low), utils::c_to_dk(high)),
+        ),
+        _ => Response::new(Status::Success, ResponseData::GetThrs(Status::HardwareError, 0, 0, 0)),
+    }
+}
+
+async fn sensor_set_warn_thrs(tzid: InstanceId, _timeout: Dword, low: Dword, high: Dword) -> Response {
+    let low_res = ts::execute_sensor_request(
+        sensor::DeviceId(tzid),
+        sensor::Request::SetThreshold(sensor::ThresholdType::WarnLow, utils::dk_to_c(low)),
+    )
+    .await;
+    let high_res = ts::execute_sensor_request(
+        sensor::DeviceId(tzid),
+        sensor::Request::SetThreshold(sensor::ThresholdType::WarnHigh, utils::dk_to_c(high)),
+    )
+    .await;
+
+    if low_res.is_ok() && high_res.is_ok() {
+        Response::new(Status::Success, ResponseData::SetThrs(Status::Success))
+    } else {
+        Response::new(Status::Success, ResponseData::SetThrs(Status::HardwareError))
+    }
+}
+
+async fn sensor_get_thrs(instance: u8, threshold_type: sensor::ThresholdType) -> Response {
+    match ts::execute_sensor_request(
+        sensor::DeviceId(instance),
+        sensor::Request::GetThreshold(threshold_type),
+    )
+    .await
+    {
+        Ok(sensor::ResponseData::Temp(temp)) => Response::new(
+            Status::Success,
+            ResponseData::GetVar(Status::Success, utils::c_to_dk(temp)),
+        ),
+        _ => Response::new(Status::Success, ResponseData::GetVar(Status::HardwareError, 0)),
+    }
+}
+
+async fn fan_get_temp(instance: u8, fan_request: fan::Request) -> Response {
+    match ts::execute_fan_request(fan::DeviceId(instance), fan_request).await {
+        Ok(fan::ResponseData::Temp(temp)) => Response::new(
+            Status::Success,
+            ResponseData::GetVar(Status::Success, utils::c_to_dk(temp)),
+        ),
+        _ => Response::new(Status::Success, ResponseData::GetVar(Status::HardwareError, 0)),
+    }
+}
+
+async fn fan_get_rpm(instance: u8, fan_request: fan::Request) -> Response {
+    match ts::execute_fan_request(fan::DeviceId(instance), fan_request).await {
+        Ok(fan::ResponseData::Rpm(rpm)) => {
+            Response::new(Status::Success, ResponseData::GetVar(Status::Success, rpm as u32))
+        }
+        _ => Response::new(Status::Success, ResponseData::GetVar(Status::HardwareError, 0)),
+    }
+}
+
+async fn sensor_set_thrs(instance: u8, threshold_type: sensor::ThresholdType, threshold_dk: Dword) -> Response {
+    match ts::execute_sensor_request(
+        sensor::DeviceId(instance),
+        sensor::Request::SetThreshold(threshold_type, utils::dk_to_c(threshold_dk)),
+    )
+    .await
+    {
+        Ok(sensor::ResponseData::Success) => Response::new(Status::Success, ResponseData::SetVar(Status::Success)),
+        _ => Response::new(Status::Success, ResponseData::SetVar(Status::HardwareError)),
+    }
+}
+
+async fn fan_set_var(instance: u8, fan_request: fan::Request) -> Response {
+    match ts::execute_fan_request(fan::DeviceId(instance), fan_request).await {
+        Ok(fan::ResponseData::Success) => Response::new(Status::Success, ResponseData::SetVar(Status::Success)),
+        _ => Response::new(Status::Success, ResponseData::SetVar(Status::HardwareError)),
+    }
+}
+
+async fn process_request(request: Request) -> Response {
+    match request {
+        Request::GetTmp(tzid) => sensor_get_tmp(tzid).await,
+        Request::GetThrs(tzid) => sensor_get_warn_thrs(tzid).await,
+        Request::SetThrs(tzid, timeout, low, high) => sensor_set_warn_thrs(tzid, timeout, low, high).await,
+
+        // TODO: How do we handle this genericly?
+        Request::SetScp(_tzid, _policy_id, _acoustic_lim, _power_lim) => todo!(),
+
+        Request::GetVar(instance, _len, uuid_standard::CRT_TEMP) => {
+            sensor_get_thrs(instance, sensor::ThresholdType::Critical).await
+        }
+        Request::GetVar(instance, _len, uuid_standard::PROC_HOT_TEMP) => {
+            sensor_get_thrs(instance, sensor::ThresholdType::Prochot).await
+        }
+
+        // TODO: Add a GetProfileId request type? But of sensor or fan?
+        Request::GetVar(_instance, _len, uuid_standard::PROFILE_TYPE) => todo!(),
+
+        Request::GetVar(instance, _len, uuid_standard::FAN_ON_TEMP) => {
+            fan_get_temp(instance, fan::Request::GetOnTemp).await
+        }
+        Request::GetVar(instance, _len, uuid_standard::FAN_RAMP_TEMP) => {
+            fan_get_temp(instance, fan::Request::GetRampTemp).await
+        }
+        Request::GetVar(instance, _len, uuid_standard::FAN_MAX_TEMP) => {
+            fan_get_temp(instance, fan::Request::GetMaxTemp).await
+        }
+        Request::GetVar(instance, _len, uuid_standard::FAN_MIN_RPM) => {
+            fan_get_rpm(instance, fan::Request::GetMinRpm).await
+        }
+        Request::GetVar(instance, _len, uuid_standard::FAN_MAX_RPM) => {
+            fan_get_rpm(instance, fan::Request::GetMaxRpm).await
+        }
+        Request::GetVar(instance, _len, uuid_standard::FAN_CURRENT_RPM) => {
+            fan_get_rpm(instance, fan::Request::GetRpm).await
+        }
+
+        Request::SetVar(instance, _len, uuid_standard::CRT_TEMP, temp_dk) => {
+            sensor_set_thrs(instance, sensor::ThresholdType::Critical, temp_dk).await
+        }
+        Request::SetVar(instance, _len, uuid_standard::PROC_HOT_TEMP, temp_dk) => {
+            sensor_set_thrs(instance, sensor::ThresholdType::Prochot, temp_dk).await
+        }
+
+        // TODO: Add a SetProfileId request type? But for sensor or fan?
+        Request::SetVar(_instance, _len, uuid_standard::PROFILE_TYPE, _profile_id) => todo!(),
+
+        Request::SetVar(instance, _len, uuid_standard::FAN_ON_TEMP, temp_dk) => {
+            fan_set_var(instance, fan::Request::SetOnTemp(utils::dk_to_c(temp_dk))).await
+        }
+        Request::SetVar(instance, _len, uuid_standard::FAN_RAMP_TEMP, temp_dk) => {
+            fan_set_var(instance, fan::Request::SetRampTemp(utils::dk_to_c(temp_dk))).await
+        }
+        Request::SetVar(instance, _len, uuid_standard::FAN_MAX_TEMP, temp_dk) => {
+            fan_set_var(instance, fan::Request::SetMaxTemp(utils::dk_to_c(temp_dk))).await
+        }
+
+        // TODO: What does it mean to set the min/max RPM? Aren't these hardware defined?
+        Request::SetVar(_instance, _len, uuid_standard::FAN_MIN_RPM, _rpm) => todo!(),
+        Request::SetVar(_instance, _len, uuid_standard::FAN_MAX_RPM, _rpm) => todo!(),
+
+        Request::SetVar(instance, _len, uuid_standard::FAN_CURRENT_RPM, rpm) => {
+            fan_set_var(instance, fan::Request::SetRpm(rpm as u16)).await
+        }
+
+        // TODO: Allow OEM to handle these?
+        Request::GetVar(_instance, _len, uuid) => {
+            error!("Received GetVar for unrecognized UUID: {:?}", uuid);
+            Response::new(
+                Status::InvalidParameter,
+                ResponseData::GetVar(Status::InvalidParameter, 0),
+            )
+        }
+        Request::SetVar(_instance, _len, uuid, _value) => {
+            error!("Received SetVar for unrecognized UUID: {:?}", uuid);
+            Response::new(
+                Status::InvalidParameter,
+                ResponseData::GetVar(Status::InvalidParameter, 0),
+            )
+        }
+    }
+}
+
+#[embassy_executor::task]
+pub async fn handle_requests() {
+    loop {
+        let request = embassy_futures::select::select(ts::wait_mptf_request(), ts::wait_mctp_payload()).await;
+        let send_result = match request {
+            // Already in MPTF request format, handle as-is
+            Either::First(request) => {
+                let response = process_request(request).await;
+                ts::send_service_msg(comms::EndpointID::External(comms::External::Host), &response).await
+            }
+
+            // A raw MCTP payload which we need to parse properly then encode the response packet back into
+            Either::Second(mctp_payload) => {
+                let request = Request::try_from(mctp_payload);
+                let response = match request {
+                    // Packet is OK
+                    Ok(request) => {
+                        let response = process_request(request).await;
+                        mctp::Payload::from(response)
+                    }
+                    // Packet is malformed
+                    Err(payload_error) => mctp::Payload::from(payload_error),
+                };
+                ts::send_service_msg(comms::EndpointID::External(comms::External::Host), &response).await
+            }
+        };
+
+        if send_result.is_err() {
+            error!("Failed to send response to MPTF request!");
+        }
+    }
+}

--- a/thermal-service/src/sensor.rs
+++ b/thermal-service/src/sensor.rs
@@ -1,0 +1,489 @@
+//! Sensor Device
+use crate::utils::SampleBuf;
+use crate::{Event, send_event};
+use embassy_sync::mutex::Mutex;
+use embassy_sync::signal::Signal;
+use embassy_time::Timer;
+use embedded_sensors_hal_async::temperature::{DegreesCelsius, TemperatureSensor, TemperatureThresholdSet};
+use embedded_services::GlobalRawMutex;
+use embedded_services::error;
+use embedded_services::ipc::deferred as ipc;
+use embedded_services::{Node, intrusive_list};
+
+// Timeout period (in ms) for physical bus access
+const BUS_TIMEOUT: u64 = 200;
+
+/// Convenience type for Sensor response result
+pub type Response = Result<ResponseData, Error>;
+
+/// Allows OEM to implement custom requests
+///
+/// The default response is to return an error on unrecognized requests
+pub trait CustomRequestHandler {
+    fn handle_custom_request(&self, _request: Request) -> impl core::future::Future<Output = Response> {
+        async { Err(Error::InvalidRequest) }
+    }
+}
+
+/// Ensures all necessary traits are implemented for the controlling driver
+pub trait Controller: TemperatureSensor + TemperatureThresholdSet + CustomRequestHandler {}
+
+/* Helper macro for calling a bus function with automatic retry after timeout or failure.
+ *
+ * Necessary since often the sensor bus is shared and occasionally the underlying bus driver
+ * gets in a bad state and can hang or report spurious errors.
+ */
+macro_rules! with_retry {
+    (
+        $self:expr,
+        $bus_method:expr
+    ) => {{
+        let mut retry_attempts = $self.profile.lock().await.retry_attempts;
+
+        loop {
+            if retry_attempts == 0 {
+                break Err(Error::Hardware);
+            }
+
+            match embassy_time::with_timeout(embassy_time::Duration::from_millis(BUS_TIMEOUT), $bus_method).await {
+                Ok(Ok(val)) => break Ok(val),
+                _ => {
+                    retry_attempts -= 1;
+                }
+            }
+        }
+    }};
+}
+
+/// Sensor threshold type
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ThresholdType {
+    /// Threshold below which host is notified
+    WarnLow,
+    /// Threshold above which host is notified
+    WarnHigh,
+    /// Threshold above which PROCHOT is asserted
+    Prochot,
+    /// Threshold above which critical temperature is reached and system should be shutdown
+    /// Some systems may tie sensor alert pin directly to reset controller, in which case
+    /// SetHardAlert should be used.
+    Critical,
+}
+
+/// Sensor error type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Invalid request
+    InvalidRequest,
+    /// Device encountered a hardware failure
+    Hardware,
+}
+
+/// Sensor request
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Request {
+    /// Most recent cached temperature measurement
+    GetTemp,
+    /// Average temperature measurement (over BUFFER_SIZE * SAMPLING_PERIOD)
+    GetAvgTemp,
+    /// Instructs sensor to immediately sample temperature (not cached)
+    GetTmpNow,
+    /// Low threshold below which sensor will set the alert pin active (in degrees Celsius)
+    SetHardAlertLow(DegreesCelsius),
+    /// High threshold above which sensor will set the alert pin active (in degrees Celsius)
+    SetHardAlertHigh(DegreesCelsius),
+    /// Get a threshold
+    GetThreshold(ThresholdType),
+    /// Set a threshold
+    SetThreshold(ThresholdType, DegreesCelsius),
+    /// Threshold in which sensor begins fast sampling
+    SetFastSamplingThreshold(DegreesCelsius),
+    /// Set temperature sampling period (in ms)
+    SetSamplingPeriod(u64),
+    /// Set fast temperature sampling period (in ms)
+    SetFastSamplingPeriod(u64),
+    /// An offset that is applied to all physical temperature samples (in degrees Celsius)
+    SetOffset(DegreesCelsius),
+    /// Enable sensor sampling
+    EnableSampling,
+    /// Disable sensor sampling
+    DisableSampling,
+    /// Set the max number of times communication with physical sensor will be attempted until error is reported
+    SetRetryAttempts(u8),
+    /// Get the thermal profile associated with this sensor
+    GetProfile,
+    /// Set the thermal profile associated with this sensor
+    SetProfile(Profile),
+    /// Custom-implemented command
+    Custom(u8, &'static [u8]),
+}
+
+/// Sensor response
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResponseData {
+    /// Response for any request that is successful but does not require data
+    Success,
+    /// Temperature (in degrees Celsius)
+    Temp(DegreesCelsius),
+    /// Threshold (in degrees Celsius)
+    Threshold(DegreesCelsius),
+    /// Profile
+    Profile(Profile),
+    /// Custom-implemented response
+    Custom(&'static [u8]),
+}
+
+/// Sensor device ID new type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceId(pub u8);
+
+/// Sensor device struct
+pub struct Device {
+    /// Intrusive list node allowing Device to be contained in a list
+    node: Node,
+    /// Device ID
+    id: DeviceId,
+    /// Channel for IPC requests and responses
+    ipc: ipc::Channel<GlobalRawMutex, Request, Response>,
+    /// Signal for enable
+    enable: Signal<GlobalRawMutex, ()>,
+}
+
+impl Device {
+    /// Create a new sensor device
+    pub fn new(id: DeviceId) -> Self {
+        Self {
+            node: Node::uninit(),
+            id,
+            ipc: ipc::Channel::new(),
+            enable: Signal::new(),
+        }
+    }
+
+    /// Get the device ID
+    pub fn id(&self) -> DeviceId {
+        self.id
+    }
+
+    /// Execute request and wait for response
+    pub async fn execute_request(&self, request: Request) -> Response {
+        self.ipc.execute(request).await
+    }
+}
+
+impl intrusive_list::NodeContainer for Device {
+    fn get_node(&self) -> &Node {
+        &self.node
+    }
+}
+
+/// Sensor profile
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Profile {
+    /// Profile ID
+    pub id: usize,
+    /// Period (in ms) sensor will sample its temperature
+    pub sample_period: u64,
+    /// Period (in ms) sensor will sample its temperature when in fast sampling state
+    pub fast_sample_period: u64,
+    /// Whether or not automatic background sampling is enabled or not
+    pub sampling_enabled: bool,
+    /// Hysteresis value (in degrees Celsius) preventing sensor from rapidly reporting threshold events
+    pub hysteresis: DegreesCelsius,
+    /// Threshold (in degrees Celsius) at which sensor will trigger a WARN LOW event
+    pub warn_low_threshold: DegreesCelsius,
+    /// Threshold (in degrees Celsius) at which sensor will trigger a WARN HIGH event
+    pub warn_high_threshold: DegreesCelsius,
+    /// Threshold (in degrees Celsius) at which sensor will trigger a PROCHOT event
+    pub prochot_threshold: DegreesCelsius,
+    /// Threshold (in degrees Celsius) at which sensor will trigger a CRITICAL event
+    pub crt_threshold: DegreesCelsius,
+    /// Threshold (in degrees Celsius) at which sensor will enter the fast sampling state
+    pub fast_sampling_threshold: DegreesCelsius,
+    /// Offset (in degrees Celsius) to be added to sampled temperature
+    pub offset: DegreesCelsius,
+    /// Number of attempts sensor will make to communicate with the physical device over the bus
+    pub retry_attempts: u8,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            sample_period: 1000,
+            fast_sample_period: 200,
+            sampling_enabled: true,
+            warn_low_threshold: DegreesCelsius::MIN,
+            warn_high_threshold: DegreesCelsius::MAX,
+            prochot_threshold: DegreesCelsius::MAX,
+            crt_threshold: DegreesCelsius::MAX,
+            fast_sampling_threshold: DegreesCelsius::MAX,
+            offset: 0.0,
+            retry_attempts: 5,
+            hysteresis: 2.0,
+        }
+    }
+}
+
+// Additional Sensor state
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+struct State {
+    is_warn_low: bool,
+    is_warn_high: bool,
+    is_prochot: bool,
+    is_critical: bool,
+}
+
+/// Wrapper binding a communication device, hardware driver, and additional state.
+pub struct Sensor<T: Controller, const SAMPLE_BUF_LEN: usize> {
+    /// Sensor communication device
+    device: Device,
+    /// Sensor controller
+    controller: Mutex<GlobalRawMutex, T>,
+    /// Sensor profile
+    profile: Mutex<GlobalRawMutex, Profile>,
+    /// Sensor state
+    state: Mutex<GlobalRawMutex, State>,
+    /// Cached temperature samples
+    samples: Mutex<GlobalRawMutex, SampleBuf<DegreesCelsius, SAMPLE_BUF_LEN>>,
+}
+
+impl<T: Controller, const SAMPLE_BUF_LEN: usize> Sensor<T, SAMPLE_BUF_LEN> {
+    /// New sensor
+    ///
+    /// Sample buffer length MUST be a power of two
+    pub fn new(id: DeviceId, controller: T, profile: Profile) -> Self {
+        Self {
+            device: Device::new(id),
+            controller: Mutex::new(controller),
+            profile: Mutex::new(profile),
+            state: Mutex::new(State::default()),
+            samples: Mutex::new(SampleBuf::create()),
+        }
+    }
+
+    /// Retrieve a reference to underlying device for registration with services
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    /// Retrieve a Mutex wrapping the underlying controller
+    ///
+    /// Should only be used to update OEM specific state
+    pub fn controller(&self) -> &Mutex<GlobalRawMutex, T> {
+        &self.controller
+    }
+
+    /// Wait for sensor to receive a request
+    pub async fn wait_request(&self) -> ipc::Request<'_, GlobalRawMutex, Request, Response> {
+        self.device.ipc.receive().await
+    }
+
+    /// Process sensor request
+    pub async fn process_request(&self, request: Request) -> Response {
+        match request {
+            Request::GetTemp => {
+                let temp = self.samples.lock().await.recent();
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::GetAvgTemp => {
+                let temp = self.samples.lock().await.average();
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::GetTmpNow => {
+                let temp = with_retry!(self, self.controller.lock().await.temperature())?;
+                Ok(ResponseData::Temp(temp))
+            }
+            Request::SetHardAlertLow(low) => {
+                with_retry!(self, self.controller.lock().await.set_temperature_threshold_low(low))?;
+                Ok(ResponseData::Success)
+            }
+            Request::SetHardAlertHigh(high) => {
+                with_retry!(self, self.controller.lock().await.set_temperature_threshold_high(high))?;
+                Ok(ResponseData::Success)
+            }
+            Request::GetThreshold(ThresholdType::WarnLow) => {
+                let threshold = self.profile.lock().await.warn_low_threshold;
+                Ok(ResponseData::Threshold(threshold))
+            }
+            Request::GetThreshold(ThresholdType::WarnHigh) => {
+                let threshold = self.profile.lock().await.warn_high_threshold;
+                Ok(ResponseData::Threshold(threshold))
+            }
+            Request::GetThreshold(ThresholdType::Prochot) => {
+                let threshold = self.profile.lock().await.prochot_threshold;
+                Ok(ResponseData::Threshold(threshold))
+            }
+            Request::GetThreshold(ThresholdType::Critical) => {
+                let threshold = self.profile.lock().await.crt_threshold;
+                Ok(ResponseData::Threshold(threshold))
+            }
+            Request::SetThreshold(ThresholdType::WarnLow, threshold) => {
+                self.profile.lock().await.warn_low_threshold = threshold;
+                Ok(ResponseData::Success)
+            }
+            Request::SetThreshold(ThresholdType::WarnHigh, threshold) => {
+                self.profile.lock().await.warn_high_threshold = threshold;
+                Ok(ResponseData::Success)
+            }
+            Request::SetThreshold(ThresholdType::Prochot, threshold) => {
+                self.profile.lock().await.prochot_threshold = threshold;
+                Ok(ResponseData::Success)
+            }
+            Request::SetThreshold(ThresholdType::Critical, threshold) => {
+                self.profile.lock().await.crt_threshold = threshold;
+                Ok(ResponseData::Success)
+            }
+            Request::SetFastSamplingThreshold(threshold) => {
+                self.profile.lock().await.fast_sampling_threshold = threshold;
+                Ok(ResponseData::Success)
+            }
+            Request::SetSamplingPeriod(period) => {
+                self.profile.lock().await.sample_period = period;
+                Ok(ResponseData::Success)
+            }
+            Request::SetFastSamplingPeriod(period) => {
+                self.profile.lock().await.fast_sample_period = period;
+                Ok(ResponseData::Success)
+            }
+            Request::SetOffset(offset) => {
+                self.profile.lock().await.offset = offset;
+                Ok(ResponseData::Success)
+            }
+            Request::EnableSampling => {
+                self.profile.lock().await.sampling_enabled = true;
+                self.device.enable.signal(());
+                Ok(ResponseData::Success)
+            }
+            Request::DisableSampling => {
+                self.profile.lock().await.sampling_enabled = false;
+                Ok(ResponseData::Success)
+            }
+            Request::SetRetryAttempts(limit) => {
+                self.profile.lock().await.retry_attempts = limit;
+                Ok(ResponseData::Success)
+            }
+            Request::GetProfile => {
+                let profile = *self.profile.lock().await;
+                Ok(ResponseData::Profile(profile))
+            }
+            Request::SetProfile(profile) => {
+                *self.profile.lock().await = profile;
+                Ok(ResponseData::Success)
+            }
+            Request::Custom(_, _) => self.controller.lock().await.handle_custom_request(request).await,
+        }
+    }
+
+    // Wait for sensor to receive a request, process it, and send a response
+    pub async fn wait_and_process(&self) {
+        let request = self.wait_request().await;
+        let response = self.process_request(request.command).await;
+        request.respond(response);
+    }
+
+    /// Waits for a request then processes it and sends a response
+    pub async fn handle_rx(&self) {
+        loop {
+            self.wait_and_process().await;
+        }
+    }
+
+    async fn check_thresholds(&self, temp: DegreesCelsius) {
+        let profile = self.profile.lock().await;
+        let mut state = self.state.lock().await;
+
+        if temp >= profile.warn_high_threshold && !state.is_warn_high {
+            send_event(Event::ThresholdExceeded(self.device.id, ThresholdType::WarnHigh, temp)).await;
+            state.is_warn_high = true;
+        } else if temp < (profile.warn_high_threshold - profile.hysteresis) && state.is_warn_high {
+            send_event(Event::ThresholdCleared(self.device.id, ThresholdType::WarnHigh)).await;
+            state.is_warn_high = false;
+        }
+
+        if temp <= profile.warn_low_threshold && !state.is_warn_low {
+            send_event(Event::ThresholdExceeded(self.device.id, ThresholdType::WarnLow, temp)).await;
+            state.is_warn_low = true;
+        } else if temp > (profile.warn_low_threshold + profile.hysteresis) && state.is_warn_low {
+            send_event(Event::ThresholdCleared(self.device.id, ThresholdType::WarnLow)).await;
+            state.is_warn_low = false;
+        }
+
+        if temp >= profile.prochot_threshold && !state.is_prochot {
+            send_event(Event::ThresholdExceeded(self.device.id, ThresholdType::Prochot, temp)).await;
+            state.is_prochot = true;
+        } else if temp < (profile.prochot_threshold - profile.hysteresis) && state.is_prochot {
+            send_event(Event::ThresholdCleared(self.device.id, ThresholdType::Prochot)).await;
+            state.is_prochot = false;
+        }
+
+        if temp >= profile.crt_threshold && !state.is_critical {
+            send_event(Event::ThresholdExceeded(self.device.id, ThresholdType::Critical, temp)).await;
+            state.is_critical = true;
+        } else if temp < (profile.crt_threshold - profile.hysteresis) && state.is_critical {
+            send_event(Event::ThresholdCleared(self.device.id, ThresholdType::Critical)).await;
+            state.is_critical = false;
+        }
+    }
+
+    /// Periodically samples temperature from physical sensor and caches it
+    pub async fn handle_sampling(&self) {
+        loop {
+            // Only sample temperature if enabled
+            if self.profile.lock().await.sampling_enabled {
+                let temp = match with_retry!(self, self.controller.lock().await.temperature()) {
+                    Ok(temp) => temp,
+                    _ => {
+                        self.profile.lock().await.sampling_enabled = false;
+                        send_event(Event::SensorFailure(self.device.id, Error::Hardware)).await;
+                        error!("Error sampling sensor {}, disabling sampling", self.device.id.0);
+                        continue;
+                    }
+                };
+
+                // Add offset to measured temperature
+                let temp = temp + self.profile.lock().await.offset;
+
+                // Cache in buffer for quick retrieval from other services
+                self.samples.lock().await.push(temp);
+
+                // Check thresholds
+                self.check_thresholds(temp).await;
+
+                // Adjust sampling rate based on how hot we are getting
+                let profile = self.profile.lock().await;
+                let sleep_duration = if temp >= profile.fast_sampling_threshold {
+                    profile.fast_sample_period
+                } else {
+                    profile.sample_period
+                };
+                drop(profile);
+
+                // Sleep in-between sampling periods
+                Timer::after_millis(sleep_duration).await;
+
+            // Otherwise sleep and wait to be re-enabled
+            } else {
+                self.device.enable.wait().await;
+            }
+        }
+    }
+}
+
+/// This is a public helper macro for implementing the sensor task since tasks cannot be generic
+#[macro_export]
+macro_rules! impl_sensor_task {
+    ($sensor_task_name:ident, $sensor_type:ty, $sample_buf_len:expr) => {
+        #[embassy_executor::task]
+        pub async fn $sensor_task_name(sensor: &'static $crate::sensor::Sensor<$sensor_type, $sample_buf_len>) {
+            let _ = embassy_futures::join::join(sensor.handle_rx(), sensor.handle_sampling()).await;
+        }
+    };
+}

--- a/thermal-service/src/utils.rs
+++ b/thermal-service/src/utils.rs
@@ -1,0 +1,52 @@
+//! Helpful utilities for the thermal service
+use crate::mptf;
+use heapless::Deque;
+
+/// Buffer for storing samples
+pub struct SampleBuf<T: Default + Copy + core::fmt::Debug, const N: usize> {
+    deque: Deque<T, N>,
+}
+
+impl<T: Default + Copy + core::fmt::Debug, const N: usize> SampleBuf<T, N> {
+    /// Create a new sample buffer
+    pub fn create() -> Self {
+        Self { deque: Deque::new() }
+    }
+
+    /// Insert a new sample into the buffer and evict the oldest
+    pub fn push(&mut self, sample: T) {
+        if self.deque.is_full() {
+            let _ = self.deque.pop_back();
+        }
+
+        // There will always be room in the buffer if we get here
+        let _ = self.deque.push_front(sample);
+    }
+
+    /// Retrieve the most recent sample from the buffer
+    pub fn recent(&self) -> T {
+        *self.deque.front().unwrap_or(&T::default())
+    }
+}
+
+impl<const N: usize> SampleBuf<f32, N> {
+    pub fn average(&self) -> f32 {
+        self.deque.iter().copied().sum::<f32>() / (self.deque.len() as f32)
+    }
+}
+
+impl<const N: usize> SampleBuf<u16, N> {
+    pub fn average(&self) -> u16 {
+        self.deque.iter().copied().sum::<u16>() / (self.deque.len() as u16)
+    }
+}
+
+/// Convert deciKelvin to degrees Celsius
+pub const fn dk_to_c(dk: mptf::DeciKelvin) -> f32 {
+    (dk as f32 / 10.0) - 273.15
+}
+
+/// Convert degrees Celsius to deciKelvin
+pub const fn c_to_dk(c: f32) -> mptf::DeciKelvin {
+    ((c + 273.15) * 10.0) as mptf::DeciKelvin
+}


### PR DESCRIPTION
This overhauls the first attempt of a thermal service to be more flexible. The thermal service provides:

- Async friendly approach to interfacing with sensors and fans. Each sensor and fan runs in its own task, waiting to receive and process commands and performing additional duties described below.
- Each sensor is responsible for periodically sampling and caching temperature samples to be quickly retrieved when asked.
- Each sensor is responsible for checking if the most recent temperature sample exceeds several thresholds (Warn, Prochot, Critical) and generating an event if so.
- These events can be listened for by OEM to handle appropriately (such as throttling AP in case of Prochot)
- Sensors support various requests such as changing sampling period (to sample more frequently as temperature rises) or to be disabled when needed to save power
- Sensors support changing thermal profile at runtime to more easily change behavior at runtime
- Each fan supports independent auto control by querying an associated sensor when it wants to update its speed
- Fans can be set to manual control (as an example, to enable a passive cooling policy where AP is throttled instead of turning fans on
- Fans also support multiple profiles such as sensors
- A default linear response is provided when the fan is in the ramping state, however OEM can easily plug in their own custom control algorithm instead
- An MPTF handler which can translate MPTF thermal commands according to spec to thermal service functions

This design should strike a fair balance between flexibility and providing usefulness. It is continually being tweaked (especially implementation details) so this PR is currently a draft.

Resolves #132 
Resolves #133 
Resolves #134 
Resolves #135 
Resolves #136 
Resolves #137 
Resolves #222 