### PR TITLE
Remove update from ThreadModeCell

### DIFF
--- a/embedded-service/src/thread_mode_cell.rs
+++ b/embedded-service/src/thread_mode_cell.rs
@@ -71,18 +71,6 @@ impl<T: Copy> ThreadModeCell<T> {
         assert!(in_thread_mode(), "ThreadModeCell can only be accessed in thread mode.");
         self.inner.get()
     }
-
-    /// Updates the `ThreadModeCell`'s content using a function.
-    ///
-    /// This guarantees race conditions will not occur as this can only be called in a single
-    /// execution environment (thread mode) with cooperative scheduling.
-    /// # Panics
-    ///
-    /// This function will panic if called from within an interrupt context.
-    pub fn update(&self, f: impl FnOnce(T) -> T) {
-        assert!(in_thread_mode(), "ThreadModeCell can only be accessed in thread mode.");
-        self.inner.update(f)
-    }
 }
 
 impl<T: ?Sized> ThreadModeCell<T> {


### PR DESCRIPTION
The `update()` method on `Cell` wasn't stabilized until 1.88, but our current MSRV is 1.85. This was not caught by our workflow as `ThreadModeCell` is only built when target is thumbv8m, but our MSRV workflow doesn't specifically check that target. A new PR will also be made to update our workflow to catch this next time.