### PR TITLE
type-c-service/ucsi: Don't notify on reset

### DIFF
--- a/type-c-service/src/service/ucsi.rs
+++ b/type-c-service/src/service/ucsi.rs
@@ -176,8 +176,6 @@ impl<'a> Service<'a> {
                         response.cci.set_cmd_complete(true);
                     }
                     PpmOutput::OpmNotifyReset => {
-                        // Always notify OPM on reset
-                        notify_opm = true;
                         response.cci.set_reset_complete(true);
                     }
                     PpmOutput::OpmNotifyBusy => {


### PR DESCRIPTION
The OPM polls the CCI to determine when a reset is completep