### PR TITLE
Const on EmbeddedCrc's new() function

### DIFF
--- a/platform-service/src/embedded_crc.rs
+++ b/platform-service/src/embedded_crc.rs
@@ -17,7 +17,7 @@ pub enum EmbeddedCrcError {
 }
 
 impl EmbeddedCrc<u32> {
-    pub fn new(algorithm: &'static Algorithm<u32>) -> Self {
+    pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
         Self {
             algorithm,
             current_crc: None,
@@ -67,7 +67,7 @@ impl EmbeddedCrc<u32> {
 }
 
 impl EmbeddedCrc<u16> {
-    pub fn new(algorithm: &'static Algorithm<u16>) -> Self {
+    pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
         Self {
             algorithm,
             current_crc: None,


### PR DESCRIPTION
Add const identifier on EmbeddedCrc object's new() function for expanded use