### PR TITLE
power-policy: Broadcast events

### DIFF
--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -129,6 +129,8 @@ pub enum CommsData {
     Unconstrained(bool),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// Message to send with the comms service
 pub struct CommsMessage {
     /// Message data

--- a/power-policy-service/src/lib.rs
+++ b/power-policy-service/src/lib.rs
@@ -86,6 +86,7 @@ impl PowerPolicy {
 
     /// Send a notification with the comms service
     async fn comms_notify(&self, message: CommsMessage) {
+        self.context.broadcast_message(message).await;
         let _ = self
             .tp
             .send(comms::EndpointID::Internal(comms::Internal::Battery), &message)


### PR DESCRIPTION
This provides a more general way to receive events than the comms service.