### PR TITLE
type-c-service/wrapper: Migrate event loop over to wait/process/finalize

### DIFF
--- a/embedded-service/src/cfu/component.rs
+++ b/embedded-service/src/cfu/component.rs
@@ -163,6 +163,8 @@ impl CfuDevice {
     }
 
     /// Wait for a request
+    ///
+    /// DROP SAFETY: Direct call to deferred channel primitive
     pub async fn wait_request(&self) -> RequestData {
         self.request.receive().await
     }

--- a/embedded-service/src/ipc/deferred.rs
+++ b/embedded-service/src/ipc/deferred.rs
@@ -62,6 +62,8 @@ impl<M: RawMutex, C, R> Channel<M, C, R> {
     }
 
     /// Wait for an invocation
+    ///
+    /// DROP SAFETY: Call to drop safe embassy primitive
     pub async fn receive(&self) -> Request<'_, M, C, R> {
         let (command, request_id) = self.command.wait().await;
         Request {

--- a/embedded-service/src/power/policy/device.rs
+++ b/embedded-service/src/power/policy/device.rs
@@ -181,6 +181,8 @@ impl Device {
     }
 
     /// Create a handler for the command channel
+    ///
+    /// DROP SAFETY: Direct call to deferred channel primitive
     pub async fn receive(&self) -> deferred::Request<'_, GlobalRawMutex, CommandData, InternalResponseData> {
         self.command.receive().await
     }

--- a/embedded-service/src/type_c/event.rs
+++ b/embedded-service/src/type_c/event.rs
@@ -9,7 +9,7 @@ use bitvec::BitArr;
 
 bitfield! {
     /// Raw bitfield of possible port status events
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq, Default)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct PortStatusChangedRaw(u16);
     impl Debug;
@@ -36,7 +36,7 @@ bitfield! {
 /// Port status change events
 /// This is a type-safe wrapper around the raw bitfield
 /// These events are related to the overall port state and typically need to be considered together.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PortStatusChanged(PortStatusChangedRaw);
 
@@ -348,6 +348,12 @@ impl PortEvent {
             status: self.status.union(other.status),
             notification: self.notification.union(other.notification),
         }
+    }
+}
+
+impl Default for PortEvent {
+    fn default() -> Self {
+        Self::none()
     }
 }
 

--- a/embedded-service/src/type_c/external.rs
+++ b/embedded-service/src/type_c/external.rs
@@ -1,7 +1,7 @@
 //! Message definitions for external type-C commands
 use embedded_usb_pd::{GlobalPortId, PdError, PortId as LocalPortId, ucsi};
 
