### PR TITLE
power-policy-service: Keep track of policy unconstrained state

### DIFF
--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -125,6 +125,8 @@ pub enum CommsData {
     ConsumerDisconnected(DeviceId),
     /// Consumer connected
     ConsumerConnected(DeviceId, PowerCapability),
+    /// Unconstrained state changed
+    Unconstrained(bool),
 }
 
 /// Message to send with the comms service

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -84,6 +84,7 @@ mod battery {
                     info!("Consumer connected: {} {:?}", id.0, capability);
                     Ok(())
                 }
+                _ => Ok(()),
             }
         }
     }

--- a/examples/std/src/bin/power_policy.rs
+++ b/examples/std/src/bin/power_policy.rs
@@ -1,7 +1,7 @@
 use embassy_executor::{Executor, Spawner};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::{self as _, Timer};
-use embedded_services::power::policy::{self, PowerCapability, device};
+use embedded_services::power::policy::{self, ConsumerPowerCapability, PowerCapability, device, flags};
 use log::*;
 use static_cell::StaticCell;
 
@@ -99,7 +99,10 @@ async fn run(spawner: Spawner) {
     info!("Connecting device 0");
     let device0 = device0.attach().await.unwrap();
     device0
-        .notify_consumer_power_capability(Some(LOW_POWER.into()))
+        .notify_consumer_power_capability(Some(ConsumerPowerCapability {
+            capability: LOW_POWER,
+            flags: flags::Consumer::none().with_unconstrained_power(),
+        }))
         .await
         .unwrap();
 

--- a/power-policy-service/src/lib.rs
+++ b/power-policy-service/src/lib.rs
@@ -15,9 +15,11 @@ pub mod charger;
 
 struct InternalState {
     /// Current consumer state, if any
-    current_consumer_state: Option<consumer::State>,
+    current_consumer_state: Option<consumer::AvailableConsumer>,
     /// Current provider global state
     current_provider_state: provider::State,
+    /// System unconstrained power
+    unconstrained: bool,
 }
 
 impl InternalState {
@@ -25,6 +27,7 @@ impl InternalState {
         Self {
             current_consumer_state: None,
             current_provider_state: provider::State::default(),
+            unconstrained: false,
         }
     }
 }


### PR DESCRIPTION
Keep track of unconstrained state and broadcast relevant event.