### PR TITLE
Quiet down battery state machine prints when collecting dynamic and static data

### DIFF
--- a/battery-service/src/context.rs
+++ b/battery-service/src/context.rs
@@ -326,8 +326,7 @@ impl Context {
                 PresentSubstate::Operational(operational_substate) => match operational_substate {
                     OperationalSubstate::Init => {
                         // Collect static data
-                        // TODO: Add retry logic
-                        info!("Collecting fuel gauge static cache with ID {:?}", event.device_id);
+                        trace!("Collecting fuel gauge static cache with ID {:?}", event.device_id);
                         if self
                             .execute_device_command(event.device_id, device::Command::UpdateStaticCache)
                             .await
@@ -341,8 +340,7 @@ impl Context {
                     }
                     OperationalSubstate::Polling => {
                         // Collect dynamic data
-                        // TODO: Add retry logic
-                        info!("Collecting fuel gauge dynamic cache with ID {:?}", event.device_id);
+                        trace!("Collecting fuel gauge dynamic cache with ID {:?}", event.device_id);
                         if self
                             .execute_device_command(event.device_id, device::Command::UpdateDynamicCache)
                             .await


### PR DESCRIPTION
Dynamic and static data requests are designed to be queried frequently, thus `info!()` prints are much too high of a log level. Reduce to `trace!()`