### PR TITLE
transformers: Create `Object` trait

### DIFF
--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -22,6 +22,7 @@ pub mod init;
 pub mod ipc;
 pub mod keyboard;
 pub mod power;
+pub mod transformers;
 pub mod type_c;
 
 /// Global Mutex type, ThreadModeRawMutex is used in a microcontroller context, whereas CriticalSectionRawMutex is used

--- a/embedded-service/src/transformers/mod.rs
+++ b/embedded-service/src/transformers/mod.rs
@@ -1,0 +1,2 @@
+//! Transformers framework
+pub mod object;

--- a/embedded-service/src/transformers/object.rs
+++ b/embedded-service/src/transformers/object.rs
@@ -1,0 +1,51 @@
+//! Object trait and related implementations
+
+use core::ops::{Deref, DerefMut};
+
+use embassy_sync::{
+    blocking_mutex::raw::RawMutex,
+    mutex::{Mutex, MutexGuard},
+};
+
+/// Trait to allow for borrowing a reference to the inner type
+pub trait RefGuard<Inner>: Deref<Target = Inner> {}
+
+/// Trait to allow for borrowing a mutable reference to the inner type
+pub trait RefMutGuard<Inner>: DerefMut<Target = Inner> {}
+
+/// Object trait
+pub trait Object<Inner> {
+    /// Get a reference to the inner object
+    fn get_inner(&self) -> impl Future<Output = impl RefGuard<Inner>>;
+    /// Get a mutable reference to the inner object
+    fn get_inner_mut(&self) -> impl Future<Output = impl RefMutGuard<Inner>>;
+}
+
+/// A mutex wrapped object
+pub struct ObjectMutex<Inner, M: RawMutex> {
+    inner: Mutex<M, Inner>,
+}
+
+impl<Inner, M: RawMutex> ObjectMutex<Inner, M> {
+    /// Create a new ObjectMutex
+    pub fn new(inner: Inner) -> Self {
+        Self {
+            inner: Mutex::new(inner),
+        }
+    }
+}
+
+impl<Inner, M: RawMutex> Object<Inner> for ObjectMutex<Inner, M> {
+    /// Get a reference to the inner object
+    async fn get_inner(&self) -> impl RefGuard<Inner> {
+        self.inner.lock().await
+    }
+
+    /// Get a mutable reference to the inner object
+    async fn get_inner_mut(&self) -> impl RefMutGuard<Inner> {
+        self.inner.lock().await
+    }
+}
+
+impl<Inner, M: RawMutex> RefGuard<Inner> for MutexGuard<'_, M, Inner> {}
+impl<Inner, M: RawMutex> RefMutGuard<Inner> for MutexGuard<'_, M, Inner> {}

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -4,6 +4,7 @@ use embassy_time::Timer;
 use embedded_cfu_protocol::protocol_definitions::{FwUpdateOfferResponse, HostToken};
 use embedded_services::comms;
 use embedded_services::power::{self, policy};
+use embedded_services::transformers::object::Object;
 use embedded_services::type_c::{ControllerId, controller};
 use embedded_usb_pd::Error;
 use embedded_usb_pd::GlobalPortId;
@@ -89,6 +90,11 @@ mod test_controller {
                 state,
                 events: Cell::new(PortEventKind::none()),
             }
+        }
+
+        /// Function to demonstrate calling functions directly on the controller
+        pub fn custom_function(&self) {
+            info!("Custom function called on controller");
         }
     }
 
@@ -244,6 +250,8 @@ async fn controller_task(state: &'static test_controller::ControllerState) {
     });
 
     wrapper.register().await.unwrap();
+
+    wrapper.get_inner().await.custom_function();
 
     loop {
         wrapper.process().await;


### PR DESCRIPTION
Our existing wrapper structs don't provide a way to access the actual device object. This makes implementing custom functionality almost impossible. Create `Object` trait that wrappers can implement to grant access to the underlying device. Also implement this trait for the type-C controller wrapper and update the type-c-service example to demonstrate this functionality.