### PR TITLE
Have rolling workflow create PR if update successful

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
+    inputs:
+      download-lockfiles:
+        required: false
+        type: boolean
+        default: false
 # If new code is pushed to a PR branch, then cancel in progress workflows for that PR. Ensures that
 # we don't waste CI time, and returns results quicker https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
@@ -97,6 +103,11 @@ jobs:
           components: clippy
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
+      - name: Download Cargo.lock files
+        if: ${{ inputs.download-lockfiles }}
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-lock-files
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # --feature-powerset runs for every combination of features
       - name: cargo hack
@@ -113,6 +124,11 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Download Cargo.lock files
+        if: ${{ inputs.download-lockfiles }}
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-lock-files
       - name: cargo install cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
@@ -143,6 +159,11 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Download Cargo.lock files
+        if: ${{ inputs.download-lockfiles }}
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-lock-files
       - name: cargo test
         run: cargo test --locked -p ${{ matrix.crate }}
         # After ensuring tests pass, finally ensure the test code itself contains no clippy warnings
@@ -169,6 +190,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.msrv }}
+      - name: Download Cargo.lock files
+        if: ${{ inputs.download-lockfiles }}
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-lock-files
       - name: cargo +${{ matrix.msrv }} check
         run: |
           cargo check -F log --locked --target ${{ matrix.target }}
@@ -189,6 +215,11 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Download Cargo.lock files
+        if: ${{ inputs.download-lockfiles }}
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-lock-files
       - name: cargo clippy
         working-directory: ${{ matrix.example_directory }}
         run: |
@@ -209,6 +240,11 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Download Cargo.lock files
+        if: ${{ inputs.download-lockfiles }}
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-lock-files
       - name: cargo clippy
         working-directory: ${{ matrix.example_directory }}
         run: |

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -1,101 +1,80 @@
-# This workflow runs every morning at midnight. It will run cargo hack
-# and a build with msrv. If any dependency breaks our crate, we will
-# know ASAP.
-#
-# - hack: cargo hack for all workspace packages
-# - msrv: check that the msrv specified in the crate is correct
-# - check-*-examples: ensures examples still compile
+# This workflow runs every morning at midnight.
+# It runs cargo update and checks that no builds or tests are broken.
+# If not, a PR is created with updated Cargo.lock files.
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 name: rolling
+
 jobs:
-
-  hack:
-    # cargo-hack checks combinations of feature flags to ensure that features are all additive
-    # which is required for feature unification
+  update-dependencies:
+    name: cargo-update / update-dependencies
     runs-on: ubuntu-latest
-    name: ubuntu / stable / features
-    strategy:
-      fail-fast: false
+    outputs:
+      pr-needed: ${{ steps.check-pr.outputs.changes }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
-      - name: cargo install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
-      # --feature-powerset runs for every combination of features
-      - name: cargo hack
+
+      - name: Run cargo update
         run: |
           cargo update
-          cargo hack --feature-powerset --mutually-exclusive-features=log,defmt check
+          cargo update --manifest-path examples/std/Cargo.toml
+          cargo update --manifest-path examples/rt633/Cargo.toml
+          cargo update --manifest-path examples/rt685s-evk/Cargo.toml
 
-  msrv:
+      - name: Check diff
+        id: check-pr
+        run: |
+          git diff --quiet || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Upload Cargo.lock files
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-lock-files
+          path: |
+            **/Cargo.lock
+
+  check-build:
+    name: cargo-update / check-build
+    needs: update-dependencies
+    if: ${{ needs.update-dependencies.outputs.pr-needed == 'true' }}
+    uses: ./.github/workflows/check.yml
+    with:
+      download-lockfiles: true
+
+  pull-request:
+    name: cargo-update / pull-request
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        msrv: ["1.85"]
-    name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
+    needs: [check-build, update-dependencies]
+    if: ${{ needs.update-dependencies.outputs.pr-needed == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install ${{ matrix.msrv }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.msrv }}
-      - name: cargo +${{ matrix.msrv }} check
-        run: |
-          cargo update
-          cargo check -F log --locked
-          cargo check -F defmt --locked
 
-  check-arm-examples:
-    runs-on: ubuntu-latest
-    # we use a matrix here just because env can't be used in job names
-    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-    strategy:
-      fail-fast: false
-      matrix:
-        example_directory: ["examples/rt633", "examples/rt685s-evk"]
-    name: ubuntu / check-examples
-    steps:
-      - uses: actions/checkout@v4
+      - name: Download Cargo.lock files
+        uses: actions/download-artifact@v4
         with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: cargo check
-        working-directory: ${{ matrix.example_directory }}
-        run: |
-          cargo update
-          cargo check --target thumbv8m.main-none-eabihf
+          name: updated-lock-files
 
-  check-std-examples:
-    runs-on: ubuntu-latest
-    # we use a matrix here just because env can't be used in job names
-    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-    strategy:
-      fail-fast: false
-      matrix:
-        example_directory: ["examples/std"]
-    name: ubuntu / check-examples
-    steps:
-      - uses: actions/checkout@v4
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
         with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: cargo check
-        working-directory: ${{ matrix.example_directory }}
-        run: |
-          cargo update
-          cargo check
+          commit-message: "chore: update dependencies"
+          branch: rolling/update-dependencies
+          title: "chore: update dependencies"
+          body: |
+            Update Cargo.lock files using `cargo update`. All tests and builds passed.
+          labels: dependencies
+          reviewers: ec-code-owners


### PR DESCRIPTION
This PR modifies the rolling workflow to perform a `cargo update` and if no builds or tests are broken, create a PR to update `Cargo.lock` files. It accomplishes this by:

- Running `cargo update` on workspace root and example folders (which are excluded from the workspace)
- If this results in a diff, run our `check.yml` job (with updated `Cargo.lock` files) for thorough checking
- If `check.yml` fails, no PR is created and we can see which job in `check.yml` failed in the Actions tab
- If `check.yml` passes, a PR is created with updated `Cargo.lock` files

The `check.yml` workflow has been modified to download the updated `Cargo.lock` files artifact if called by `rolling.yml`.

This has been tested reasonably thoroughly on my fork but it's hard to test all possible cases, so if it doesn't always perform as expected this workflow can be modified to address issues in future PRs.

Of note is the PRs generated by this workflow won't trigger other workflows without special workarounds involving new tokens (see: [note](https://github.com/peter-evans/create-pull-request/blob/v5/docs/concepts-guidelines.md#triggering-further-workflow-runs)). This means the PR itself won't trigger the `check.yml` workflow. This might not be a problem since the PR doesn't get created if `check.yml` fails in the first place, and if we update the PR ourselves (e.g. to rebase it off new main changes) that should trigger the workflow then.