### PR TITLE
type-c-service/wrapper: Clear software interrupt

### DIFF
--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -462,6 +462,9 @@ pub trait Controller {
     /// Any intermediate side effects must be undone if the returned [`Future`] is dropped before completing.
     fn wait_port_event(&mut self) -> impl Future<Output = Result<(), Error<Self::BusError>>>;
     /// Returns and clears current events for the given port
+    /// # Implementation guide
+    /// This function should be drop safe.
+    /// Any intermediate side effects must be undone if the returned [`Future`] is dropped before completing.
     fn clear_port_events(
         &mut self,
         port: LocalPortId,

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -216,6 +216,8 @@ impl<const N: usize, M: RawMutex, B: I2c> Controller for Tps6699x<'_, N, M, B> {
     }
 
     /// Returns and clears current events for the given port
+    ///
+    /// Drop safety: All state changes happen after await point
     async fn clear_port_events(&mut self, port: LocalPortId) -> Result<PortEvent, Error<Self::BusError>> {
         if port.0 >= self.port_events.len() as u8 {
             return PdError::InvalidPort.into();

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -401,8 +401,8 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                         .next::<Error<<C as Controller>::BusError>, _, _>(async |port_index| {
                             // Combine the event read from the controller with any software generated events
                             // Acquire the locks first to centralize the awaits here
-                            let mut state = self.state.lock().await;
                             let mut controller = self.controller.lock().await;
+                            let mut state = self.state.lock().await;
                             let hw_event = controller.clear_port_events(LocalPortId(port_index as u8)).await?;
 
                             // No more awaits, modify state here for drop safety


### PR DESCRIPTION
The wrapper generates a software interrupt as part of `sync_state` but this interrupt was not being cleared.