### PR TITLE
Type-c: Event loop refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "embedded-services",
  "embedded-usb-pd",
  "log",
+ "tokio",
  "tps6699x",
 ]
 

--- a/embedded-service/src/type_c/event.rs
+++ b/embedded-service/src/type_c/event.rs
@@ -1,13 +1,17 @@
-//! Event definitions
+//! This module provides TCPM event types and bitfields.
+//! Hardware typically uses bitfields to store pending events/interrupts so we provide generic versions of these.
+//! [`PortStatusChanged`] contains events related to the overall port state (plug state, power contract, etc).
+//! Processing these events typically requires acessing similar registers so they are grouped together.
+//! [`PortNotification`] contains events that are typically more message-like (PD alerts, VDMs, etc) and can be processed independently.
+//! Consequently [`PortNotification`] implements iterator traits to allow for processing these events as a stream.
 use bitfield::bitfield;
 use bitvec::BitArr;
-use embedded_usb_pd::GlobalPortId;
 
 bitfield! {
-    /// Raw bitfield of possible port events
+    /// Raw bitfield of possible port status events
     #[derive(Copy, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    struct PortEventKindRaw(u32);
+    struct PortStatusChangedRaw(u16);
     impl Debug;
     /// Plug inserted or removed
     pub u8, plug_inserted_or_removed, set_plug_inserted_or_removed: 0, 0;
@@ -27,39 +31,25 @@ bitfield! {
     pub u8, alt_mode_entered, set_alt_mode_entered: 7, 7;
     /// PD hard reset
     pub u8, pd_hard_reset, set_pd_hard_reset: 8, 8;
-    /// usb mux error recovery
-    pub u8, usb_mux_error_recovery, set_usb_mux_error_recovery: 9, 9;
-    /// user svid mode entered
-    pub u8, custom_mode_entered, set_custom_mode_entered: 10, 10;
-    /// user svid mode exited
-    pub u8, custom_mode_exited, set_custom_mode_exited: 11, 11;
-    /// user svid attention vdm received
-    pub u8, custom_mode_attention_received, set_custom_mode_attention_received: 12, 12;
-    /// user svid other vdm received
-    pub u8, custom_mode_other_vdm_received, set_custom_mode_other_vdm_received: 13, 13;
-    /// discover mode completed
-    pub u8, discover_mode_completed, set_discover_mode_completed: 14, 14;
-    /// DP status update
-    pub u8, dp_status_update, set_dp_status_update: 15, 15;
-    /// PD Alert received
-    pub u8, pd_alert_received, set_pd_alert_received: 16, 16;
 }
 
-/// Type-safe wrapper for the raw port event kind
+/// Port status change events
+/// This is a type-safe wrapper around the raw bitfield
+/// These events are related to the overall port state and typically need to be considered together.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct PortEventKind(PortEventKindRaw);
+pub struct PortStatusChanged(PortStatusChangedRaw);
 
-impl PortEventKind {
+impl PortStatusChanged {
     /// Create a new PortEventKind with no pending events
     pub const fn none() -> Self {
-        Self(PortEventKindRaw(0))
+        Self(PortStatusChangedRaw(0))
     }
 
     /// Returns the union of self and other
-    pub fn union(self, other: PortEventKind) -> PortEventKind {
+    pub fn union(self, other: PortStatusChanged) -> PortStatusChanged {
         // This spacing is what rustfmt wants
-        PortEventKind(PortEventKindRaw(self.0.0 | other.0.0))
+        PortStatusChanged(PortStatusChangedRaw(self.0.0 | other.0.0))
     }
 
     /// Returns true if a plug was inserted or removed
@@ -151,15 +141,59 @@ impl PortEventKind {
     pub fn set_pd_hard_reset(&mut self, value: bool) {
         self.0.set_pd_hard_reset(value.into());
     }
+}
 
-    /// Returns true if a USB mux error recovery event triggered
-    pub fn usb_mux_error_recovery(self) -> bool {
-        self.0.usb_mux_error_recovery() != 0
+bitfield! {
+    /// Raw bitfield of possible port notification events
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    struct PortNotificationRaw(u16);
+    impl Debug;
+    /// PD alert
+    pub u8, alert, set_alert: 0, 0;
+     /// user svid mode entered
+    pub u8, custom_mode_entered, set_custom_mode_entered: 1, 1;
+    /// user svid mode exited
+    pub u8, custom_mode_exited, set_custom_mode_exited: 2, 2;
+    /// user svid attention vdm received
+    pub u8, custom_mode_attention_received, set_custom_mode_attention_received: 3, 3;
+    /// user svid other vdm received
+    pub u8, custom_mode_other_vdm_received, set_custom_mode_other_vdm_received: 4, 4;
+    /// discover mode completed
+    pub u8, discover_mode_completed, set_discover_mode_completed: 5, 5;
+    /// usb mux error recovery
+    pub u8, usb_mux_error_recovery, set_usb_mux_error_recovery: 6, 6;
+    /// DP status update
+    pub u8, dp_status_update, set_dp_status_update: 15, 15;
+}
+
+/// Port notification events
+/// This is a type-safe wrapper around the raw bitfield
+/// These events are unrelated to the overall port state and each other.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PortNotification(PortNotificationRaw);
+
+impl PortNotification {
+    /// Create a new PortNotification with no pending events
+    pub const fn none() -> Self {
+        Self(PortNotificationRaw(0))
     }
 
-    /// Sets the USB mux error recovery event
-    pub fn set_usb_mux_error_recovery(&mut self, value: bool) {
-        self.0.set_usb_mux_error_recovery(value.into());
+    /// Returns the union of self and other
+    pub fn union(self, other: PortNotification) -> PortNotification {
+        // This spacing is what rustfmt wants
+        PortNotification(PortNotificationRaw(self.0.0 | other.0.0))
+    }
+
+    /// Returns true if an alert was received
+    pub fn alert(self) -> bool {
+        self.0.alert() != 0
+    }
+
+    /// Sets the alert event
+    pub fn set_alert(&mut self, value: bool) {
+        self.0.set_alert(value.into());
     }
 
     /// Returns true if a custom mode entered event triggered
@@ -212,6 +246,16 @@ impl PortEventKind {
         self.0.set_discover_mode_completed(value.into());
     }
 
+    /// Returns true if a USB mux error recovery event triggered
+    pub fn usb_mux_error_recovery(self) -> bool {
+        self.0.usb_mux_error_recovery() != 0
+    }
+
+    /// Sets the USB mux error recovery event
+    pub fn set_usb_mux_error_recovery(&mut self, value: bool) {
+        self.0.set_usb_mux_error_recovery(value.into());
+    }
+
     /// Returns true if a DP status update event triggered
     pub fn dp_status_update(self) -> bool {
         self.0.dp_status_update() != 0
@@ -221,100 +265,210 @@ impl PortEventKind {
     pub fn set_dp_status_update(&mut self, value: bool) {
         self.0.set_dp_status_update(value.into());
     }
+}
 
-    /// Returns true if a PD alert received event triggered
-    pub fn pd_alert_received(self) -> bool {
-        self.0.pd_alert_received() != 0
+/// Individual port notifications
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PortNotificationSingle {
+    /// PD alert
+    Alert,
+    /// Custom mode entered
+    CustomModeEntered,
+    /// Custom mode exited
+    CustomModeExited,
+    /// Custom mode attention received
+    CustomModeAttentionReceived,
+    /// Custom mode other VDM received
+    CustomModeOtherVdmReceived,
+    /// Discover mode completed
+    DiscoverModeCompleted,
+    /// USB mux error recovery
+    UsbMuxErrorRecovery,
+    /// DP status update
+    DpStatusUpdate,
+}
+
+impl Iterator for PortNotification {
+    type Item = PortNotificationSingle;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.alert() {
+            self.set_alert(false);
+            Some(PortNotificationSingle::Alert)
+        } else if self.custom_mode_entered() {
+            self.set_custom_mode_entered(false);
+            Some(PortNotificationSingle::CustomModeEntered)
+        } else if self.custom_mode_exited() {
+            self.set_custom_mode_exited(false);
+            Some(PortNotificationSingle::CustomModeExited)
+        } else if self.custom_mode_attention_received() {
+            self.set_custom_mode_attention_received(false);
+            Some(PortNotificationSingle::CustomModeAttentionReceived)
+        } else if self.custom_mode_other_vdm_received() {
+            self.set_custom_mode_other_vdm_received(false);
+            Some(PortNotificationSingle::CustomModeOtherVdmReceived)
+        } else if self.discover_mode_completed() {
+            self.set_discover_mode_completed(false);
+            Some(PortNotificationSingle::DiscoverModeCompleted)
+        } else if self.usb_mux_error_recovery() {
+            self.set_usb_mux_error_recovery(false);
+            Some(PortNotificationSingle::UsbMuxErrorRecovery)
+        } else if self.dp_status_update() {
+            self.set_dp_status_update(false);
+            Some(PortNotificationSingle::DpStatusUpdate)
+        } else {
+            None
+        }
+    }
+}
+
+/// Overall port event type
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PortEvent {
+    /// Port status change events
+    pub status: PortStatusChanged,
+    /// Port notification events
+    pub notification: PortNotification,
+}
+
+impl PortEvent {
+    /// Creates a new PortEvent with no pending events
+    pub const fn none() -> Self {
+        Self {
+            status: PortStatusChanged::none(),
+            notification: PortNotification::none(),
+        }
     }
 
-    /// Sets the PD alert received event
-    pub fn set_pd_alert_received(&mut self, value: bool) {
-        self.0.set_pd_alert_received(value.into());
+    /// Returns the union of self and other
+    pub fn union(self, other: PortEvent) -> PortEvent {
+        PortEvent {
+            status: self.status.union(other.status),
+            notification: self.notification.union(other.notification),
+        }
+    }
+}
+
+impl From<PortStatusChanged> for PortEvent {
+    fn from(status: PortStatusChanged) -> Self {
+        Self {
+            status,
+            notification: PortNotification::none(),
+        }
+    }
+}
+
+impl From<PortNotification> for PortEvent {
+    fn from(notification: PortNotification) -> Self {
+        Self {
+            status: PortStatusChanged::none(),
+            notification,
+        }
     }
 }
 
 /// Bit vector type to store pending port events
-type PortEventFlagsVec = BitArr!(for 32, in u32);
+type PortPendingVec = BitArr!(for 32, in u32);
 
 /// Pending port events
+///
+/// This type works using usize to allow use with both global and local port IDs.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct PortEventFlags(PortEventFlagsVec);
+pub struct PortPending(PortPendingVec);
 
-impl PortEventFlags {
-    /// Creates a new PortEventFlags with no pending events
+impl PortPending {
+    /// Creates a new PortPending with no pending ports
     pub const fn none() -> Self {
-        Self(PortEventFlagsVec::ZERO)
+        Self(PortPendingVec::ZERO)
     }
 
-    /// Returns true if there are no pending events
+    /// Returns true if there are no pending ports
     pub fn is_none(&self) -> bool {
-        self.0 == PortEventFlagsVec::ZERO
+        self.0 == PortPendingVec::ZERO
     }
 
     /// Marks the given port as pending
-    pub fn pend_port(&mut self, port: GlobalPortId) {
-        self.0.set(port.0 as usize, true);
+    pub fn pend_port(&mut self, port: usize) {
+        self.0.set(port, true);
+    }
+
+    /// Marks the indexes given by the iterator as pending
+    pub fn pend_ports<I: IntoIterator<Item = usize>>(&mut self, iter: I) {
+        for port in iter {
+            self.pend_port(port);
+        }
     }
 
     /// Clears the pending status of the given port
-    pub fn clear_port(&mut self, port: GlobalPortId) {
-        self.0.set(port.0 as usize, false);
+    pub fn clear_port(&mut self, port: usize) {
+        self.0.set(port, false);
     }
 
     /// Returns true if the given port is pending
-    pub fn is_pending(&self, port: GlobalPortId) -> bool {
-        self.0[port.0 as usize]
+    pub fn is_pending(&self, port: usize) -> bool {
+        self.0[port]
     }
 
-    /// Returns a combination of the current event flags and other
-    pub fn union(&self, other: PortEventFlags) -> PortEventFlags {
-        PortEventFlags(self.0 | other.0)
+    /// Returns a combination of the current pending ports and other
+    pub fn union(&self, other: PortPending) -> PortPending {
+        PortPending(self.0 | other.0)
     }
 
-    /// Returns the number of bits in the event
+    /// Returns the number of bits in Self
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 }
 
-impl From<PortEventFlags> for u32 {
-    fn from(flags: PortEventFlags) -> Self {
+impl From<PortPending> for u32 {
+    fn from(flags: PortPending) -> Self {
         flags.0.data[0]
     }
 }
 
+impl FromIterator<usize> for PortPending {
+    fn from_iter<T: IntoIterator<Item = usize>>(iter: T) -> Self {
+        let mut flags = PortPending::none();
+        flags.pend_ports(iter);
+        flags
+    }
+}
+
 /// An iterator over the pending port event flags
-pub struct PortEventFlagsIter {
+#[derive(Copy, Clone)]
+pub struct PortPendingIter {
     /// The flags being iterated over
-    flags: PortEventFlags,
+    flags: PortPending,
     /// The current index in the flags
     index: usize,
 }
 
-impl Iterator for PortEventFlagsIter {
-    type Item = GlobalPortId;
+impl Iterator for PortPendingIter {
+    type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.index < self.flags.len() {
-            let port_id = GlobalPortId(self.index as u8);
-            if self.flags.is_pending(port_id) {
-                self.index += 1;
-                return Some(port_id);
-            }
+            let port_index = self.index;
             self.index += 1;
+            if self.flags.is_pending(port_index) {
+                self.flags.clear_port(port_index);
+                return Some(port_index);
+            }
         }
         None
     }
 }
 
-impl IntoIterator for PortEventFlags {
-    type Item = GlobalPortId;
-    type IntoIter = PortEventFlagsIter;
+impl IntoIterator for PortPending {
+    type Item = usize;
+    type IntoIter = PortPendingIter;
 
-    fn into_iter(self) -> PortEventFlagsIter {
-        PortEventFlagsIter { flags: self, index: 0 }
+    fn into_iter(self) -> PortPendingIter {
+        PortPendingIter { flags: self, index: 0 }
     }
 }
 
@@ -324,22 +478,111 @@ mod tests {
 
     #[test]
     fn test_port_event_flags_iter() {
-        let mut pending = PortEventFlags::none();
+        let mut pending = PortPending::none();
 
-        pending.pend_port(GlobalPortId(0));
-        pending.pend_port(GlobalPortId(1));
-        pending.pend_port(GlobalPortId(2));
-        pending.pend_port(GlobalPortId(10));
-        pending.pend_port(GlobalPortId(23));
-        pending.pend_port(GlobalPortId(31));
+        pending.pend_port(0);
+        pending.pend_port(1);
+        pending.pend_port(2);
+        pending.pend_port(10);
+        pending.pend_port(23);
+        pending.pend_port(31);
 
         let mut iter = pending.into_iter();
-        assert_eq!(iter.next(), Some(GlobalPortId(0)));
-        assert_eq!(iter.next(), Some(GlobalPortId(1)));
-        assert_eq!(iter.next(), Some(GlobalPortId(2)));
-        assert_eq!(iter.next(), Some(GlobalPortId(10)));
-        assert_eq!(iter.next(), Some(GlobalPortId(23)));
-        assert_eq!(iter.next(), Some(GlobalPortId(31)));
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.next(), Some(10));
+        assert_eq!(iter.next(), Some(23));
+        assert_eq!(iter.next(), Some(31));
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_all() {
+        let mut notification = PortNotification::none();
+        notification.set_alert(true);
+        notification.set_custom_mode_entered(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::Alert));
+        assert_eq!(notification.next(), Some(PortNotificationSingle::CustomModeEntered));
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_alert() {
+        let mut notification = PortNotification::none();
+        notification.set_alert(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::Alert));
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_custom_mode_entered() {
+        let mut notification = PortNotification::none();
+        notification.set_custom_mode_entered(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::CustomModeEntered));
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_custom_mode_exited() {
+        let mut notification = PortNotification::none();
+        notification.set_custom_mode_exited(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::CustomModeExited));
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_custom_mode_attention_received() {
+        let mut notification = PortNotification::none();
+        notification.set_custom_mode_attention_received(true);
+
+        assert_eq!(
+            notification.next(),
+            Some(PortNotificationSingle::CustomModeAttentionReceived)
+        );
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_custom_mode_other_vdm_received() {
+        let mut notification = PortNotification::none();
+        notification.set_custom_mode_other_vdm_received(true);
+
+        assert_eq!(
+            notification.next(),
+            Some(PortNotificationSingle::CustomModeOtherVdmReceived)
+        );
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_discover_mode_completed() {
+        let mut notification = PortNotification::none();
+        notification.set_discover_mode_completed(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::DiscoverModeCompleted));
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_usb_mux_error_recovery() {
+        let mut notification = PortNotification::none();
+        notification.set_usb_mux_error_recovery(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::UsbMuxErrorRecovery));
+        assert_eq!(notification.next(), None);
+    }
+
+    #[test]
+    fn test_port_notification_iter_dp_status_update() {
+        let mut notification = PortNotification::none();
+        notification.set_dp_status_update(true);
+
+        assert_eq!(notification.next(), Some(PortNotificationSingle::DpStatusUpdate));
+        assert_eq!(notification.next(), None);
     }
 }

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use ::tps6699x::ADDR0;
-use defmt::info;
 use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio::{Input, Inverter, Pull};
@@ -16,6 +15,7 @@ use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferRe
 use embedded_services::comms;
 use embedded_services::power::policy::DeviceId as PowerId;
 use embedded_services::type_c::{self, ControllerId};
+use embedded_services::{error, info};
 use embedded_usb_pd::GlobalPortId;
 use static_cell::StaticCell;
 use tps6699x::asynchronous::embassy as tps6699x;
@@ -123,7 +123,9 @@ mod debug {
 #[embassy_executor::task]
 async fn pd_controller_task(controller: &'static Wrapper<'static>) {
     loop {
-        controller.process().await;
+        if let Err(e) = controller.process_next_event().await {
+            error!("Error processing controller event: {:?}", e);
+        }
     }
 }
 

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use ::tps6699x::ADDR1;
-use defmt::info;
 use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio::{Input, Inverter, Pull};
@@ -20,6 +19,7 @@ use embedded_services::cfu::component::InternalResponseData;
 use embedded_services::cfu::component::RequestData;
 use embedded_services::power::policy::DeviceId as PowerId;
 use embedded_services::type_c::{self, ControllerId};
+use embedded_services::{error, info};
 use embedded_usb_pd::GlobalPortId;
 use static_cell::StaticCell;
 use tps6699x::asynchronous::embassy as tps6699x;
@@ -56,7 +56,9 @@ const PORT1_PWR_ID: PowerId = PowerId(1);
 #[embassy_executor::task]
 async fn pd_controller_task(controller: &'static Wrapper<'static>) {
     loop {
-        controller.process().await;
+        if let Err(e) = controller.process_next_event().await {
+            error!("Error processing controller event: {:?}", e);
+        }
     }
 }
 

--- a/type-c-service/Cargo.toml
+++ b/type-c-service/Cargo.toml
@@ -33,6 +33,7 @@ embassy-executor = { workspace = true, features = [
     "executor-thread",
 ] }
 embassy-futures.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 
 [features]
 default = []

--- a/type-c-service/src/lib.rs
+++ b/type-c-service/src/lib.rs
@@ -3,4 +3,358 @@ pub mod driver;
 pub mod task;
 pub mod wrapper;
 
+use core::future::Future;
+
+use embedded_services::type_c::event::{
+    PortEvent, PortNotification, PortNotificationSingle, PortPendingIter, PortStatusChanged,
+};
 pub use task::task;
+
+/// Enum to contain all port event variants
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PortEventVariant {
+    /// Port status change events
+    StatusChanged(PortStatusChanged),
+    /// Port notification events
+    Notification(PortNotificationSingle),
+}
+
+/// Struct to convert port events into a stream of events
+#[derive(Clone, Copy)]
+pub struct PortEventStreamer {
+    /// Current port index being processed
+    port_index: Option<usize>,
+    /// Iterator over pending ports
+    pending_iter: PortPendingIter,
+    /// Notification to be streamed
+    pending_notifications: Option<PortNotification>,
+}
+
+impl PortEventStreamer {
+    /// Create new PortEventStreamer
+    ///
+    /// Returns none if there are no pending ports to process.
+    pub fn new(pending_iter: PortPendingIter) -> Self {
+        Self {
+            port_index: None,
+            pending_iter,
+            pending_notifications: None,
+        }
+    }
+}
+
+impl PortEventStreamer {
+    /// Get the next port event, calls the closure if it needs to get pending events for the current port.
+    pub async fn next<E, Fut: Future<Output = Result<PortEvent, E>>, F: FnMut(usize) -> Fut>(
+        &mut self,
+        mut f: F,
+    ) -> Result<Option<(usize, PortEventVariant)>, E> {
+        loop {
+            let port_index = if let Some(index) = self.port_index {
+                index
+            } else if let Some(next_port) = self.pending_iter.next() {
+                // First time this function is called, get our starting port index
+                self.port_index = Some(next_port);
+                next_port
+            } else {
+                // No pending ports to process
+                return Ok(None);
+            };
+
+            let mut advance_port = false;
+            let mut ret = None;
+
+            if let Some(mut pending) = self.pending_notifications {
+                if let Some(port_event) = pending.next() {
+                    // Return a single notification
+                    self.pending_notifications = Some(pending);
+                    ret = Some((port_index, PortEventVariant::Notification(port_event)));
+                } else {
+                    // Done with pending notifications, continue to the next port
+                    advance_port = true;
+                    self.pending_notifications = None;
+                }
+            } else {
+                // Haven't read port events yet
+                let event = f(port_index).await?;
+
+                if event.notification != PortNotification::none() {
+                    // Have pending notifications to stream as events, store those for the next loop/call to this function
+                    self.pending_notifications = Some(event.notification);
+                } else {
+                    // No pending notifications, we can advance to the next port
+                    advance_port = true;
+                    self.pending_notifications = None;
+                }
+
+                if event.status != PortStatusChanged::none() {
+                    // Return the port status changed event first if there is one
+                    ret = Some((port_index, PortEventVariant::StatusChanged(event.status)));
+                }
+            }
+
+            if advance_port {
+                if let Some(next_port) = self.pending_iter.next() {
+                    // Move to the next port
+                    self.port_index = Some(next_port);
+                } else if ret.is_none() {
+                    // Don't have any more ports to process
+                    // And we didn't have any events to return, we're done
+                    return Ok(None);
+                } else {
+                    // This is the last port, but we have an event to return
+                    // We'll have to return none on the next call, achieve this by setting port_index to None
+                    // The next call will call next() on the pending port iterator which will return None
+                    self.port_index = None;
+                }
+            }
+
+            // Return the event if we have one, otherwise loop to get the next event
+            if ret.is_some() {
+                return Ok(ret);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::AtomicBool;
+
+    use embedded_services::type_c::event::PortPending;
+
+    use super::*;
+
+    /// Utitily function to create a PortStatusChanged event
+    fn status_changed(plug_event: bool, power_contract: bool, sink_ready: bool) -> PortStatusChanged {
+        let mut status_changed = PortStatusChanged::none();
+        status_changed.set_plug_inserted_or_removed(plug_event);
+        status_changed.set_new_power_contract_as_consumer(power_contract);
+        status_changed.set_sink_ready(sink_ready);
+        status_changed
+    }
+
+    /// Utility function to create a PortNotification event
+    fn notification(alert: bool, discover_mode_completed: bool) -> PortNotification {
+        let mut notification = PortNotification::none();
+        notification.set_alert(alert);
+        notification.set_discover_mode_completed(discover_mode_completed);
+        notification
+    }
+
+    /// Test iterating over port status changed events
+    #[tokio::test]
+    async fn test_port_status_changed() {
+        let mut pending_ports = PortPending::none();
+        pending_ports.pend_port(0);
+        pending_ports.pend_port(2);
+        pending_ports.pend_port(3);
+
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(status_changed(true, true, true).into()))
+            .await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                0,
+                PortEventVariant::StatusChanged(status_changed(true, true, true))
+            )))
+        );
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(status_changed(true, false, true).into()))
+            .await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                2,
+                PortEventVariant::StatusChanged(status_changed(true, false, true))
+            )))
+        );
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(status_changed(false, false, true).into()))
+            .await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                3,
+                PortEventVariant::StatusChanged(status_changed(false, false, true))
+            )))
+        );
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(status_changed(false, false, true).into()))
+            .await;
+        assert_eq!(event, Ok(None));
+    }
+
+    /// Test iterating over port notifications
+    #[tokio::test]
+    async fn test_port_notification() {
+        let mut pending_ports = PortPending::none();
+        pending_ports.pend_port(0);
+
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(notification(true, true).into()))
+            .await;
+        assert_eq!(
+            event,
+            Ok(Some((0, PortEventVariant::Notification(PortNotificationSingle::Alert))))
+        );
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(notification(true, true).into()))
+            .await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                0,
+                PortEventVariant::Notification(PortNotificationSingle::DiscoverModeCompleted)
+            )))
+        );
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(notification(true, true).into()))
+            .await;
+        assert_eq!(event, Ok(None));
+    }
+
+    /// Test the the final port with no pending notifications
+    #[tokio::test]
+    async fn test_last_notifications() {
+        let mut pending_ports = PortPending::none();
+        pending_ports.pend_port(0);
+
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+
+        // Test p0 events
+        let p0_event = status_changed(true, true, true).into();
+        let event = streamer.next::<(), _, _>(async |_| Ok(p0_event)).await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                0,
+                PortEventVariant::StatusChanged(status_changed(true, true, true))
+            )))
+        );
+
+        let event = streamer.next::<(), _, _>(async |_| Ok(p0_event)).await;
+        assert_eq!(event, Ok(None));
+    }
+
+    /// Test iterating over both status and notification events
+    #[tokio::test]
+    async fn test_port_event() {
+        let mut pending_ports = PortPending::none();
+        pending_ports.pend_port(0);
+        pending_ports.pend_port(6);
+
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+
+        // Test p0 events
+        let p0_event = PortEvent {
+            status: status_changed(true, true, true),
+            notification: notification(true, false),
+        };
+
+        let event = streamer.next::<(), _, _>(async |_| Ok(p0_event)).await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                0,
+                PortEventVariant::StatusChanged(status_changed(true, true, true))
+            )))
+        );
+
+        let event = streamer.next::<(), _, _>(async |_| Ok(p0_event)).await;
+        assert_eq!(
+            event,
+            Ok(Some((0, PortEventVariant::Notification(PortNotificationSingle::Alert))))
+        );
+
+        // Test p6 events
+        let p6_event = PortEvent {
+            status: status_changed(false, true, false),
+            notification: notification(false, true),
+        };
+
+        let event = streamer.next::<(), _, _>(async |_| Ok(p6_event)).await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                6,
+                PortEventVariant::StatusChanged(status_changed(false, true, false))
+            )))
+        );
+
+        let event = streamer.next::<(), _, _>(async |_| Ok(p6_event)).await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                6,
+                PortEventVariant::Notification(PortNotificationSingle::DiscoverModeCompleted)
+            )))
+        );
+
+        let event = streamer.next::<(), _, _>(async |_| Ok(p6_event)).await;
+        assert_eq!(event, Ok(None));
+    }
+
+    /// Test no pending ports
+    #[tokio::test]
+    async fn test_no_pending_ports() {
+        let pending_ports = PortPending::none();
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(status_changed(true, true, true).into()))
+            .await;
+        assert_eq!(event, Ok(None));
+    }
+
+    /// Test a port with a pending event with no actual event
+    #[tokio::test]
+    async fn test_empty_event() {
+        let mut pending_ports = PortPending::none();
+        pending_ports.pend_port(0);
+
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+        let event = streamer.next::<(), _, _>(async |_| Ok(PortEvent::none())).await;
+        assert_eq!(event, Ok(None));
+    }
+
+    /// Test advancing to the next port when there are no events
+    #[tokio::test]
+    async fn test_skip_no_pending() {
+        let mut pending_ports = PortPending::none();
+        pending_ports.pend_port(0);
+        pending_ports.pend_port(1);
+
+        let mut streamer = PortEventStreamer::new(pending_ports.into_iter());
+        let event = streamer
+            .next::<(), _, _>(async |_| {
+                static HAVE_EVENTS: AtomicBool = AtomicBool::new(false);
+                let have_events = HAVE_EVENTS.load(core::sync::atomic::Ordering::Relaxed);
+                let event = Ok(status_changed(have_events, have_events, have_events).into());
+                HAVE_EVENTS.store(true, core::sync::atomic::Ordering::Relaxed);
+                event
+            })
+            .await;
+        assert_eq!(
+            event,
+            Ok(Some((
+                1,
+                PortEventVariant::StatusChanged(status_changed(true, true, true))
+            )))
+        );
+
+        let event = streamer
+            .next::<(), _, _>(async |_| Ok(status_changed(false, false, false).into()))
+            .await;
+        assert_eq!(event, Ok(None));
+    }
+}