-use crate::type_c::controller::execute_external_ucsi_command;
+use crate::type_c::{Cached, controller::execute_external_ucsi_command};
 
 use super::{
     ControllerId,
@@ -49,7 +49,7 @@ pub type ControllerResponse<'a> = Result<ControllerResponseData<'a>, PdError>;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PortCommandData {
     /// Get port status. The `bool` argument indicates whether to use cached data or force a fetch of register values.
-    PortStatus(bool),
+    PortStatus(Cached),
     /// Get retimer fw update status
     RetimerFwUpdateGetState,
     /// Set retimer fw update status
@@ -132,7 +132,7 @@ pub enum Response<'a> {
 /// Get the status of the given port.
 ///
 /// Use the `cached` argument to specify whether to use cached data or force a fetch of register values.
-pub async fn get_port_status(port: GlobalPortId, cached: bool) -> Result<PortStatus, PdError> {
+pub async fn get_port_status(port: GlobalPortId, cached: Cached) -> Result<PortStatus, PdError> {
     match execute_external_port_command(Command::Port(PortCommand {
         port,
         data: PortCommandData::PortStatus(cached),
@@ -150,7 +150,7 @@ pub async fn get_port_status(port: GlobalPortId, cached: bool) -> Result<PortSta
 pub async fn get_controller_port_status(
     controller: ControllerId,
     port: LocalPortId,
-    cached: bool,
+    cached: Cached,
 ) -> Result<PortStatus, PdError> {
     let global_port = controller_port_to_global_id(controller, port).await?;
     get_port_status(global_port, cached).await

--- a/embedded-service/src/type_c/mod.rs
+++ b/embedded-service/src/type_c/mod.rs
@@ -148,3 +148,8 @@ pub const POWER_CAPABILITY_5V_3A0: policy::PowerCapability = policy::PowerCapabi
     voltage_mv: 5000,
     current_ma: 3000,
 };
+
+/// Newtype to help clarify arguments to port status commands
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Cached(pub bool);

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -13,7 +13,7 @@ use embassy_sync::mutex::Mutex;
 use embassy_time::{self as _, Delay};
 use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferResponse, FwVersion, HostToken};
 use embedded_services::power::policy::DeviceId as PowerId;
-use embedded_services::type_c::{self, ControllerId};
+use embedded_services::type_c::{self, Cached, ControllerId};
 use embedded_services::{GlobalRawMutex, comms};
 use embedded_services::{error, info};
 use embedded_usb_pd::GlobalPortId;
@@ -227,9 +227,9 @@ async fn main(spawner: Spawner) {
 
     info!("Controller status: {:?}", status);
 
-    let status = type_c::external::get_port_status(PORT0_ID, true).await.unwrap();
+    let status = type_c::external::get_port_status(PORT0_ID, Cached(true)).await.unwrap();
     info!("Port status: {:?}", status);
 
-    let status = type_c::external::get_port_status(PORT1_ID, true).await.unwrap();
+    let status = type_c::external::get_port_status(PORT1_ID, Cached(true)).await.unwrap();
     info!("Port status: {:?}", status);
 }

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -102,7 +102,7 @@ async fn fw_update_task() {
     info!("Got response: {:?}", offer);
 
     let fw = &[]; //include_bytes!("../../fw.bin");
-    let num_chunks = fw.len() / DEFAULT_DATA_LENGTH;
+    let num_chunks = fw.len() / DEFAULT_DATA_LENGTH + (fw.len() % DEFAULT_DATA_LENGTH != 0) as usize;
 
     for (i, chunk) in fw.chunks(DEFAULT_DATA_LENGTH).enumerate() {
         let header = FwUpdateContentHeader {
@@ -125,7 +125,7 @@ async fn fw_update_task() {
             data: chunk_data,
         };
 
-        info!("Sending chunk {} of {}", i, fw.len());
+        info!("Sending chunk {} of {}", i + 1, num_chunks);
         let response = device
             .execute_device_request(RequestData::GiveContent(request))
             .await

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#dda1b74f37df6aba6fa46aa94726a2cd86139331"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x#49589684f06106e6732e60675b90e1aed2dac799"
 dependencies = [
  "bincode",
  "bitfield 0.19.1",

--- a/examples/std/src/bin/type_c/basic.rs
+++ b/examples/std/src/bin/type_c/basic.rs
@@ -2,7 +2,7 @@ use embassy_executor::{Executor, Spawner};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::Timer;
 use embedded_services::power;
-use embedded_services::type_c::{ControllerId, controller};
+use embedded_services::type_c::{Cached, ControllerId, controller};
 use embedded_usb_pd::ucsi::lpm;
 use embedded_usb_pd::{GlobalPortId, PdError as Error};
 use log::*;
@@ -86,7 +86,7 @@ mod test_controller {
             command: controller::PortCommand,
         ) -> Result<controller::PortResponseData, Error> {
             Ok(match command.data {
-                controller::PortCommandData::PortStatus(true) => {
+                controller::PortCommandData::PortStatus(Cached(true)) => {
                     info!("Port status for port {}", command.port.0);
                     controller::PortResponseData::PortStatus(PortStatus::new())
                 }
@@ -153,10 +153,10 @@ async fn task(spawner: Spawner) {
     let status = context.get_controller_status(CONTROLLER0).await.unwrap();
     info!("Controller 0 status: {status:#?}");
 
-    let status = context.get_port_status(PORT0, true).await.unwrap();
+    let status = context.get_port_status(PORT0, Cached(true)).await.unwrap();
     info!("Port 0 status: {status:#?}");
 
-    let status = context.get_port_status(PORT1, true).await.unwrap();
+    let status = context.get_port_status(PORT1, Cached(true)).await.unwrap();
     info!("Port 1 status: {status:#?}");
 }
 

--- a/examples/std/src/bin/type_c/external.rs
+++ b/examples/std/src/bin/type_c/external.rs
@@ -3,7 +3,7 @@ use embassy_executor::{Executor, Spawner};
 use embassy_time::Timer;
 use embedded_services::{
     GlobalRawMutex, power,
-    type_c::{ControllerId, external},
+    type_c::{Cached, ControllerId, external},
 };
 use embedded_usb_pd::GlobalPortId;
 use log::*;
@@ -55,7 +55,7 @@ async fn task(_spawner: Spawner) {
     info!("Controller status: {controller_status:?}");
 
     info!("Getting port status");
-    let port_status = external::get_port_status(GlobalPortId(0), true).await.unwrap();
+    let port_status = external::get_port_status(GlobalPortId(0), Cached(true)).await.unwrap();
     info!("Port status: {port_status:?}");
 
     info!("Getting retimer fw update status");

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -115,10 +115,6 @@ impl<'a> Controller<'a> {
 impl embedded_services::type_c::controller::Controller for Controller<'_> {
     type BusError = ();
 
-    async fn sync_state(&mut self) -> Result<(), Error<Self::BusError>> {
-        Ok(())
-    }
-
     async fn wait_port_event(&mut self) -> Result<(), Error<Self::BusError>> {
         let events = self.state.events.wait().await;
         trace!("Port event: {events:#?}");
@@ -133,11 +129,7 @@ impl embedded_services::type_c::controller::Controller for Controller<'_> {
         Ok(events)
     }
 
-    async fn get_port_status(
-        &mut self,
-        _port: LocalPortId,
-        _cached: bool,
-    ) -> Result<PortStatus, Error<Self::BusError>> {
+    async fn get_port_status(&mut self, _port: LocalPortId) -> Result<PortStatus, Error<Self::BusError>> {
         debug!("Get port status: {:#?}", *self.state.status.lock().await);
         Ok(*self.state.status.lock().await)
     }

--- a/type-c-service/src/service/mod.rs
+++ b/type-c-service/src/service/mod.rs
@@ -3,7 +3,6 @@ use embassy_sync::{
     mutex::Mutex,
     pubsub::{DynImmediatePublisher, DynSubscriber},
 };
-use embedded_services::power::policy as power_policy;
 use embedded_services::{
     comms::{self, EndpointID, Internal},
     debug, error, info, intrusive_list,
@@ -17,6 +16,7 @@ use embedded_services::{
     },
     GlobalRawMutex,
 };
+use embedded_services::{power::policy as power_policy, type_c::Cached};
 use embedded_usb_pd::ado::Ado;
 use embedded_usb_pd::GlobalPortId;
 use embedded_usb_pd::PdError as Error;
@@ -193,7 +193,7 @@ impl<'a> Service<'a> {
                         match event {
                             PortEventVariant::StatusChanged(status_event) => {
                                 // Return a port status changed event
-                                let status = self.context.get_port_status(port_id, true).await?;
+                                let status = self.context.get_port_status(port_id, Cached(true)).await?;
                                 return Ok(Event::PortStatusChanged(port_id, status_event, status));
                             }
                             PortEventVariant::Notification(notification) => match notification {

--- a/type-c-service/src/service/port.rs
+++ b/type-c-service/src/service/port.rs
@@ -50,7 +50,7 @@ impl<'a> Service<'a> {
     pub(super) async fn process_external_port_status(
         &self,
         port_id: GlobalPortId,
-        cached: bool,
+        cached: Cached,
     ) -> external::Response<'static> {
         let status = self.context.get_port_status(port_id, cached).await;
         if let Err(e) = status {

--- a/type-c-service/src/wrapper/message.rs
+++ b/type-c-service/src/wrapper/message.rs
@@ -1,0 +1,125 @@
+//! [`crate::wrapper::ControllerWrapper`] message types
+use embedded_services::{
+    ipc::deferred,
+    power::policy,
+    type_c::{
+        controller::{self, PortStatus},
+        event::{PortNotificationSingle, PortStatusChanged},
+    },
+    GlobalRawMutex,
+};
+use embedded_usb_pd::{ado::Ado, PortId as LocalPortId};
+
+/// Port status changed event data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EventPortStatusChanged {
+    /// Port ID
+    pub port: LocalPortId,
+    /// Status changed event
+    pub status_event: PortStatusChanged,
+}
+
+/// Port notification event data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EventPortNotification {
+    /// Port ID
+    pub port: LocalPortId,
+    /// Notification event
+    pub notification: PortNotificationSingle,
+}
+
+/// Power policy command event data
+pub struct EventPowerPolicyCommand<'a> {
+    /// Port ID
+    pub port: LocalPortId,
+    /// Power policy request
+    pub request:
+        deferred::Request<'a, GlobalRawMutex, policy::device::CommandData, policy::device::InternalResponseData>,
+}
+
+/// CFU events
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum EventCfu {
+    /// CFU request
+    Request(embedded_services::cfu::component::RequestData),
+    /// Recovery tick
+    ///
+    /// Occurs when the FW update has timed out to abort the update and return hardware to its normal state
+    RecoveryTick,
+}
+
+/// Wrapper events
+pub enum Event<'a> {
+    /// Port status changed
+    PortStatusChanged(EventPortStatusChanged),
+    /// Port notification
+    PortNotification(EventPortNotification),
+    /// Power policy command received
+    PowerPolicyCommand(EventPowerPolicyCommand<'a>),
+    /// Command from TCPM
+    ControllerCommand(deferred::Request<'a, GlobalRawMutex, controller::Command, controller::Response<'static>>),
+    /// Cfu event
+    CfuEvent(EventCfu),
+}
+
+/// Port status changed output data
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct OutputPortStatusChanged {
+    /// Port ID
+    pub port: LocalPortId,
+    /// Status changed event
+    pub status_event: PortStatusChanged,
+    /// Port status
+    pub status: PortStatus,
+}
+
+/// PD alert output data
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct OutputPdAlert {
+    /// Port ID
+    pub port: LocalPortId,
+    /// ADO data
+    pub ado: Ado,
+}
+
+/// Power policy command output data
+pub struct OutputPowerPolicyCommand<'a> {
+    /// Port ID
+    pub port: LocalPortId,
+    /// Power policy request
+    pub request:
+        deferred::Request<'a, GlobalRawMutex, policy::device::CommandData, policy::device::InternalResponseData>,
+    /// Response
+    pub response: policy::device::InternalResponseData,
+}
+
+/// Controller command output data
+pub struct OutputControllerCommand<'a> {
+    /// Controller request
+    pub request: deferred::Request<'a, GlobalRawMutex, controller::Command, controller::Response<'static>>,
+    /// Response
+    pub response: controller::Response<'static>,
+}
+
+/// [`crate::wrapper::ControllerWrapper`] output
+pub enum Output<'a> {
+    /// No-op when nothing specific is needed
+    Nop,
+    /// Port status changed
+    PortStatusChanged(OutputPortStatusChanged),
+    /// PD alert
+    PdAlert(OutputPdAlert),
+    /// Power policy command received
+    PowerPolicyCommand(OutputPowerPolicyCommand<'a>),
+    /// TPCM command response
+    ControllerCommand(OutputControllerCommand<'a>),
+    /// CFU recovery tick
+    CfuRecovery,
+    /// CFU response
+    CfuResponse(embedded_services::cfu::component::InternalResponseData),
+}

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -1,30 +1,47 @@
-//! This module contains the `Controller` trait. Any types that implement this trait can be used with the `ControllerWrapper` struct
-//! which provides a bridge between various service messages and the actual controller functions.
+//! This module contains the [`ControllerWrapper`] struct. This struct serves as a bridge between various service messages
+//! and the actual controller functions provided by [`embedded_services::type_c::controller::Controller`].
+//! # Supported service messaging
+//! This struct current currently supports messages from the following services:
+//! * Type-C: [`embedded_services::type_c::controller::Command`]
+//! * Power policy: [`embedded_services::power::policy::device::Command`]
+//! * CFU: [`embedded_services::cfu::Request`]
+//! # Event loop
+//! This struct follows a standard wait/process/finalize event loop.
+//!
+//! [`ControllerWrapper::wait_next`] returns [`message::Event`] and does not perform any actions on the controller
+//! aside from reading pending events.
+//!
+//! [`ControllerWrapper::process_event`] reads any additional data relevant to the event and returns [`message::Output`].
+//! e.g. port status for a port status changed event, VDM data for a VDM event
+//!
+//! [`ControllerWrapper::process_event`] consumes [`message::Output`] and responds to any deferred requests, performs
+//! any caching/buffering of data, and notifies the type-C service implementation of the event if needed.
 use core::array::from_fn;
 use core::future::{pending, Future};
 
-use embassy_futures::select::{select5, select_array, Either5};
+use embassy_futures::select::{select, select5, select_array, Either, Either5};
 use embassy_sync::mutex::Mutex;
+use embassy_sync::signal::Signal;
 use embassy_time::Instant;
 use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferResponse, FwVersion};
 use embedded_services::cfu::component::CfuDevice;
-use embedded_services::ipc::deferred;
 use embedded_services::power::policy::device::StateKind;
 use embedded_services::power::policy::{self, action};
 use embedded_services::transformers::object::{Object, RefGuard, RefMutGuard};
 use embedded_services::type_c::controller::{self, Controller, PortStatus};
 use embedded_services::type_c::event::{PortEvent, PortNotificationSingle, PortPending, PortStatusChanged};
 use embedded_services::GlobalRawMutex;
-use embedded_services::SyncCell;
 use embedded_services::{debug, error, info, trace, warn};
 use embedded_usb_pd::ado::Ado;
 use embedded_usb_pd::{Error, PdError, PortId as LocalPortId};
 
 use crate::wrapper::backing::Backing;
+use crate::wrapper::message::*;
 use crate::{PortEventStreamer, PortEventVariant};
 
 pub mod backing;
 mod cfu;
+pub mod message;
 mod pd;
 mod power;
 
@@ -34,15 +51,28 @@ pub const DEFAULT_FW_UPDATE_TICK_INTERVAL_MS: u64 = 5000;
 /// 300 seconds at 5 seconds per tick
 pub const DEFAULT_FW_UPDATE_TIMEOUT_TICKS: u8 = 60;
 
+/// Internal per-port state
+#[derive(Copy, Clone, Default)]
+pub struct PortState {
+    /// Cached port status
+    status: PortStatus,
+    /// Software status event
+    sw_status_event: PortStatusChanged,
+    /// Sink ready deadline instant
+    sink_ready_deadline: Option<Instant>,
+    /// Pending events for the type-C service
+    pending_events: PortEvent,
+}
+
 /// Internal wrapper state
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct InternalState<const N: usize> {
     /// If we're currently doing a firmware update
     pub fw_update_state: cfu::FwUpdateState,
     /// State used to keep track of where we are as we turn the event bitfields into a stream of events
     port_event_streaming_state: Option<PortEventStreamer>,
-    /// Sink ready timeout values
-    sink_ready_deadline: [Option<Instant>; N],
+    /// Per-port state
+    port_states: [PortState; N],
 }
 
 impl<const N: usize> Default for InternalState<N> {
@@ -50,7 +80,7 @@ impl<const N: usize> Default for InternalState<N> {
         Self {
             fw_update_state: cfu::FwUpdateState::Idle,
             port_event_streaming_state: None,
-            sink_ready_deadline: [None; N],
+            port_states: [Default::default(); N],
         }
     }
 }
@@ -63,24 +93,7 @@ pub trait FwOfferValidator {
     fn validate(&self, current: FwVersion, offer: &FwUpdateOffer) -> FwUpdateOfferResponse;
 }
 
-/// Wrapper events
-pub enum Event<'a> {
-    /// Port status changed
-    PortStatusChanged(LocalPortId, PortStatusChanged),
-    /// PD alert
-    PdAlert(LocalPortId, Ado),
-    /// Power policy command received
-    PowerPolicyCommand(
-        LocalPortId,
-        deferred::Request<'a, GlobalRawMutex, policy::device::CommandData, policy::device::InternalResponseData>,
-    ),
-    /// Command from TCPM
-    ControllerCommand(deferred::Request<'a, GlobalRawMutex, controller::Command, controller::Response<'static>>),
-    CfuEvent(cfu::Event),
-}
-
-/// Takes an implementation of the `Controller` trait and wraps it with logic to handle
-/// message passing and power-policy integration.
+/// Common functionality implemented on top of [`embedded_services::type_c::controller::Controller`]
 pub struct ControllerWrapper<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> {
     /// PD controller to interface with PD service
     pd_controller: controller::Device<'a>,
@@ -91,13 +104,14 @@ pub struct ControllerWrapper<'a, const N: usize, C: Controller, BACK: Backing<'a
     /// Internal state for the wrapper
     state: Mutex<GlobalRawMutex, InternalState<N>>,
     controller: Mutex<GlobalRawMutex, C>,
-    active_events: [SyncCell<PortEvent>; N],
     /// Trait object for validating firmware versions
     fw_version_validator: V,
     /// FW update ticker used to check for timeouts and recovery attempts
     fw_update_ticker: Mutex<GlobalRawMutex, embassy_time::Ticker>,
     /// Channels and buffers used by the wrapper
     backing: Mutex<GlobalRawMutex, BACK>,
+    /// SW port status event signal
+    sw_status_event: Signal<GlobalRawMutex, ()>,
 }
 
 impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> ControllerWrapper<'a, N, C, BACK, V> {
@@ -116,18 +130,67 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
             cfu_device,
             state: Mutex::new(Default::default()),
             controller: Mutex::new(controller),
-            active_events: [const { SyncCell::new(PortEvent::none()) }; N],
             fw_version_validator,
             fw_update_ticker: Mutex::new(embassy_time::Ticker::every(embassy_time::Duration::from_millis(
                 DEFAULT_FW_UPDATE_TICK_INTERVAL_MS,
             ))),
             backing: Mutex::new(backing),
+            sw_status_event: Signal::new(),
         }
     }
 
     /// Get the power policy devices for this controller.
     pub fn power_policy_devices(&self) -> &[policy::device::Device] {
         &self.power
+    }
+
+    /// Get the cached port status
+    pub async fn get_cached_port_status(&self, local_port: LocalPortId) -> PortStatus {
+        self.state.lock().await.port_states[local_port.0 as usize].status
+    }
+
+    /// Synchronize the state between the controller and the internal state
+    pub async fn sync_state(&self) -> Result<(), Error<<C as Controller>::BusError>> {
+        let mut controller = self.controller.lock().await;
+        let mut state = self.state.lock().await;
+        self.sync_state_internal(&mut controller, &mut state).await
+    }
+
+    /// Synchronize the state between the controller and the internal state
+    async fn sync_state_internal(
+        &self,
+        controller: &mut C,
+        state: &mut InternalState<N>,
+    ) -> Result<(), Error<<C as Controller>::BusError>> {
+        // Sync the controller state with the PD controller
+        for port in 0..N {
+            let mut status_changed = state.port_states[port].sw_status_event;
+            let local_port = LocalPortId(port as u8);
+            let status = controller.get_port_status(local_port).await?;
+            trace!("Port{} status: {:#?}", port, status);
+
+            let previous_status = state.port_states[port].status;
+
+            if previous_status.is_connected() != status.is_connected() {
+                status_changed.set_plug_inserted_or_removed(true);
+            }
+
+            if previous_status.available_sink_contract != status.available_sink_contract {
+                status_changed.set_new_power_contract_as_consumer(true);
+            }
+
+            if previous_status.available_source_contract != status.available_source_contract {
+                status_changed.set_new_power_contract_as_provider(true);
+            }
+
+            state.port_states[port].sw_status_event = status_changed;
+            if state.port_states[port].sw_status_event != PortStatusChanged::none() {
+                // Have a status changed event, notify
+                trace!("Port{} status changed: {:#?}", port, status);
+                self.sw_status_event.signal(());
+            }
+        }
+        Ok(())
     }
 
     /// Handle a plug event
@@ -178,27 +241,19 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
     }
 
     /// Process port status changed events
-    async fn process_port_status_changed(
+    async fn process_port_status_changed<'b>(
         &self,
         controller: &mut C,
         state: &mut InternalState<N>,
         local_port_id: LocalPortId,
         status_event: PortStatusChanged,
-    ) -> Result<(), Error<<C as Controller>::BusError>> {
-        let port_index = local_port_id.0 as usize;
-        let mut event = self.active_events[port_index].get();
+    ) -> Result<Output<'b>, Error<<C as Controller>::BusError>> {
         let global_port_id = self
             .pd_controller
             .lookup_global_port(local_port_id)
             .map_err(Error::Pd)?;
 
-        if status_event == PortStatusChanged::none() {
-            event.status = PortStatusChanged::none();
-            self.active_events[port_index].set(event);
-            return Ok(());
-        }
-
-        let status = controller.get_port_status(local_port_id, true).await?;
+        let status = controller.get_port_status(local_port_id).await?;
         trace!("Port{} status: {:#?}", global_port_id.0, status);
 
         let power = self.get_power_device(local_port_id).map_err(Error::Pd)?;
@@ -210,13 +265,11 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
 
         // Only notify power policy of a contract after Sink Ready event (always after explicit or implicit contract)
         if status_event.sink_ready() {
-            self.process_new_consumer_contract(controller, power, local_port_id, &status)
-                .await?;
+            self.process_new_consumer_contract(power, &status).await?;
         }
 
         if status_event.new_power_contract_as_provider() {
-            self.process_new_provider_contract(global_port_id, power, &status)
-                .await?;
+            self.process_new_provider_contract(power, &status).await?;
         }
 
         self.check_sink_ready_timeout(
@@ -228,22 +281,48 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         )
         .await?;
 
-        self.active_events[port_index].set(event.union(status_event.into()));
+        Ok(Output::PortStatusChanged(OutputPortStatusChanged {
+            port: local_port_id,
+            status_event,
+            status,
+        }))
+    }
 
-        let mut pending = PortPending::none();
-        pending.pend_port(global_port_id.0 as usize);
-        self.pd_controller.notify_ports(pending).await;
+    /// Finalize a port status change output
+    async fn finalize_port_status_change(
+        &self,
+        state: &mut InternalState<N>,
+        local_port: LocalPortId,
+        status_event: PortStatusChanged,
+        status: PortStatus,
+    ) -> Result<(), Error<<C as Controller>::BusError>> {
+        let global_port_id = self.pd_controller.lookup_global_port(local_port).map_err(Error::Pd)?;
+
+        let port_index = local_port.0 as usize;
+        let mut events = state.port_states[port_index].pending_events;
+        events.status = events.status.union(status_event);
+        state.port_states[port_index].pending_events = events;
+        state.port_states[port_index].status = status;
+
+        if events != PortEvent::none() {
+            let mut pending = PortPending::none();
+            pending.pend_port(global_port_id.0 as usize);
+            self.pd_controller.notify_ports(pending).await;
+            trace!("P{}: Notified service for events: {:#?}", global_port_id.0, events);
+        }
 
         Ok(())
     }
 
-    /// Process a PD alert
-    async fn process_pd_alert(&self, port: LocalPortId, alert: Ado) -> Result<(), Error<<C as Controller>::BusError>> {
-        let port_index = port.0 as usize;
-        if port_index >= N {
-            error!("Invalid port {}", port_index);
-            return Err(PdError::InvalidPort.into());
-        }
+    /// Finalize a PD alert output
+    async fn finalize_pd_alert(
+        &self,
+        state: &mut InternalState<N>,
+        local_port: LocalPortId,
+        alert: Ado,
+    ) -> Result<(), Error<<C as Controller>::BusError>> {
+        let global_port_id = self.pd_controller.lookup_global_port(local_port).map_err(Error::Pd)?;
+        let port_index = local_port.0 as usize;
 
         // Buffer the alert
         let backing = self.backing.lock().await;
@@ -251,18 +330,21 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         channel.0.publish_immediate(alert);
 
         // Pend the alert
-        let mut event = self.active_events[port_index].get();
-        event.notification.set_alert(true);
-        self.active_events[port_index].set(event);
+        state.port_states[port_index]
+            .pending_events
+            .notification
+            .set_alert(true);
 
         // Pend this port
         let mut pending = PortPending::none();
-        pending.pend_port(port.0 as usize);
+        pending.pend_port(global_port_id.0 as usize);
         self.pd_controller.notify_ports(pending).await;
         Ok(())
     }
 
     /// Wait for a pending port event
+    ///
+    /// DROP SAFETY: No state that needs to be restored
     async fn wait_port_pending(
         &self,
         controller: &mut C,
@@ -279,18 +361,29 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
             embassy_futures::yield_now().await;
             Ok(streamer)
         } else {
-            // We aren't in the process of converting the bitfields into an event stream
-            // Wait for the next event
-            controller.wait_port_event().await?;
+            // Otherwise, wait for the next port event
+            // DROP SAFETY: Safe as long as `wait_port_event` is drop safe
+            match select(controller.wait_port_event(), async {
+                self.sw_status_event.wait().await;
+                Ok::<_, Error<<C as Controller>::BusError>>(())
+            })
+            .await
+            {
+                Either::First(r) => r?,
+                Either::Second(_) => (),
+            };
             let pending: PortPending = FromIterator::from_iter(0..N);
             Ok(PortEventStreamer::new(pending.into_iter()))
         }
     }
 
+    /// Wait for the next event
     pub async fn wait_next(&self) -> Result<Event<'_>, Error<<C as Controller>::BusError>> {
+        // This loop is to ensure that if we finish streaming events we go back to waiting for the next port event
         loop {
             let event = {
                 let mut controller = self.controller.lock().await;
+                // DROP SAFETY: Select over drop safe functions
                 select5(
                     self.wait_port_pending(&mut controller),
                     self.wait_power_command(),
@@ -303,101 +396,175 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
             match event {
                 Either5::First(stream) => {
                     let mut stream = stream?;
-                    if let Some((port_id, event)) = stream
-                        .next(async |port_id| {
-                            let mut controller = self.controller.lock().await;
-
-                            controller.clear_port_events(LocalPortId(port_id as u8)).await
+                    if let Some((port_index, event)) = stream
+                        .next::<Error<<C as Controller>::BusError>, _, _>(async |port_index| {
+                            // Combine the event read from the controller with any software generated events
+                            let sw_event: PortEvent =
+                                self.state.lock().await.port_states[port_index].sw_status_event.into();
+                            let hw_event = self
+                                .controller
+                                .lock()
+                                .await
+                                .clear_port_events(LocalPortId(port_index as u8))
+                                .await?;
+                            Ok(hw_event.union(sw_event))
                         })
                         .await?
                     {
-                        let port_id = LocalPortId(port_id as u8);
+                        let port_id = LocalPortId(port_index as u8);
                         self.state.lock().await.port_event_streaming_state = Some(stream);
                         match event {
                             PortEventVariant::StatusChanged(status_event) => {
-                                // Return a port status changed event
-                                return Ok(Event::PortStatusChanged(port_id, status_event));
+                                return Ok(Event::PortStatusChanged(EventPortStatusChanged {
+                                    port: port_id,
+                                    status_event,
+                                }));
                             }
-                            PortEventVariant::Notification(notification) => match notification {
-                                PortNotificationSingle::Alert => {
-                                    if let Some(ado) = self.controller.lock().await.get_pd_alert(port_id).await? {
-                                        // Return a PD alert event
-                                        return Ok(Event::PdAlert(port_id, ado));
-                                    } else {
-                                        // Didn't get an ADO, wait for next event
-                                        continue;
-                                    }
-                                }
-                                _ => {
-                                    // Other notifications currently unimplemented
-                                    trace!("Unimplemented port notification: {:?}", notification);
-                                    continue;
-                                }
-                            },
+                            PortEventVariant::Notification(notification) => {
+                                return Ok(Event::PortNotification(EventPortNotification {
+                                    port: port_id,
+                                    notification,
+                                }));
+                            }
                         }
                     } else {
                         self.state.lock().await.port_event_streaming_state = None;
                     }
                 }
-                Either5::Second((port, request)) => return Ok(Event::PowerPolicyCommand(port, request)),
+                Either5::Second((port, request)) => {
+                    return Ok(Event::PowerPolicyCommand(EventPowerPolicyCommand { port, request }))
+                }
                 Either5::Third(request) => return Ok(Event::ControllerCommand(request)),
                 Either5::Fourth(event) => return Ok(Event::CfuEvent(event)),
                 Either5::Fifth(port) => {
                     // Sink ready timeout event
                     debug!("Port{0}: Sink ready timeout", port.0);
-                    self.state.lock().await.sink_ready_deadline[port.0 as usize] = None;
-                    let mut event = PortStatusChanged::none();
-                    event.set_sink_ready(true);
-                    return Ok(Event::PortStatusChanged(port, event));
+                    self.state.lock().await.port_states[port.0 as usize].sink_ready_deadline = None;
+                    let mut status_event = PortStatusChanged::none();
+                    status_event.set_sink_ready(true);
+                    return Ok(Event::PortStatusChanged(EventPortStatusChanged { port, status_event }));
                 }
+            }
+        }
+    }
+
+    /// Process a port notification
+    async fn process_port_notification<'b>(
+        &self,
+        controller: &mut C,
+        port: LocalPortId,
+        notification: PortNotificationSingle,
+    ) -> Result<Output<'b>, Error<<C as Controller>::BusError>> {
+        match notification {
+            PortNotificationSingle::Alert => {
+                let ado = controller.get_pd_alert(port).await?;
+                trace!("Port{}: PD alert: {:#?}", port.0, ado);
+                if let Some(ado) = ado {
+                    Ok(Output::PdAlert(OutputPdAlert { port, ado }))
+                } else {
+                    // For some reason we didn't read an alert, nothing to do
+                    Ok(Output::Nop)
+                }
+            }
+            rest => {
+                // Nothing currently implemented for these
+                trace!("Port{}: Notification: {:#?}", port.0, rest);
+                Ok(Output::Nop)
             }
         }
     }
 
     /// Top-level processing function
     /// Only call this fn from one place in a loop. Otherwise a deadlock could occur.
-    pub async fn process_event(&self, event: Event<'_>) -> Result<(), Error<<C as Controller>::BusError>> {
+    pub async fn process_event<'b>(&self, event: Event<'b>) -> Result<Output<'b>, Error<<C as Controller>::BusError>> {
         let mut controller = self.controller.lock().await;
         let mut state = self.state.lock().await;
         match event {
-            Event::PortStatusChanged(port_id, status_event) => {
-                self.process_port_status_changed(&mut controller, &mut state, port_id, status_event)
+            Event::PortStatusChanged(EventPortStatusChanged { port, status_event }) => {
+                self.process_port_status_changed(&mut controller, &mut state, port, status_event)
                     .await
             }
-            Event::PowerPolicyCommand(port, request) => {
+            Event::PowerPolicyCommand(EventPowerPolicyCommand { port, request }) => {
                 let response = self
                     .process_power_command(&mut controller, &mut state, port, &request.command)
                     .await;
-                request.respond(response);
-                Ok(())
+                Ok(Output::PowerPolicyCommand(OutputPowerPolicyCommand {
+                    port,
+                    request,
+                    response,
+                }))
             }
             Event::ControllerCommand(request) => {
                 let response = self
                     .process_pd_command(&mut controller, &mut state, &request.command)
                     .await;
+                Ok(Output::ControllerCommand(OutputControllerCommand { request, response }))
+            }
+            Event::CfuEvent(event) => match event {
+                EventCfu::Request(request) => {
+                    let response = self.process_cfu_command(&mut controller, &mut state, &request).await;
+                    Ok(Output::CfuResponse(response))
+                }
+                EventCfu::RecoveryTick => {
+                    // FW Update tick, process timeouts and recovery attempts
+                    self.process_cfu_tick(&mut controller, &mut state).await;
+                    Ok(Output::CfuRecovery)
+                }
+            },
+            Event::PortNotification(EventPortNotification { port, notification }) => {
+                self.process_port_notification(&mut controller, port, notification)
+                    .await
+            }
+        }
+    }
+
+    /// Event loop finalize
+    pub async fn finalize<'b>(&self, output: Output<'b>) -> Result<(), Error<<C as Controller>::BusError>> {
+        let mut state = self.state.lock().await;
+
+        match output {
+            Output::Nop => Ok(()),
+            Output::PortStatusChanged(OutputPortStatusChanged {
+                port,
+                status_event,
+                status,
+            }) => {
+                self.finalize_port_status_change(&mut state, port, status_event, status)
+                    .await
+            }
+            Output::PdAlert(OutputPdAlert { port, ado }) => self.finalize_pd_alert(&mut state, port, ado).await,
+            Output::PowerPolicyCommand(OutputPowerPolicyCommand { request, response, .. }) => {
                 request.respond(response);
                 Ok(())
             }
-            Event::CfuEvent(event) => match event {
-                cfu::Event::Request(request) => {
-                    let response = self.process_cfu_command(&mut controller, &mut state, &request).await;
-                    self.send_cfu_response(response).await;
-                    Ok(())
-                }
-                cfu::Event::RecoveryTick => {
-                    // FW Update tick, process timeouts and recovery attempts
-                    self.process_cfu_tick(&mut controller, &mut state).await;
-                    Ok(())
-                }
-            },
-            Event::PdAlert(port, alert) => self.process_pd_alert(port, alert).await,
+            Output::ControllerCommand(OutputControllerCommand { request, response }) => {
+                request.respond(response);
+                Ok(())
+            }
+            Output::CfuRecovery => {
+                // Nothing to do here
+                Ok(())
+            }
+            Output::CfuResponse(response) => {
+                self.send_cfu_response(response).await;
+                Ok(())
+            }
         }
+    }
+
+    /// Combined processing and finialization function
+    pub async fn process_and_finalize_event<'b>(
+        &self,
+        event: Event<'b>,
+    ) -> Result<(), Error<<C as Controller>::BusError>> {
+        let output = self.process_event(event).await?;
+        self.finalize(output).await
     }
 
     /// Combined processing function
     pub async fn process_next_event(&self) -> Result<(), Error<<C as Controller>::BusError>> {
         let event = self.wait_next().await?;
-        self.process_event(event).await
+        self.process_and_finalize_event(event).await
     }
 
     /// Register all devices with their respective services


### PR DESCRIPTION
This PR refactors the wrapper event loop into its final form. This consists of several parts:
* Move register reads out of `wait_next`. This function currently reads the port status and other data, but this makes it impossible for external code to implement custom behavior immediately after an interrupt is received. Instead of producing events like `(port id, event, data)`, events are now of the form `(port id, event)`. 
* Break up the current `process_event` into `process_event` and `finalize`. `process_event` is now responsible for reading additional data from the PD controller. This break-up allows external code to still access the data for these events. The `finalize` stage is now responsible for sending response to deferred requests and committing any cached state.
* Simplify existing TPS6699x driver code. The above changes allow for some simplification in the driver-specific code. Per-port status caching is now implemented in the wrapper and the `get_port_status` function no longer takes a `cached` argument. The functionality provided by `sync_state` is also now implemented in the wrapper and the corresponding trait function has been removed. The software event signaling used by `sync_state` is also now implemented in wrapper.
* Minor fixes and improvements:
* This also removes the mode check from the TPS6699x driver because it can now be implemented in external code.

## Migration guide

* The `Event` type is now under `wrapper::message` and its variants now generally use structs to make accessing data easier.
* Calls to `process_event` should be replaced with `process_and_finalize_event`.
* Any code that uses data from the PD controller (e.g. port status or PD alert) can be moved from after `wait_event` to after `process_event`.