### PR TITLE
type-c-service/wrapper: Pend global port instead of local port

### DIFF
--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -216,7 +216,7 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         self.active_events[port_index].set(event.union(status_event.into()));
 
         let mut pending = PortPending::none();
-        pending.pend_port(port_index);
+        pending.pend_port(global_port_id.0 as usize);
         self.pd_controller.notify_ports(pending).await;
 
         Ok(())


### PR DESCRIPTION
The existing implementation was notifying the type-C service with the local port number but the service works with global port numbers.