--- a/type-c-service/src/wrapper/cfu.rs
+++ b/type-c-service/src/wrapper/cfu.rs
@@ -28,6 +28,14 @@ impl FwUpdateState {
     }
 }
 
+/// CFU events
+pub enum Event {
+    /// CFU request
+    Request(RequestData),
+    /// Recovery tick
+    RecoveryTick,
+}
+
 impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N, C, V> {
     /// Create a new invalid FW version response
     fn create_invalid_fw_version_response(&self) -> InternalResponseData {
@@ -147,7 +155,7 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
             }
 
             // Need to start the update
-            state.fw_update_ticker.reset();
+            self.fw_update_ticker.lock().await.reset();
             match controller.start_fw_update().await {
                 Ok(_) => {
                     debug!("FW update started successfully");
@@ -313,26 +321,33 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
     /// Wait for a CFU command
     ///
     /// Returns None if the FW update ticker has ticked
-    pub async fn wait_cfu_command(&self, state: &mut InternalState) -> Option<RequestData> {
-        match state.fw_update_state {
+    pub async fn wait_cfu_command(&self) -> Event {
+        // Only lock long enough to grab our state
+        let fw_update_state = self.state.lock().await.fw_update_state;
+        match fw_update_state {
             FwUpdateState::Idle => {
                 // No FW update in progress, just wait for a command
-                Some(self.cfu_device.wait_request().await)
+                Event::Request(self.cfu_device.wait_request().await)
             }
             FwUpdateState::InProgress(_) => {
-                match select(self.cfu_device.wait_request(), state.fw_update_ticker.next()).await {
-                    Either::First(command) => Some(command),
+                match select(
+                    self.cfu_device.wait_request(),
+                    self.fw_update_ticker.lock().await.next(),
+                )
+                .await
+                {
+                    Either::First(command) => Event::Request(command),
                     Either::Second(_) => {
                         debug!("FW update ticker ticked");
-                        None
+                        Event::RecoveryTick
                     }
                 }
             }
             FwUpdateState::Recovery => {
                 // Recovery state, wait for the next attempt to recover the device
-                state.fw_update_ticker.next().await;
+                self.fw_update_ticker.lock().await.next().await;
                 debug!("FW update ticker ticked");
-                None
+                Event::RecoveryTick
             }
         }
     }

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -35,7 +35,7 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
             }
             controller::PortCommandData::ClearEvents => {
                 let event = self.active_events[0].get();
-                self.active_events[0].set(PortEventKind::none());
+                self.active_events[0].set(PortEvent::none());
                 Ok(controller::PortResponseData::ClearEvents(event))
             }
             controller::PortCommandData::RetimerFwUpdateGetState => {

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -174,16 +174,18 @@ impl<const N: usize, C: Controller, V: FwOfferValidator> ControllerWrapper<'_, N
     }
 
     /// Wait for a power command
+    ///
+    /// Returns (local port ID, deferred request)
     pub(super) async fn wait_power_command(
         &self,
     ) -> (
-        deferred::Request<'_, GlobalRawMutex, CommandData, InternalResponseData>,
         LocalPortId,
+        deferred::Request<'_, GlobalRawMutex, CommandData, InternalResponseData>,
     ) {
         let futures: [_; N] = from_fn(|i| self.power[i].receive());
         let (request, local_id) = select_array(futures).await;
         trace!("Power command: device{} {:#?}", local_id, request.command);
-        (request, LocalPortId(local_id as u8))
+        (LocalPortId(local_id as u8), request)
     }
 
     /// Process a power command


### PR DESCRIPTION
This PR is a refactoring of the type-C event loop to achieve the following:

* Open up the wrapper event loop to allow for users of the code to control event processing. This moves the wrapper code over to use a stream of port events. This better matches how the type-C service implementation events are.
* Add support for alert/VDM. The existing event bitflags are now split up. The existing port status related flags are in their own portion and the alert and VDM ones are in their own. This is meant to reflect how they're used in code. The status flags are related to port state and are generally handled by the same code paths. While the alert and VDM events are notifications to us that are don't really impact the port state and will be handled by completely different code.

Also increase the delays in one of the std examples, 250 ms is very short to simulate a plug and unplug.