### PR TITLE
Make `type_c_service::task` module public

### DIFF
--- a/type-c-service/src/lib.rs
+++ b/type-c-service/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 pub mod driver;
-mod task;
+pub mod task;
 pub mod wrapper;
 
 pub use task::task;


### PR DESCRIPTION
The module needs to be public to access types like `Service` to implement OEM-specific event loops.