### PR TITLE
Implement pdreset function

### DIFF
--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -348,6 +348,9 @@ pub trait Controller {
     fn get_port_status(&mut self, port: LocalPortId)
     -> impl Future<Output = Result<PortStatus, Error<Self::BusError>>>;
 
+    /// Reset the controller
+    fn reset_controller(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
+
     /// Returns the retimer fw update state
     fn get_rt_fw_update_status(
         &mut self,

--- a/embedded-service/src/type_c/external.rs
+++ b/embedded-service/src/type_c/external.rs
@@ -19,6 +19,8 @@ pub enum ControllerCommandData {
     ControllerStatus,
     /// Sync controller state
     SyncState,
+    /// Controller reset
+    Reset,
 }
 
 /// Controller-specific commands
@@ -154,6 +156,19 @@ pub async fn get_controller_port_status(
 ) -> Result<PortStatus, PdError> {
     let global_port = controller_port_to_global_id(controller, port).await?;
     get_port_status(global_port, cached).await
+}
+
+/// Reset the given controller.
+pub async fn reset_controller(controller_id: ControllerId) -> Result<(), PdError> {
+    match execute_external_controller_command(Command::Controller(ControllerCommand {
+        id: controller_id,
+        data: ControllerCommandData::Reset,
+    }))
+    .await?
+    {
+        ControllerResponseData::Complete => Ok(()),
+        _ => Err(PdError::InvalidResponse),
+    }
 }
 
 /// Get the status of the given controller

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -173,6 +173,19 @@ impl<'a, const N: usize, M: RawMutex, B: I2c> Tps6699x<'a, N, M, B> {
 impl<const N: usize, M: RawMutex, B: I2c> Controller for Tps6699x<'_, N, M, B> {
     type BusError = B::Error;
 
+    /// Controller reset
+    async fn reset_controller(&mut self) -> Result<(), Error<Self::BusError>> {
+        let mut tps6699x = self
+            .tps6699x
+            .try_lock()
+            .expect("Driver should not have been locked before this, thus infallible");
+
+        let mut delay = Delay;
+        tps6699x.reset(&mut delay).await?;
+
+        Ok(())
+    }
+
     /// Wait for an event on any port
     async fn wait_port_event(&mut self) -> Result<(), Error<Self::BusError>> {
         let mut tps6699x = self

--- a/type-c-service/src/service/controller.rs
+++ b/type-c-service/src/service/controller.rs
@@ -33,6 +33,18 @@ impl<'a> Service<'a> {
         external::Response::Controller(status.map(|_| external::ControllerResponseData::Complete))
     }
 
+    /// Process external controller reset command
+    pub(super) async fn process_external_controller_reset(
+        &self,
+        controller: ControllerId,
+    ) -> external::Response<'static> {
+        let status = self.context.reset_controller(controller).await;
+        if let Err(e) = status {
+            error!("Error resetting controller: {:#?}", e);
+        }
+        external::Response::Controller(status.map(|_| external::ControllerResponseData::Complete))
+    }
+
     /// Process external controller commands
     pub(super) async fn process_external_controller_command(
         &self,
@@ -42,6 +54,7 @@ impl<'a> Service<'a> {
         match command.data {
             ControllerCommandData::ControllerStatus => self.process_external_controller_status(command.id).await,
             ControllerCommandData::SyncState => self.process_external_controller_sync_state(command.id).await,
+            ControllerCommandData::Reset => self.process_external_controller_reset(command.id).await,
         }
     }
 }

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -285,7 +285,14 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                         .map_err(|_| PdError::Failed),
                 )
             }
-            _ => controller::Response::Controller(Err(PdError::UnrecognizedCommand)),
+            controller::InternalCommandData::Reset => {
+                let result = controller.reset_controller().await;
+                controller::Response::Controller(
+                    result
+                        .map(|_| InternalResponseData::Complete)
+                        .map_err(|_| PdError::Failed),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
why:
Need a .pdreset command from surfdbg for debug

what changed:
Add reset_controller function

How tested:
1. Run on WON_931 DK
2. Run command .pdreset with surfdbg
3. log shows:
.pdreset
16:59:03.408 : 179259.954318 INFO Received PdReset, resetting PD controllers.
16:59:04.956 : 179261.536438 INFO Power:PSU detach
16:59:04.967 : 179261.536566 INFO Bat PSU Track: event saved, false:1755680344 (3)
16:59:04.967 : 179261.536603 INFO PowerManager: Psu Detached
16:59:04.967 : 179261.536619 INFO PowerManager: Handling event: Event(PsuDetached) State: S0(S0)
16:59:04.967 : 179261.536653 INFO PowerManager: Waiting for new event
.
.
16:59:05.202 : 179261.717221 INFO Plug event
16:59:05.202 : 179261.717237 INFO Plug inserted
16:59:05.202 : 179261.717254 WARN Power device not in detached state, recovering
16:59:05.202 : 179261.717280 INFO Received detach from device 1
16:59:05.202 : 179261.717305 INFO Received notify detached from device 1
.
.

16:59:05.960 : 179262.546906 INFO Power:PSU attach
16:59:06.024 : 179262.605019 INFO Power capabilities received from service: voltage 20000 current 4800 power 96000
16:59:06.024 : 179262.605070 INFO Unconstrained state changed: UnconstrainedState { unconstrained: true, available: 1 }