### PR TITLE
Remove no-std badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![check](https://github.com/OpenDevicePartnership/embedded-services/actions/workflows/check.yml/badge.svg)](https://github.com/OpenDevicePartnership/embedded-services/actions/workflows/check.yml)
-[![no-std](https://github.com/OpenDevicePartnership/embedded-services/actions/workflows/nostd.yml/badge.svg)](https://github.com/OpenDevicePartnership/embedded-services/actions/workflows/nostd.yml)
 [![rolling](https://github.com/OpenDevicePartnership/embedded-services/actions/workflows/rolling.yml/badge.svg)](https://github.com/OpenDevicePartnership/embedded-services/actions/workflows/rolling.yml)
 [![LICENSE](https://img.shields.io/badge/License-MIT-blue)](./LICENSE)
 


### PR DESCRIPTION
After removing nostd.yml (since it is obsolete with updated check.yml, see #417), this badge is no longer necessary and is currently broken so remove it from the README.