### PR TITLE
Add version limit to embedded-cfu-protocol import after breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy" }
 embedded-batteries-async = "0.1.0"
-embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", version = "0.1.0" }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-hal-nb = "1.0"


### PR DESCRIPTION
There was a breaking change and minor version update (0.2.0) in embedded-cfu via https://github.com/OpenDevicePartnership/embedded-cfu/pull/21. While the necessary changes are integrated, limit version to 0.1.0 for the workspace in cargo.toml