### PR TITLE
power-policy: Add unconstrained logic

### DIFF
--- a/embedded-service/src/power/policy/action/device.rs
+++ b/embedded-service/src/power/policy/action/device.rs
@@ -1,6 +1,6 @@
 //! Device state machine actions
 use super::*;
-use crate::power::policy::{Error, PowerCapability, device, policy};
+use crate::power::policy::{ConsumerPowerCapability, Error, ProviderPowerCapability, device, policy};
 use crate::{info, trace};
 
 /// Device state machine control
@@ -66,7 +66,7 @@ impl<'a, S: Kind> Device<'a, S> {
     /// Notify the power policy service of an updated consumer power capability
     async fn notify_consumer_power_capability_internal(
         &self,
-        capability: Option<PowerCapability>,
+        capability: Option<ConsumerPowerCapability>,
     ) -> Result<(), Error> {
         info!(
             "Device {} consume capability updated: {:#?}",
@@ -83,7 +83,10 @@ impl<'a, S: Kind> Device<'a, S> {
     }
 
     /// Request the given power from the power policy service
-    async fn request_provider_power_capability_internal(&self, capability: PowerCapability) -> Result<(), Error> {
+    async fn request_provider_power_capability_internal(
+        &self,
+        capability: ProviderPowerCapability,
+    ) -> Result<(), Error> {
         if self.device.provider_capability().await == Some(capability) {
             // Already operating at this capability, power policy is already aware, don't need to do anything
             trace!("Device {} already requested: {:#?}", self.device.id().0, capability);
@@ -116,12 +119,15 @@ impl<'a> Device<'a, Detached> {
 
 impl Device<'_, Idle> {
     /// Notify the power policy service of an updated consumer power capability
-    pub async fn notify_consumer_power_capability(&self, capability: Option<PowerCapability>) -> Result<(), Error> {
+    pub async fn notify_consumer_power_capability(
+        &self,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> Result<(), Error> {
         self.notify_consumer_power_capability_internal(capability).await
     }
 
     /// Request the given power from the power policy service
-    pub async fn request_provider_power_capability(&self, capability: PowerCapability) -> Result<(), Error> {
+    pub async fn request_provider_power_capability(&self, capability: ProviderPowerCapability) -> Result<(), Error> {
         self.request_provider_power_capability_internal(capability).await
     }
 }
@@ -134,7 +140,10 @@ impl<'a> Device<'a, ConnectedConsumer> {
     }
 
     /// Notify the power policy service of an updated consumer power capability
-    pub async fn notify_consumer_power_capability(&self, capability: Option<PowerCapability>) -> Result<(), Error> {
+    pub async fn notify_consumer_power_capability(
+        &self,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> Result<(), Error> {
         self.notify_consumer_power_capability_internal(capability).await
     }
 }
@@ -147,12 +156,15 @@ impl<'a> Device<'a, ConnectedProvider> {
     }
 
     /// Request the given power from the power policy service
-    pub async fn request_provider_power_capability(&self, capability: PowerCapability) -> Result<(), Error> {
+    pub async fn request_provider_power_capability(&self, capability: ProviderPowerCapability) -> Result<(), Error> {
         self.request_provider_power_capability_internal(capability).await
     }
 
     /// Notify the power policy service of an updated consumer power capability
-    pub async fn notify_consumer_power_capability(&self, capability: Option<PowerCapability>) -> Result<(), Error> {
+    pub async fn notify_consumer_power_capability(
+        &self,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> Result<(), Error> {
         self.notify_consumer_power_capability_internal(capability).await
     }
 }

--- a/embedded-service/src/power/policy/flags.rs
+++ b/embedded-service/src/power/policy/flags.rs
@@ -1,0 +1,53 @@
+//! Consumer and provider flags, these are used to signal additional information about a consumer/provider request
+
+use bitfield::bitfield;
+
+bitfield! {
+    /// Raw consumer flags bit field
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    struct ConsumerRaw(u32);
+    impl Debug;
+    /// Unconstrained power, indicates that we are drawing power from something like an outlet and not a limited source like a battery
+    pub u8, unconstrained_power, set_unconstrained_power: 0, 0;
+}
+
+/// Type safe wrapper for consumer flags
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Consumer(ConsumerRaw);
+
+impl Consumer {
+    /// Create a new consumer with no flags set
+    pub const fn none() -> Self {
+        Self(ConsumerRaw(0))
+    }
+
+    /// Builder method to set the unconstrained power flag
+    pub fn with_unconstrained_power(mut self) -> Self {
+        self.0.set_unconstrained_power(1);
+        self
+    }
+
+    /// Check if the unconstrained power flag is set
+    pub fn unconstrained_power(&self) -> bool {
+        self.0.unconstrained_power() != 0
+    }
+
+    /// Set the unconstrained power flag
+    pub fn set_unconstrained_power(&mut self, value: bool) {
+        self.0.set_unconstrained_power(value as u8);
+    }
+}
+
+/// Type safe wrapper for provider flags
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Provider(());
+
+impl Provider {
+    /// Create a new provider with no flags set
+    pub const fn none() -> Self {
+        Self(())
+    }
+}

--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -2,6 +2,7 @@
 pub mod action;
 pub mod charger;
 pub mod device;
+pub mod flags;
 pub mod policy;
 
 pub use policy::{init, register_device};
@@ -66,6 +67,54 @@ impl Ord for PowerCapability {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.max_power_mw().cmp(&other.max_power_mw())
     }
+}
+
+/// Power capability with consumer flags
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ConsumerPowerCapability {
+    /// Power capability
+    pub capability: PowerCapability,
+    /// Consumer flags
+    pub flags: flags::Consumer,
+}
+
+impl From<PowerCapability> for ConsumerPowerCapability {
+    fn from(capability: PowerCapability) -> Self {
+        Self {
+            capability,
+            flags: flags::Consumer::none(),
+        }
+    }
+}
+
+/// Power capability with provider flags
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ProviderPowerCapability {
+    /// Power capability
+    pub capability: PowerCapability,
+    /// Provider flags
+    pub flags: flags::Provider,
+}
+
+impl From<PowerCapability> for ProviderPowerCapability {
+    fn from(capability: PowerCapability) -> Self {
+        Self {
+            capability,
+            flags: flags::Provider::none(),
+        }
+    }
+}
+
+/// Combined power capability with flags enum
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PowerCapabilityFlags {
+    /// Consumer flags
+    Consumer(ConsumerPowerCapability),
+    /// Provider flags
+    Provider(ProviderPowerCapability),
 }
 
 /// Data to send with the comms service

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -2,12 +2,13 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::GlobalRawMutex;
+use crate::power::policy::{ConsumerPowerCapability, ProviderPowerCapability};
 use embassy_sync::channel::Channel;
 use embassy_sync::once_lock::OnceLock;
 
 use super::charger::ChargerResponse;
 use super::device::{self};
-use super::{DeviceId, Error, PowerCapability, action, charger};
+use super::{DeviceId, Error, action, charger};
 use crate::power::policy::charger::ChargerResponseData::Ack;
 use crate::{error, intrusive_list};
 
@@ -21,9 +22,9 @@ pub enum RequestData {
     /// Notify that a device has attached
     NotifyAttached,
     /// Notify that available power for consumption has changed
-    NotifyConsumerCapability(Option<PowerCapability>),
+    NotifyConsumerCapability(Option<ConsumerPowerCapability>),
     /// Request the given amount of power to provider
-    RequestProviderCapability(PowerCapability),
+    RequestProviderCapability(ProviderPowerCapability),
     /// Notify that a device cannot consume or provide power anymore
     NotifyDisconnect,
     /// Notify that a device has detached

--- a/examples/std/src/bin/power_policy.rs
+++ b/examples/std/src/bin/power_policy.rs
@@ -1,7 +1,7 @@
 use embassy_executor::{Executor, Spawner};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::{self as _, Timer};
-use embedded_services::power::policy::{self, device, PowerCapability};
+use embedded_services::power::policy::{self, PowerCapability, device};
 use log::*;
 use static_cell::StaticCell;
 
@@ -98,13 +98,16 @@ async fn run(spawner: Spawner) {
     // Plug in device 0, should become current consumer
     info!("Connecting device 0");
     let device0 = device0.attach().await.unwrap();
-    device0.notify_consumer_power_capability(Some(LOW_POWER)).await.unwrap();
+    device0
+        .notify_consumer_power_capability(Some(LOW_POWER.into()))
+        .await
+        .unwrap();
 
     // Plug in device 1, should become current consumer
     info!("Connecting device 1");
     let device1 = device1.attach().await.unwrap();
     device1
-        .notify_consumer_power_capability(Some(HIGH_POWER))
+        .notify_consumer_power_capability(Some(HIGH_POWER.into()))
         .await
         .unwrap();
 
@@ -115,7 +118,10 @@ async fn run(spawner: Spawner) {
     // Plug in device 0, device 1 should remain current consumer
     info!("Connecting device 0");
     let device0 = device0.attach().await.unwrap();
-    device0.notify_consumer_power_capability(Some(LOW_POWER)).await.unwrap();
+    device0
+        .notify_consumer_power_capability(Some(LOW_POWER.into()))
+        .await
+        .unwrap();
 
     // Unplug device 1, device 0 should become current consumer
     info!("Unplugging device 1");
@@ -125,7 +131,7 @@ async fn run(spawner: Spawner) {
     info!("Connecting device 1");
     let device1 = device1.attach().await.unwrap();
     device1
-        .notify_consumer_power_capability(Some(HIGH_POWER))
+        .notify_consumer_power_capability(Some(HIGH_POWER.into()))
         .await
         .unwrap();
 
@@ -137,18 +143,27 @@ async fn run(spawner: Spawner) {
 
     // Switch to provider on device0
     info!("Device 0 requesting provider");
-    device0.request_provider_power_capability(LOW_POWER).await.unwrap();
+    device0
+        .request_provider_power_capability(LOW_POWER.into())
+        .await
+        .unwrap();
     Timer::after_millis(250).await;
 
     info!("Device 1 attach and requesting provider");
     let device1 = device1.attach().await.unwrap();
-    device1.request_provider_power_capability(LOW_POWER).await.unwrap();
+    device1
+        .request_provider_power_capability(LOW_POWER.into())
+        .await
+        .unwrap();
     // Wait for the provider to be connected
     Timer::after_millis(250).await;
 
     // Provider upgrade should fail because device 0 is already connected
     info!("Device 1 attempting provider upgrade");
-    device1.request_provider_power_capability(HIGH_POWER).await.unwrap();
+    device1
+        .request_provider_power_capability(HIGH_POWER.into())
+        .await
+        .unwrap();
     // Wait for the upgrade flow to complete
     Timer::after_millis(250).await;
 
@@ -160,7 +175,10 @@ async fn run(spawner: Spawner) {
 
     // Provider upgrade should succeed now
     info!("Device 1 attempting provider upgrade");
-    device1.request_provider_power_capability(HIGH_POWER).await.unwrap();
+    device1
+        .request_provider_power_capability(HIGH_POWER.into())
+        .await
+        .unwrap();
     // Wait for the upgrade flow to complete
     Timer::after_millis(250).await;
 }

--- a/power-policy-service/src/lib.rs
+++ b/power-policy-service/src/lib.rs
@@ -107,17 +107,17 @@ impl PowerPolicy {
             }
             policy::RequestData::NotifyConsumerCapability(capability) => {
                 info!(
-                    "Received notify consumer capability from device {}: {:#?}",
+                    "Device{}: Received notify consumer capability: {:#?}",
                     device.id().0,
-                    capability
+                    capability,
                 );
                 self.process_notify_consumer_power_capability().await
             }
             policy::RequestData::RequestProviderCapability(capability) => {
                 info!(
-                    "Received request provider capability from device {}: {:#?}",
+                    "Device{}: Received request provider capability: {:#?}",
                     device.id().0,
-                    capability
+                    capability,
                 );
                 self.process_request_provider_power_capabilities(device.id()).await
             }


### PR DESCRIPTION
* Add consumer and provider flags to allow signaling more info to policy without needing future breaking changes
* Implement logic to prioritize unconstrained devices