### PR TITLE
type-c-service/wrapper: Remove port count generics

### DIFF
--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -19,8 +19,8 @@ use embedded_services::{error, info};
 use embedded_usb_pd::GlobalPortId;
 use static_cell::StaticCell;
 use tps6699x::asynchronous::embassy as tps6699x;
-use type_c_service::driver::tps6699x::{self as tps6699x_driver, Tps66994Wrapper};
-use type_c_service::wrapper::backing::{BackingDefault, BackingDefaultStorage};
+use type_c_service::driver::tps6699x::{self as tps6699x_driver, Tps6699xWrapper};
+use type_c_service::wrapper::backing::{ReferencedStorage, Storage};
 
 extern crate rt685s_evk_example;
 
@@ -45,7 +45,7 @@ impl type_c_service::wrapper::FwOfferValidator for Validator {
 
 type BusMaster<'a> = I2cMaster<'a, Async>;
 type BusDevice<'a> = I2cDevice<'a, NoopRawMutex, BusMaster<'a>>;
-type Wrapper<'a> = Tps66994Wrapper<'a, NoopRawMutex, BusDevice<'a>, BackingDefault<'a, TPS66994_NUM_PORTS>, Validator>;
+type Wrapper<'a> = Tps6699xWrapper<'a, NoopRawMutex, BusDevice<'a>, Validator>;
 type Controller<'a> = tps6699x::controller::Controller<NoopRawMutex, BusDevice<'a>>;
 type Interrupt<'a> = tps6699x::Interrupt<'a, NoopRawMutex, BusDevice<'a>>;
 
@@ -183,26 +183,21 @@ async fn main(spawner: Spawner) {
         .await
         .unwrap();
 
-    static PD_PORTS: [GlobalPortId; 2] = [PORT0_ID, PORT1_ID];
-    static BACKING_STORAGE: StaticCell<BackingDefaultStorage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
-    let backing_storage = BACKING_STORAGE.init(BackingDefaultStorage::new());
-    let backing = backing_storage.get_backing().expect("Failed to create backing storage");
+    static STORAGE: StaticCell<Storage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
+    let storage = STORAGE.init(Storage::new(
+        CONTROLLER0_ID,
+        0, // CFU component ID
+        [(PORT0_ID, PORT0_PWR_ID), (PORT1_ID, PORT1_PWR_ID)],
+    ));
+
+    static REFERENCED: StaticCell<ReferencedStorage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
+    let referenced = REFERENCED.init(storage.create_referenced());
+    let backing = referenced.create_backing().expect("Failed to create backing storage");
 
     info!("Spawining PD controller task");
     static PD_CONTROLLER: StaticCell<Wrapper> = StaticCell::new();
-    let pd_controller = PD_CONTROLLER.init(
-        tps6699x_driver::tps66994(
-            tps6699x,
-            CONTROLLER0_ID,
-            &PD_PORTS,
-            [PORT0_PWR_ID, PORT1_PWR_ID],
-            0x00,
-            backing,
-            Default::default(),
-            Validator,
-        )
-        .unwrap(),
-    );
+    let pd_controller =
+        PD_CONTROLLER.init(tps6699x_driver::tps66994(tps6699x, backing, Default::default(), Validator).unwrap());
 
     pd_controller.register().await.unwrap();
     spawner.must_spawn(pd_controller_task(pd_controller));

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -8,7 +8,6 @@ use embassy_imxrt::gpio::{Input, Inverter, Pull};
 use embassy_imxrt::i2c::Async;
 use embassy_imxrt::i2c::master::{Config, I2cMaster};
 use embassy_imxrt::{bind_interrupts, peripherals};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_time::Timer;
 use embassy_time::{self as _, Delay};
@@ -42,10 +41,10 @@ impl type_c_service::wrapper::FwOfferValidator for Validator {
 }
 
 type BusMaster<'a> = I2cMaster<'a, Async>;
-type BusDevice<'a> = I2cDevice<'a, NoopRawMutex, BusMaster<'a>>;
-type Wrapper<'a> = tps6699x_drv::Tps6699xWrapper<'a, NoopRawMutex, BusDevice<'a>, Validator>;
-type Controller<'a> = tps6699x::controller::Controller<NoopRawMutex, BusDevice<'a>>;
-type Interrupt<'a> = tps6699x::Interrupt<'a, NoopRawMutex, BusDevice<'a>>;
+type BusDevice<'a> = I2cDevice<'a, GlobalRawMutex, BusMaster<'a>>;
+type Wrapper<'a> = tps6699x_drv::Tps6699xWrapper<'a, GlobalRawMutex, BusDevice<'a>, Validator>;
+type Controller<'a> = tps6699x::controller::Controller<GlobalRawMutex, BusDevice<'a>>;
+type Interrupt<'a> = tps6699x::Interrupt<'a, GlobalRawMutex, BusDevice<'a>>;
 
 const CONTROLLER0_ID: ControllerId = ControllerId(0);
 const CONTROLLER0_CFU_ID: ComponentId = 0x12;
@@ -164,7 +163,7 @@ async fn main(spawner: Spawner) {
     spawner.must_spawn(type_c_service::task(Default::default()));
 
     let int_in = Input::new(p.PIO1_7, Pull::Up, Inverter::Disabled);
-    static BUS: StaticCell<Mutex<NoopRawMutex, BusMaster<'static>>> = StaticCell::new();
+    static BUS: StaticCell<Mutex<GlobalRawMutex, BusMaster<'static>>> = StaticCell::new();
     let bus = BUS.init(Mutex::new(
         I2cMaster::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, Config::default(), p.DMA0_CH5).unwrap(),
     ));
@@ -204,12 +203,11 @@ async fn main(spawner: Spawner) {
 
     static REFERENCED: StaticCell<ReferencedStorage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
     let referenced = REFERENCED.init(storage.create_referenced());
-    let backing = referenced.create_backing().expect("Failed to create backing storage");
 
     info!("Spawining PD controller task");
     static PD_CONTROLLER: StaticCell<Wrapper> = StaticCell::new();
     let pd_controller =
-        PD_CONTROLLER.init(tps6699x_drv::tps66994(tps6699x, backing, Default::default(), Validator).unwrap());
+        PD_CONTROLLER.init(tps6699x_drv::tps66994(tps6699x, referenced, Default::default(), Validator).unwrap());
 
     pd_controller.register().await.unwrap();
     spawner.must_spawn(pd_controller_task(pd_controller));

--- a/examples/std/src/bin/type_c/external.rs
+++ b/examples/std/src/bin/type_c/external.rs
@@ -9,7 +9,7 @@ use embedded_usb_pd::GlobalPortId;
 use log::*;
 use static_cell::StaticCell;
 use std_examples::type_c::mock_controller;
-use type_c_service::wrapper::backing::BackingDefaultStorage;
+use type_c_service::wrapper::backing::Storage;
 
 const CONTROLLER0: ControllerId = ControllerId(0);
 const PORT0: GlobalPortId = GlobalPortId(0);
@@ -20,20 +20,24 @@ async fn controller_task() {
     static STATE: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state = STATE.init(mock_controller::ControllerState::new());
 
-    static BACKING_STORAGE: StaticCell<BackingDefaultStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let backing_storage = BACKING_STORAGE.init(BackingDefaultStorage::new());
-    let backing = backing_storage.get_backing().expect("Failed to create backing storage");
+    static STORAGE: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
+    let backing_storage = STORAGE.init(Storage::new(
+        CONTROLLER0,
+        0, // CFU component ID (unused)
+        [(PORT0, POWER0)],
+    ));
+
+    static REFERENCED: StaticCell<type_c_service::wrapper::backing::ReferencedStorage<1, GlobalRawMutex>> =
+        StaticCell::new();
+    let referenced = REFERENCED.init(backing_storage.create_referenced());
+    let backing = referenced.create_backing().expect("Failed to create backing storage");
 
     static WRAPPER: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let controller = mock_controller::Controller::new(state);
-    let wrapper = WRAPPER.init(mock_controller::Wrapper::new(
-        embedded_services::type_c::controller::Device::new(CONTROLLER0, &[PORT0]),
-        [power::policy::device::Device::new(POWER0)],
-        embedded_services::cfu::component::CfuDevice::new(0x00),
-        backing,
-        controller,
-        crate::mock_controller::Validator,
-    ));
+    let wrapper = WRAPPER.init(
+        mock_controller::Wrapper::try_new(controller, backing, crate::mock_controller::Validator)
+            .expect("Failed to create wrapper"),
+    );
 
     wrapper.register().await.unwrap();
     loop {

--- a/examples/std/src/bin/type_c/external.rs
+++ b/examples/std/src/bin/type_c/external.rs
@@ -26,16 +26,14 @@ async fn controller_task() {
         0, // CFU component ID (unused)
         [(PORT0, POWER0)],
     ));
-
     static REFERENCED: StaticCell<type_c_service::wrapper::backing::ReferencedStorage<1, GlobalRawMutex>> =
         StaticCell::new();
     let referenced = REFERENCED.init(backing_storage.create_referenced());
-    let backing = referenced.create_backing().expect("Failed to create backing storage");
 
     static WRAPPER: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let controller = mock_controller::Controller::new(state);
     let wrapper = WRAPPER.init(
-        mock_controller::Wrapper::try_new(controller, backing, crate::mock_controller::Validator)
+        mock_controller::Wrapper::try_new(controller, referenced, crate::mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
 

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -63,12 +63,11 @@ async fn controller_task(state: &'static mock_controller::ControllerState) {
     ));
     static REFERENCED: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
     let referenced = REFERENCED.init(storage.create_referenced());
-    let backing = referenced.create_backing().expect("Failed to create backing storage");
 
     static WRAPPER: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let controller = mock_controller::Controller::new(state);
     let wrapper = WRAPPER.init(
-        mock_controller::Wrapper::try_new(controller, backing, crate::mock_controller::Validator)
+        mock_controller::Wrapper::try_new(controller, referenced, crate::mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
 

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -1,7 +1,7 @@
 use embassy_executor::{Executor, Spawner};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::Timer;
-use embedded_services::power::{self, policy};
+use embedded_services::power::{self};
 use embedded_services::transformers::object::Object;
 use embedded_services::type_c::{ControllerId, controller};
 use embedded_services::{GlobalRawMutex, comms};
@@ -11,7 +11,7 @@ use embedded_usb_pd::type_c::Current;
 use log::*;
 use static_cell::StaticCell;
 use std_examples::type_c::mock_controller;
-use type_c_service::wrapper::backing::BackingDefaultStorage;
+use type_c_service::wrapper::backing::{ReferencedStorage, Storage};
 use type_c_service::wrapper::message::*;
 
 const CONTROLLER0: ControllerId = ControllerId(0);
@@ -55,20 +55,22 @@ mod debug {
 
 #[embassy_executor::task]
 async fn controller_task(state: &'static mock_controller::ControllerState) {
-    static BACKING_STORAGE: StaticCell<BackingDefaultStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let backing_storage = BACKING_STORAGE.init(BackingDefaultStorage::new());
-    let backing = backing_storage.get_backing().expect("Failed to create backing storage");
+    static STORAGE: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
+    let storage = STORAGE.init(Storage::new(
+        CONTROLLER0,
+        0, // CFU component ID (unused)
+        [(PORT0, POWER0)],
+    ));
+    static REFERENCED: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
+    let referenced = REFERENCED.init(storage.create_referenced());
+    let backing = referenced.create_backing().expect("Failed to create backing storage");
 
     static WRAPPER: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let controller = mock_controller::Controller::new(state);
-    let wrapper = WRAPPER.init(mock_controller::Wrapper::new(
-        embedded_services::type_c::controller::Device::new(CONTROLLER0, &[PORT0, PORT0]),
-        [policy::device::Device::new(POWER0)],
-        embedded_services::cfu::component::CfuDevice::new(0x00),
-        backing,
-        controller,
-        crate::mock_controller::Validator,
-    ));
+    let wrapper = WRAPPER.init(
+        mock_controller::Wrapper::try_new(controller, backing, crate::mock_controller::Validator)
+            .expect("Failed to create wrapper"),
+    );
 
     wrapper.register().await.unwrap();
 

--- a/examples/std/src/bin/type_c/unconstrained.rs
+++ b/examples/std/src/bin/type_c/unconstrained.rs
@@ -2,13 +2,13 @@ use embassy_executor::{Executor, Spawner};
 use embassy_time::Timer;
 use embedded_services::GlobalRawMutex;
 use embedded_services::power::policy::PowerCapability;
-use embedded_services::power::{self, policy};
+use embedded_services::power::{self};
 use embedded_services::type_c::{ControllerId, controller};
 use embedded_usb_pd::GlobalPortId;
 use log::*;
 use static_cell::StaticCell;
 use std_examples::type_c::mock_controller;
-use type_c_service::wrapper::backing::BackingDefaultStorage;
+use type_c_service::wrapper::backing::{ReferencedStorage, Storage};
 
 const CONTROLLER0: ControllerId = ControllerId(0);
 const PORT0: GlobalPortId = GlobalPortId(0);
@@ -44,62 +44,50 @@ async fn task(spawner: Spawner) {
 
     controller::init();
 
-    static BACKING_STORAGE0: StaticCell<BackingDefaultStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let backing_storage0 = BACKING_STORAGE0.init(BackingDefaultStorage::new());
-    let backing0 = backing_storage0
-        .get_backing()
-        .expect("Failed to create backing storage");
+    static STORAGE: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
+    let storage = STORAGE.init(Storage::new(CONTROLLER0, CFU0, [(PORT0, POWER0)]));
+    static REFERENCED: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
+    let referenced = REFERENCED.init(storage.create_referenced());
+    let backing0 = referenced.create_backing().expect("Failed to create backing storage");
 
     static STATE0: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state0 = STATE0.init(mock_controller::ControllerState::new());
     let controller0 = mock_controller::Controller::new(state0);
     static WRAPPER0: StaticCell<mock_controller::Wrapper> = StaticCell::new();
-    let wrapper0 = WRAPPER0.init(mock_controller::Wrapper::new(
-        embedded_services::type_c::controller::Device::new(CONTROLLER0, &[PORT0]),
-        [policy::device::Device::new(POWER0)],
-        embedded_services::cfu::component::CfuDevice::new(CFU0),
-        backing0,
-        controller0,
-        crate::mock_controller::Validator,
-    ));
+    let wrapper0 = WRAPPER0.init(
+        mock_controller::Wrapper::try_new(controller0, backing0, crate::mock_controller::Validator)
+            .expect("Failed to create wrapper"),
+    );
 
-    static BACKING_STORAGE1: StaticCell<BackingDefaultStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let backing_storage1 = BACKING_STORAGE1.init(BackingDefaultStorage::new());
-    let backing1 = backing_storage1
-        .get_backing()
-        .expect("Failed to create backing storage");
+    static STORAGE1: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
+    let storage1 = STORAGE1.init(Storage::new(CONTROLLER1, CFU1, [(PORT1, POWER1)]));
+    static REFERENCED1: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
+    let referenced1 = REFERENCED1.init(storage1.create_referenced());
+    let backing1 = referenced1.create_backing().expect("Failed to create backing storage");
 
     static STATE1: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state1 = STATE1.init(mock_controller::ControllerState::new());
     let controller1 = mock_controller::Controller::new(state1);
     static WRAPPER1: StaticCell<mock_controller::Wrapper> = StaticCell::new();
-    let wrapper1 = WRAPPER1.init(mock_controller::Wrapper::new(
-        embedded_services::type_c::controller::Device::new(CONTROLLER1, &[PORT1]),
-        [policy::device::Device::new(POWER1)],
-        embedded_services::cfu::component::CfuDevice::new(CFU1),
-        backing1,
-        controller1,
-        crate::mock_controller::Validator,
-    ));
+    let wrapper1 = WRAPPER1.init(
+        mock_controller::Wrapper::try_new(controller1, backing1, crate::mock_controller::Validator)
+            .expect("Failed to create wrapper"),
+    );
 
-    static BACKING_STORAGE2: StaticCell<BackingDefaultStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let backing_storage2 = BACKING_STORAGE2.init(BackingDefaultStorage::new());
-    let backing2 = backing_storage2
-        .get_backing()
-        .expect("Failed to create backing storage");
+    static STORAGE2: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
+    let storage2 = STORAGE2.init(Storage::new(CONTROLLER2, CFU2, [(PORT2, POWER2)]));
+    static REFERENCED2: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
+    let referenced2 = REFERENCED2.init(storage2.create_referenced());
+    let backing2 = referenced2.create_backing().expect("Failed to create backing storage");
 
     static STATE2: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state2 = STATE2.init(mock_controller::ControllerState::new());
     let controller2 = mock_controller::Controller::new(state2);
     static WRAPPER2: StaticCell<mock_controller::Wrapper> = StaticCell::new();
-    let wrapper2 = WRAPPER2.init(mock_controller::Wrapper::new(
-        embedded_services::type_c::controller::Device::new(CONTROLLER2, &[PORT2]),
-        [policy::device::Device::new(POWER2)],
-        embedded_services::cfu::component::CfuDevice::new(CFU2),
-        backing2,
-        controller2,
-        crate::mock_controller::Validator,
-    ));
+    let wrapper2 = WRAPPER2.init(
+        mock_controller::Wrapper::try_new(controller2, backing2, crate::mock_controller::Validator)
+            .expect("Failed to create wrapper"),
+    );
 
     info!("Starting controller tasks");
     spawner.must_spawn(controller_task(wrapper0));

--- a/examples/std/src/bin/type_c/unconstrained.rs
+++ b/examples/std/src/bin/type_c/unconstrained.rs
@@ -48,14 +48,13 @@ async fn task(spawner: Spawner) {
     let storage = STORAGE.init(Storage::new(CONTROLLER0, CFU0, [(PORT0, POWER0)]));
     static REFERENCED: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
     let referenced = REFERENCED.init(storage.create_referenced());
-    let backing0 = referenced.create_backing().expect("Failed to create backing storage");
 
     static STATE0: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state0 = STATE0.init(mock_controller::ControllerState::new());
     let controller0 = mock_controller::Controller::new(state0);
     static WRAPPER0: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let wrapper0 = WRAPPER0.init(
-        mock_controller::Wrapper::try_new(controller0, backing0, crate::mock_controller::Validator)
+        mock_controller::Wrapper::try_new(controller0, referenced, crate::mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
 
@@ -63,14 +62,13 @@ async fn task(spawner: Spawner) {
     let storage1 = STORAGE1.init(Storage::new(CONTROLLER1, CFU1, [(PORT1, POWER1)]));
     static REFERENCED1: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
     let referenced1 = REFERENCED1.init(storage1.create_referenced());
-    let backing1 = referenced1.create_backing().expect("Failed to create backing storage");
 
     static STATE1: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state1 = STATE1.init(mock_controller::ControllerState::new());
     let controller1 = mock_controller::Controller::new(state1);
     static WRAPPER1: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let wrapper1 = WRAPPER1.init(
-        mock_controller::Wrapper::try_new(controller1, backing1, crate::mock_controller::Validator)
+        mock_controller::Wrapper::try_new(controller1, referenced1, crate::mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
 
@@ -78,14 +76,13 @@ async fn task(spawner: Spawner) {
     let storage2 = STORAGE2.init(Storage::new(CONTROLLER2, CFU2, [(PORT2, POWER2)]));
     static REFERENCED2: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
     let referenced2 = REFERENCED2.init(storage2.create_referenced());
-    let backing2 = referenced2.create_backing().expect("Failed to create backing storage");
 
     static STATE2: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state2 = STATE2.init(mock_controller::ControllerState::new());
     let controller2 = mock_controller::Controller::new(state2);
     static WRAPPER2: StaticCell<mock_controller::Wrapper> = StaticCell::new();
     let wrapper2 = WRAPPER2.init(
-        mock_controller::Wrapper::try_new(controller2, backing2, crate::mock_controller::Validator)
+        mock_controller::Wrapper::try_new(controller2, referenced2, crate::mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
 

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -17,7 +17,6 @@ use embedded_usb_pd::type_c::Current;
 use embedded_usb_pd::{Error, ado::Ado};
 use log::{debug, info, trace};
 use std::cell::Cell;
-use type_c_service::wrapper::backing::BackingDefault;
 
 pub struct ControllerState {
     events: Signal<GlobalRawMutex, PortEvent>,
@@ -306,5 +305,4 @@ impl type_c_service::wrapper::FwOfferValidator for Validator {
     }
 }
 
-pub type Wrapper<'a> =
-    type_c_service::wrapper::ControllerWrapper<'a, 1, Controller<'a>, BackingDefault<'a, 1>, Validator>;
+pub type Wrapper<'a> = type_c_service::wrapper::ControllerWrapper<'a, GlobalRawMutex, Controller<'a>, Validator>;

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -1,4 +1,4 @@
-use crate::wrapper::backing::Backing;
+use crate::wrapper::backing::ReferencedStorage;
 use crate::wrapper::{ControllerWrapper, FwOfferValidator};
 use ::tps6699x::registers::field_sets::IntEventBus1;
 use ::tps6699x::registers::{PdCcPullUp, PpExtVbusSw, PpIntVbusSw};
@@ -746,22 +746,19 @@ pub type Tps6699xWrapper<'a, M, BUS, V> = ControllerWrapper<'a, M, Tps6699x<'a, 
 /// Create a TPS66994 controller wrapper, returns `None` if the number of ports is invalid
 pub fn tps66994<'a, M: RawMutex, BUS: I2c, V: FwOfferValidator>(
     controller: tps6699x_drv::Tps6699x<'a, M, BUS>,
-    backing: Backing<'a>,
+    storage: &'a ReferencedStorage<'a, TPS66994_NUM_PORTS, M>,
     fw_update_config: FwUpdateConfig,
     fw_version_validator: V,
 ) -> Option<Tps6699xWrapper<'a, M, BUS, V>> {
-    if backing.registration.num_ports() != TPS66994_NUM_PORTS {
-        return None;
-    }
-
     const _: () = assert!(
         TPS66994_NUM_PORTS > 0 && TPS66994_NUM_PORTS <= MAX_SUPPORTED_PORTS,
         "Number of ports exceeds maximum supported"
     );
+
     ControllerWrapper::try_new(
         // Statically checked above
         Tps6699x::try_new(controller, TPS66994_NUM_PORTS, fw_update_config).unwrap(),
-        backing,
+        storage,
         fw_version_validator,
     )
 }
@@ -769,14 +766,10 @@ pub fn tps66994<'a, M: RawMutex, BUS: I2c, V: FwOfferValidator>(
 /// Create a new TPS66993 controller wrapper, returns `None` if the number of ports is invalid
 pub fn tps66993<'a, M: RawMutex, BUS: I2c, V: FwOfferValidator>(
     controller: tps6699x_drv::Tps6699x<'a, M, BUS>,
-    backing: Backing<'a>,
+    backing: &'a ReferencedStorage<'a, TPS66993_NUM_PORTS, M>,
     fw_update_config: FwUpdateConfig,
     fw_version_validator: V,
 ) -> Option<Tps6699xWrapper<'a, M, BUS, V>> {
-    if backing.registration.num_ports() != TPS66993_NUM_PORTS {
-        return None;
-    }
-
     const _: () = assert!(
         TPS66993_NUM_PORTS > 0 && TPS66993_NUM_PORTS <= MAX_SUPPORTED_PORTS,
         "Number of ports exceeds maximum supported"

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -10,22 +10,20 @@ use core::future::Future;
 use core::iter::zip;
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::Delay;
-use embedded_cfu_protocol::protocol_definitions::ComponentId;
 use embedded_hal_async::i2c::I2c;
-use embedded_services::cfu::component::CfuDevice;
-use embedded_services::power::policy::{self, PowerCapability};
+use embedded_services::power::policy::PowerCapability;
 use embedded_services::type_c::controller::{
     self, AttnVdm, Controller, ControllerStatus, DpPinConfig, OtherVdm, PortStatus, SendVdm, TbtConfig,
     UsbControlConfig,
 };
 use embedded_services::type_c::event::PortEvent;
-use embedded_services::type_c::{ControllerId, ATTN_VDM_LEN};
+use embedded_services::type_c::ATTN_VDM_LEN;
 use embedded_services::{debug, error, info, trace, type_c, warn};
 use embedded_usb_pd::ado::Ado;
 use embedded_usb_pd::pdinfo::PowerPathStatus;
 use embedded_usb_pd::pdo::{sink, source, Common, Rdo};
 use embedded_usb_pd::type_c::Current as TypecCurrent;
-use embedded_usb_pd::{DataRole, Error, GlobalPortId, LocalPortId, PdError, PlugOrientation, PowerRole};
+use embedded_usb_pd::{DataRole, Error, LocalPortId, PdError, PlugOrientation, PowerRole};
 use tps6699x::asynchronous::embassy as tps6699x_drv;
 use tps6699x::asynchronous::fw_update::UpdateTarget;
 use tps6699x::asynchronous::fw_update::{
@@ -742,76 +740,53 @@ impl<'a, M: RawMutex, BUS: I2c> AsMut<tps6699x_drv::Tps6699x<'a, M, BUS>> for Tp
     }
 }
 
-/// TPS66994 controller wrapper
-pub type Tps66994Wrapper<'a, M, BUS, BACK, V> =
-    ControllerWrapper<'a, TPS66994_NUM_PORTS, Tps6699x<'a, M, BUS>, BACK, V>;
+/// TPS6699x controller wrapper
+pub type Tps6699xWrapper<'a, M, BUS, V> = ControllerWrapper<'a, M, Tps6699x<'a, M, BUS>, V>;
 
-/// TPS66993 controller wrapper
-pub type Tps66993Wrapper<'a, M, BUS, BACK, V> =
-    ControllerWrapper<'a, TPS66993_NUM_PORTS, Tps6699x<'a, M, BUS>, BACK, V>;
-
-/// Create a TPS66994 controller wrapper
-// TODO: combine and trim down the number of parameters
-#[allow(clippy::too_many_arguments)]
-pub fn tps66994<'a, M: RawMutex, BUS: I2c, BACK: Backing<'a>, V: FwOfferValidator>(
+/// Create a TPS66994 controller wrapper, returns `None` if the number of ports is invalid
+pub fn tps66994<'a, M: RawMutex, BUS: I2c, V: FwOfferValidator>(
     controller: tps6699x_drv::Tps6699x<'a, M, BUS>,
-    controller_id: ControllerId,
-    port_ids: &'a [GlobalPortId],
-    power_ids: [policy::DeviceId; TPS66994_NUM_PORTS],
-    cfu_id: ComponentId,
-    backing: BACK,
+    backing: Backing<'a>,
     fw_update_config: FwUpdateConfig,
     fw_version_validator: V,
-) -> Result<Tps66994Wrapper<'a, M, BUS, BACK, V>, PdError> {
-    if port_ids.len() != TPS66994_NUM_PORTS {
-        return Err(PdError::InvalidParams);
+) -> Option<Tps6699xWrapper<'a, M, BUS, V>> {
+    if backing.registration.num_ports() != TPS66994_NUM_PORTS {
+        return None;
     }
 
     const _: () = assert!(
         TPS66994_NUM_PORTS > 0 && TPS66994_NUM_PORTS <= MAX_SUPPORTED_PORTS,
         "Number of ports exceeds maximum supported"
     );
-    Ok(ControllerWrapper::new(
-        controller::Device::new(controller_id, port_ids),
-        from_fn(|i| policy::device::Device::new(power_ids[i])),
-        CfuDevice::new(cfu_id),
-        backing,
+    ControllerWrapper::try_new(
         // Statically checked above
         Tps6699x::try_new(controller, TPS66994_NUM_PORTS, fw_update_config).unwrap(),
+        backing,
         fw_version_validator,
-    ))
+    )
 }
 
-/// Create a new TPS66993 controller wrapper
-// TODO: combine and trim down the number of parameters
-#[allow(clippy::too_many_arguments)]
-pub fn tps66993<'a, M: RawMutex, BUS: I2c, BACK: Backing<'a>, V: FwOfferValidator>(
+/// Create a new TPS66993 controller wrapper, returns `None` if the number of ports is invalid
+pub fn tps66993<'a, M: RawMutex, BUS: I2c, V: FwOfferValidator>(
     controller: tps6699x_drv::Tps6699x<'a, M, BUS>,
-    controller_id: ControllerId,
-    port_ids: &'a [GlobalPortId],
-    power_ids: [policy::DeviceId; TPS66993_NUM_PORTS],
-    cfu_id: ComponentId,
-    backing: BACK,
+    backing: Backing<'a>,
     fw_update_config: FwUpdateConfig,
     fw_version_validator: V,
-) -> Result<Tps66993Wrapper<'a, M, BUS, BACK, V>, PdError> {
-    if port_ids.len() != TPS66993_NUM_PORTS {
-        return Err(PdError::InvalidParams);
+) -> Option<Tps6699xWrapper<'a, M, BUS, V>> {
+    if backing.registration.num_ports() != TPS66993_NUM_PORTS {
+        return None;
     }
 
     const _: () = assert!(
         TPS66993_NUM_PORTS > 0 && TPS66993_NUM_PORTS <= MAX_SUPPORTED_PORTS,
         "Number of ports exceeds maximum supported"
     );
-    Ok(ControllerWrapper::new(
-        controller::Device::new(controller_id, port_ids),
-        from_fn(|i| policy::device::Device::new(power_ids[i])),
-        CfuDevice::new(cfu_id),
-        backing,
+    ControllerWrapper::try_new(
         // Statically checked above
         Tps6699x::try_new(controller, TPS66993_NUM_PORTS, fw_update_config).unwrap(),
+        backing,
         fw_version_validator,
-    ))
+    )
 }
 
 bitfield! {

--- a/type-c-service/src/wrapper/backing.rs
+++ b/type-c-service/src/wrapper/backing.rs
@@ -72,6 +72,8 @@ pub struct PortState<'a> {
     /// Pending events for the type-C service
     pub(crate) pending_events: PortEvent,
     /// PD alert channel for this port
+    // There's no direct immediate equivalent of a channel. PubSubChannel has immediate publisher behavior
+    // so we use that, but this requires us to keep separate publisher and subscriber objects.
     pub(crate) pd_alerts: (DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>),
 }
 

--- a/type-c-service/src/wrapper/backing.rs
+++ b/type-c-service/src/wrapper/backing.rs
@@ -1,100 +1,245 @@
-//! Code related to simplifying the creation of backing channels and buffers for the wrapper.
-
+//! Various types of state and objects required for [`crate::wrapper::ControllerWrapper`].
+//!
+//! The wrapper needs per-port state which ultimately needs to come from something like an array.
+//! We need to erase the generic `N` parameter from that storage so as not to monomorphize the entire
+//! wrapper over it. This module provides the necessary types and traits to do so. Things required by
+//! the wrapper can be split into two categories: objects used for service registration (which must be immutable),
+//! and mutable state. These are represented by the [`Registration`] and [`DynPortState`] respectively. The later
+//! is a trait intended to be used as a trait object to erase the generic port count.
+//!
+//! [`Storage`] is the base storage type and is generic over the number of ports. However, there are additional
+//! objects that need to reference the storage. To avoid a self-referential
+//! struct, [`ReferencedStorage`] contains these. This struct is still generic over the number of ports.
+//!
+//! Lastly, [`Backing`] contains references to the registration and type-erased state and is what is passed
+//! to the wrapper.
+//!
+//! Example usage:
+//! ```
+//! use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+//! use static_cell::StaticCell;
+//! use embedded_services::type_c::ControllerId;
+//! use embedded_services::power;
+//! use embedded_usb_pd::GlobalPortId;
+//! use type_c_service::wrapper::backing::{Storage, ReferencedStorage};
+//!
+//!
+//! const NUM_PORTS: usize = 2;
+//!
+//! fn init() {
+//!    static STORAGE: StaticCell<Storage<NUM_PORTS, NoopRawMutex>> = StaticCell::new();
+//!    let storage = STORAGE.init(Storage::new(
+//!        ControllerId(0),
+//!        0x0,
+//!        [(GlobalPortId(0), power::policy::DeviceId(0)), (GlobalPortId(1), power::policy::DeviceId(1))],
+//!    ));
+//!    static REFERENCED: StaticCell<ReferencedStorage<NUM_PORTS, NoopRawMutex>> = StaticCell::new();
+//!    let referenced = REFERENCED.init(storage.create_referenced());
+//!    let _backing = referenced.create_backing().unwrap();
+//! }
+//! ```
 use core::{
     array::from_fn,
-    future::Future,
-    ops::{Deref, DerefMut},
+    cell::{RefCell, RefMut},
 };
 
 use embassy_sync::{
     blocking_mutex::raw::RawMutex,
     pubsub::{DynImmediatePublisher, DynSubscriber, PubSubChannel},
 };
-use embedded_usb_pd::ado::Ado;
+use embassy_time::Instant;
+use embedded_cfu_protocol::protocol_definitions::ComponentId;
+use embedded_services::{
+    power,
+    type_c::{
+        controller::PortStatus,
+        event::{PortEvent, PortStatusChanged},
+        ControllerId,
+    },
+};
+use embedded_usb_pd::{ado::Ado, GlobalPortId};
 
-/// Trait for any struct that can provide backing storage for the controller wrapper.
-pub trait Backing<'a> {
-    /// Get the PD alert channel for a specific port index.
-    fn pd_alert_channel(
-        &self,
-        port_index: usize,
-    ) -> impl Future<Output = Option<impl Deref<Target = (DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>)>>>;
-    /// Get the PD alert channel for a specific port index.
-    fn pd_alert_channel_mut(
-        &mut self,
-        port_index: usize,
-    ) -> impl Future<Output = Option<impl DerefMut<Target = (DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>)>>>;
+use crate::{wrapper::cfu, PortEventStreamer};
+
+/// Per-port state
+pub struct PortState<'a> {
+    /// Cached port status
+    pub(crate) status: PortStatus,
+    /// Software status event
+    pub(crate) sw_status_event: PortStatusChanged,
+    /// Sink ready deadline instant
+    pub(crate) sink_ready_deadline: Option<Instant>,
+    /// Pending events for the type-C service
+    pub(crate) pending_events: PortEvent,
+    /// PD alert channel for this port
+    pub(crate) pd_alerts: (DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>),
+}
+
+/// Internal per-controller state
+#[derive(Copy, Clone)]
+pub struct ControllerState {
+    /// If we're currently doing a firmware update
+    pub(crate) fw_update_state: cfu::FwUpdateState,
+    /// State used to keep track of where we are as we turn the event bitfields into a stream of events
+    pub(crate) port_event_streaming_state: Option<PortEventStreamer>,
+}
+
+impl Default for ControllerState {
+    fn default() -> Self {
+        Self {
+            fw_update_state: cfu::FwUpdateState::Idle,
+            port_event_streaming_state: None,
+        }
+    }
+}
+
+/// Internal state containing all per-port and per-controller state
+struct InternalState<'a, const N: usize> {
+    controller_state: ControllerState,
+    port_states: [PortState<'a>; N],
+}
+
+impl<'a, const N: usize> InternalState<'a, N> {
+    fn new<M: RawMutex>(storage: &'a Storage<N, M>) -> Self {
+        Self {
+            controller_state: ControllerState::default(),
+            port_states: from_fn(|i| PortState {
+                status: PortStatus::new(),
+                sw_status_event: PortStatusChanged::none(),
+                sink_ready_deadline: None,
+                pending_events: PortEvent::none(),
+                pd_alerts: (
+                    storage.pd_alerts[i].dyn_immediate_publisher(),
+                    storage.pd_alerts[i].dyn_subscriber().unwrap(),
+                ),
+            }),
+        }
+    }
+}
+
+impl<'a, const N: usize> DynPortState<'a> for InternalState<'a, N> {
+    fn num_ports(&self) -> usize {
+        self.port_states.len()
+    }
+
+    fn port_states(&self) -> &[PortState<'a>] {
+        &self.port_states
+    }
+
+    fn port_states_mut(&mut self) -> &mut [PortState<'a>] {
+        &mut self.port_states
+    }
+
+    fn controller_state(&self) -> &ControllerState {
+        &self.controller_state
+    }
+
+    fn controller_state_mut(&mut self) -> &mut ControllerState {
+        &mut self.controller_state
+    }
+}
+
+/// Trait to erase the generic port count argument
+pub trait DynPortState<'a> {
+    fn num_ports(&self) -> usize;
+
+    fn port_states(&self) -> &[PortState<'a>];
+    fn port_states_mut(&mut self) -> &mut [PortState<'a>];
+
+    fn controller_state(&self) -> &ControllerState;
+    fn controller_state_mut(&mut self) -> &mut ControllerState;
+}
+
+/// Service registration objects
+pub struct Registration<'a> {
+    pub(crate) pd_controller: &'a embedded_services::type_c::controller::Device<'a>,
+    pub(crate) cfu_device: &'a embedded_services::cfu::component::CfuDevice,
+    pub(crate) power_devices: &'a [embedded_services::power::policy::device::Device],
+}
+
+impl<'a> Registration<'a> {
+    pub fn num_ports(&self) -> usize {
+        self.power_devices.len()
+    }
 }
 
 /// PD alerts should be fairly uncommon, four seems like a reasonable number to start with.
 const MAX_BUFFERED_PD_ALERTS: usize = 4;
 
-/// Actual backing channels and buffers
-pub struct BackingDefaultStorage<const N: usize, M: RawMutex> {
-    /// PD alert channels for each port
-    // 0 PUBS because we only use immediate publishers for PD alerts
+/// Base storage
+pub struct Storage<const N: usize, M: RawMutex> {
+    // Registration-related
+    controller_id: ControllerId,
+    pd_ports: [GlobalPortId; N],
+    cfu_device: embedded_services::cfu::component::CfuDevice,
+    power_devices: [embedded_services::power::policy::device::Device; N],
+
+    // State-related
     pd_alerts: [PubSubChannel<M, Ado, MAX_BUFFERED_PD_ALERTS, 1, 0>; N],
 }
 
-impl<const N: usize, M: RawMutex> BackingDefaultStorage<N, M> {
-    pub const fn new() -> Self {
+impl<const N: usize, M: RawMutex> Storage<N, M> {
+    pub fn new(
+        controller_id: ControllerId,
+        cfu_id: ComponentId,
+        ports: [(GlobalPortId, power::policy::DeviceId); N],
+    ) -> Self {
         Self {
+            controller_id,
+            pd_ports: ports.map(|(port, _)| port),
+            cfu_device: embedded_services::cfu::component::CfuDevice::new(cfu_id),
+            power_devices: ports.map(|(_, device)| embedded_services::power::policy::device::Device::new(device)),
             pd_alerts: [const { PubSubChannel::new() }; N],
         }
     }
 
-    pub fn get_backing(&self) -> Option<BackingDefault<'_, N>> {
-        let pd_alerts: [_; N] = from_fn(|i| {
-            let publisher = self.pd_alerts[i].dyn_immediate_publisher();
-            let subscriber = self.pd_alerts[i].dyn_subscriber().ok()?;
-            Some((publisher, subscriber))
-        });
-
-        // If any subscriber creation failed, return None
-        if pd_alerts.iter().any(|x| x.is_none()) {
-            return None;
-        }
-
-        // Unwrap all elements (safe because we checked above)
-        let mut iter = pd_alerts.into_iter();
-        let pd_alerts = from_fn(|_| iter.next().unwrap().unwrap());
-
-        Some(BackingDefault { pd_alerts })
+    /// Create referenced storage from this storage
+    pub fn create_referenced(&self) -> ReferencedStorage<'_, N, M> {
+        ReferencedStorage::from_storage(self)
     }
 }
 
-impl<const N: usize, M: RawMutex> Default for BackingDefaultStorage<N, M> {
-    fn default() -> Self {
-        Self::new()
-    }
+/// Contains any values that need to reference [`Storage`]
+///
+/// To simplify usage, we use interior mutability through a ref cell to avoid having to declare the state
+/// completely separately.
+pub struct ReferencedStorage<'a, const N: usize, M: RawMutex> {
+    storage: &'a Storage<N, M>,
+    state: RefCell<InternalState<'a, N>>,
+    pd_controller: embedded_services::type_c::controller::Device<'a>,
 }
 
-/// A reference to the storage provided by [`BackingDefaultStorage`].
-pub struct BackingDefault<'a, const N: usize> {
-    /// PD alert channels for each port
-    pd_alerts: [(DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>); N],
-}
-
-impl<'a, const N: usize> Backing<'a> for BackingDefault<'a, N> {
-    async fn pd_alert_channel(
-        &self,
-        port_index: usize,
-    ) -> Option<impl Deref<Target = (DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>)>> {
-        if port_index < N {
-            Some(&self.pd_alerts[port_index])
-        } else {
-            None
+impl<'a, const N: usize, M: RawMutex> ReferencedStorage<'a, N, M> {
+    /// Create a new referenced storage from the given storage and controller ID
+    fn from_storage(storage: &'a Storage<N, M>) -> Self {
+        Self {
+            storage,
+            state: RefCell::new(InternalState::new(storage)),
+            pd_controller: embedded_services::type_c::controller::Device::new(
+                storage.controller_id,
+                storage.pd_ports.as_slice(),
+            ),
         }
     }
 
-    async fn pd_alert_channel_mut(
-        &mut self,
-        port_index: usize,
-    ) -> Option<impl DerefMut<Target = (DynImmediatePublisher<'a, Ado>, DynSubscriber<'a, Ado>)>> {
-        if port_index < N {
-            Some(&mut self.pd_alerts[port_index])
-        } else {
-            None
-        }
+    /// Creates the backing, returns `None` if a backing has already been created
+    pub fn create_backing<'b>(&'b self) -> Option<Backing<'b>>
+    where
+        'b: 'a,
+    {
+        self.state.try_borrow_mut().ok().map(|state| Backing {
+            registration: Registration {
+                pd_controller: &self.pd_controller,
+                cfu_device: &self.storage.cfu_device,
+                power_devices: &self.storage.power_devices,
+            },
+            state,
+        })
     }
+}
+
+/// Wrapper around registration and type-erased state
+pub struct Backing<'a> {
+    pub(crate) registration: Registration<'a>,
+    pub(crate) state: RefMut<'a, dyn DynPortState<'a>>,
 }

--- a/type-c-service/src/wrapper/backing.rs
+++ b/type-c-service/src/wrapper/backing.rs
@@ -154,9 +154,9 @@ pub trait DynPortState<'a> {
 
 /// Service registration objects
 pub struct Registration<'a> {
-    pub(crate) pd_controller: &'a embedded_services::type_c::controller::Device<'a>,
-    pub(crate) cfu_device: &'a embedded_services::cfu::component::CfuDevice,
-    pub(crate) power_devices: &'a [embedded_services::power::policy::device::Device],
+    pub pd_controller: &'a embedded_services::type_c::controller::Device<'a>,
+    pub cfu_device: &'a embedded_services::cfu::component::CfuDevice,
+    pub power_devices: &'a [embedded_services::power::policy::device::Device],
 }
 
 impl<'a> Registration<'a> {

--- a/type-c-service/src/wrapper/dp.rs
+++ b/type-c-service/src/wrapper/dp.rs
@@ -1,9 +1,10 @@
-use super::{backing::Backing, ControllerWrapper, FwOfferValidator};
+use super::{ControllerWrapper, FwOfferValidator};
 use crate::wrapper::message::OutputDpStatusChanged;
+use embassy_sync::blocking_mutex::raw::RawMutex;
 use embedded_services::{trace, type_c::controller::Controller};
 use embedded_usb_pd::{Error, LocalPortId};
 
-impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> ControllerWrapper<'a, N, C, BACK, V> {
+impl<'a, M: RawMutex, C: Controller, V: FwOfferValidator> ControllerWrapper<'a, M, C, V> {
     /// Process a DisplayPort status update by retrieving the current DP status from the `controller` for the appropriate `port`.
     pub(super) async fn process_dp_status_update(
         &self,

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -17,14 +17,16 @@
 //! [`ControllerWrapper::process_event`] consumes [`message::Output`] and responds to any deferred requests, performs
 //! any caching/buffering of data, and notifies the type-C service implementation of the event if needed.
 use core::array::from_fn;
+use core::cell::RefMut;
 use core::future::{pending, Future};
+use core::ops::DerefMut;
 
 use embassy_futures::select::{select, select5, select_array, Either, Either5};
+use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_sync::signal::Signal;
 use embassy_time::Instant;
 use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferResponse, FwVersion};
-use embedded_services::cfu::component::CfuDevice;
 use embedded_services::power::policy::device::StateKind;
 use embedded_services::power::policy::{self, action};
 use embedded_services::transformers::object::{Object, RefGuard, RefMutGuard};
@@ -35,7 +37,7 @@ use embedded_services::{debug, error, info, trace, warn};
 use embedded_usb_pd::ado::Ado;
 use embedded_usb_pd::{Error, LocalPortId, PdError};
 
-use crate::wrapper::backing::Backing;
+use crate::wrapper::backing::{Backing, DynPortState};
 use crate::wrapper::message::*;
 use crate::{PortEventStreamer, PortEventVariant};
 
@@ -53,40 +55,6 @@ pub const DEFAULT_FW_UPDATE_TICK_INTERVAL_MS: u64 = 5000;
 /// 300 seconds at 5 seconds per tick
 pub const DEFAULT_FW_UPDATE_TIMEOUT_TICKS: u8 = 60;
 
-/// Internal per-port state
-#[derive(Copy, Clone, Default)]
-pub struct PortState {
-    /// Cached port status
-    status: PortStatus,
-    /// Software status event
-    sw_status_event: PortStatusChanged,
-    /// Sink ready deadline instant
-    sink_ready_deadline: Option<Instant>,
-    /// Pending events for the type-C service
-    pending_events: PortEvent,
-}
-
-/// Internal wrapper state
-#[derive(Copy, Clone)]
-pub struct InternalState<const N: usize> {
-    /// If we're currently doing a firmware update
-    pub fw_update_state: cfu::FwUpdateState,
-    /// State used to keep track of where we are as we turn the event bitfields into a stream of events
-    port_event_streaming_state: Option<PortEventStreamer>,
-    /// Per-port state
-    port_states: [PortState; N],
-}
-
-impl<const N: usize> Default for InternalState<N> {
-    fn default() -> Self {
-        Self {
-            fw_update_state: cfu::FwUpdateState::Idle,
-            port_event_streaming_state: None,
-            port_states: [Default::default(); N],
-        }
-    }
-}
-
 /// Trait for validating firmware versions before applying an update
 // TODO: remove this once we have a better framework for OEM customization
 // See https://github.com/OpenDevicePartnership/embedded-services/issues/326
@@ -95,83 +63,80 @@ pub trait FwOfferValidator {
     fn validate(&self, current: FwVersion, offer: &FwUpdateOffer) -> FwUpdateOfferResponse;
 }
 
+/// Maximum number of supported ports
+pub const MAX_SUPPORTED_PORTS: usize = 2;
+
 /// Common functionality implemented on top of [`embedded_services::type_c::controller::Controller`]
-pub struct ControllerWrapper<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> {
-    /// PD controller to interface with PD service
-    pd_controller: controller::Device<'a>,
-    /// Power policy devices to interface with power policy service
-    power: [policy::device::Device; N],
-    /// CFU device to interface with firmware update service
-    cfu_device: CfuDevice,
-    /// Internal state for the wrapper
-    state: Mutex<GlobalRawMutex, InternalState<N>>,
-    controller: Mutex<GlobalRawMutex, C>,
+pub struct ControllerWrapper<'a, M: RawMutex, C: Controller, V: FwOfferValidator> {
+    controller: Mutex<M, C>,
     /// Trait object for validating firmware versions
     fw_version_validator: V,
     /// FW update ticker used to check for timeouts and recovery attempts
-    fw_update_ticker: Mutex<GlobalRawMutex, embassy_time::Ticker>,
-    /// Channels and buffers used by the wrapper
-    backing: Mutex<GlobalRawMutex, BACK>,
+    fw_update_ticker: Mutex<M, embassy_time::Ticker>,
+    /// Registration information for services
+    registration: backing::Registration<'a>,
+    /// State
+    state: Mutex<M, RefMut<'a, dyn DynPortState<'a>>>,
     /// SW port status event signal
-    sw_status_event: Signal<GlobalRawMutex, ()>,
+    sw_status_event: Signal<M, ()>,
 }
 
-impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> ControllerWrapper<'a, N, C, BACK, V> {
-    /// Create a new controller wrapper
-    pub fn new(
-        pd_controller: controller::Device<'a>,
-        power: [policy::device::Device; N],
-        cfu_device: CfuDevice,
-        backing: BACK,
-        controller: C,
-        fw_version_validator: V,
-    ) -> Self {
-        Self {
-            pd_controller,
-            power,
-            cfu_device,
-            state: Mutex::new(Default::default()),
+impl<'a, M: RawMutex, C: Controller, V: FwOfferValidator> ControllerWrapper<'a, M, C, V> {
+    /// Create a new controller wrapper, returns `None` if the backing storage has an invalid port count
+    pub fn try_new(controller: C, backing: Backing<'a>, fw_version_validator: V) -> Option<Self> {
+        if backing.registration.num_ports() == 0 || backing.registration.num_ports() > MAX_SUPPORTED_PORTS {
+            return None;
+        }
+
+        Some(Self {
             controller: Mutex::new(controller),
             fw_version_validator,
             fw_update_ticker: Mutex::new(embassy_time::Ticker::every(embassy_time::Duration::from_millis(
                 DEFAULT_FW_UPDATE_TICK_INTERVAL_MS,
             ))),
-            backing: Mutex::new(backing),
+            registration: backing.registration,
+            state: Mutex::new(backing.state),
             sw_status_event: Signal::new(),
-        }
+        })
     }
 
     /// Get the power policy devices for this controller.
     pub fn power_policy_devices(&self) -> &[policy::device::Device] {
-        &self.power
+        self.registration.power_devices
     }
 
-    /// Get the cached port status
-    pub async fn get_cached_port_status(&self, local_port: LocalPortId) -> PortStatus {
-        self.state.lock().await.port_states[local_port.0 as usize].status
+    /// Get the cached port status, returns None if the port is invalid
+    pub async fn get_cached_port_status(&self, local_port: LocalPortId) -> Option<PortStatus> {
+        self.state
+            .lock()
+            .await
+            .port_states()
+            .get(local_port.0 as usize)
+            .map(|s| s.status)
     }
 
     /// Synchronize the state between the controller and the internal state
     pub async fn sync_state(&self) -> Result<(), Error<<C as Controller>::BusError>> {
         let mut controller = self.controller.lock().await;
         let mut state = self.state.lock().await;
-        self.sync_state_internal(&mut controller, &mut state).await
+        self.sync_state_internal(&mut controller, state.deref_mut().deref_mut())
+            .await
     }
 
     /// Synchronize the state between the controller and the internal state
     async fn sync_state_internal(
         &self,
         controller: &mut C,
-        state: &mut InternalState<N>,
+        state: &mut dyn DynPortState<'_>,
     ) -> Result<(), Error<<C as Controller>::BusError>> {
         // Sync the controller state with the PD controller
-        for port in 0..N {
-            let mut status_changed = state.port_states[port].sw_status_event;
-            let local_port = LocalPortId(port as u8);
+        for (i, port_state) in state.port_states_mut().iter_mut().enumerate() {
+            let mut status_changed = port_state.sw_status_event;
+            let local_port = LocalPortId(i as u8);
             let status = controller.get_port_status(local_port).await?;
-            trace!("Port{} status: {:#?}", port, status);
+            trace!("Port{} status: {:#?}", i, status);
 
-            let previous_status = state.port_states[port].status;
+            let previous_status = port_state.status;
 
             if previous_status.is_connected() != status.is_connected() {
                 status_changed.set_plug_inserted_or_removed(true);
@@ -185,10 +150,10 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                 status_changed.set_new_power_contract_as_provider(true);
             }
 
-            state.port_states[port].sw_status_event = status_changed;
-            if state.port_states[port].sw_status_event != PortStatusChanged::none() {
+            port_state.sw_status_event = status_changed;
+            if port_state.sw_status_event != PortStatusChanged::none() {
                 // Have a status changed event, notify
-                trace!("Port{} status changed: {:#?}", port, status);
+                trace!("Port{} status changed: {:#?}", i, status);
                 self.sw_status_event.signal(());
             }
         }
@@ -203,7 +168,7 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         port: LocalPortId,
         status: &PortStatus,
     ) -> Result<(), Error<<C as Controller>::BusError>> {
-        if port.0 > N as u8 {
+        if port.0 as usize >= self.registration.num_ports() {
             error!("Invalid port {}", port.0);
             return PdError::InvalidPort.into();
         }
@@ -246,11 +211,12 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
     async fn process_port_status_changed<'b>(
         &self,
         controller: &mut C,
-        state: &mut InternalState<N>,
+        state: &mut dyn DynPortState<'_>,
         local_port_id: LocalPortId,
         status_event: PortStatusChanged,
     ) -> Result<Output<'b>, Error<<C as Controller>::BusError>> {
         let global_port_id = self
+            .registration
             .pd_controller
             .lookup_global_port(local_port_id)
             .map_err(Error::Pd)?;
@@ -258,7 +224,9 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         let status = controller.get_port_status(local_port_id).await?;
         trace!("Port{} status: {:#?}", global_port_id.0, status);
 
-        let power = self.get_power_device(local_port_id).map_err(Error::Pd)?;
+        let power = self
+            .get_power_device(local_port_id)
+            .ok_or(Error::Pd(PdError::InvalidPort))?;
         trace!("Port{} status events: {:#?}", global_port_id.0, status_event);
         if status_event.plug_inserted_or_removed() {
             self.process_plug_event(controller, power, local_port_id, &status)
@@ -293,23 +261,32 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
     /// Finalize a port status change output
     async fn finalize_port_status_change(
         &self,
-        state: &mut InternalState<N>,
+        state: &mut dyn DynPortState<'_>,
         local_port: LocalPortId,
         status_event: PortStatusChanged,
         status: PortStatus,
     ) -> Result<(), Error<<C as Controller>::BusError>> {
-        let global_port_id = self.pd_controller.lookup_global_port(local_port).map_err(Error::Pd)?;
-
         let port_index = local_port.0 as usize;
-        let mut events = state.port_states[port_index].pending_events;
+        if port_index >= state.num_ports() {
+            return Err(PdError::InvalidPort.into());
+        }
+
+        let global_port_id = self
+            .registration
+            .pd_controller
+            .lookup_global_port(local_port)
+            .map_err(Error::Pd)?;
+
+        let port_state = &mut state.port_states_mut()[port_index];
+        let mut events = port_state.pending_events;
         events.status = events.status.union(status_event);
-        state.port_states[port_index].pending_events = events;
-        state.port_states[port_index].status = status;
+        port_state.pending_events = events;
+        port_state.status = status;
 
         if events != PortEvent::none() {
             let mut pending = PortPending::none();
             pending.pend_port(global_port_id.0 as usize);
-            self.pd_controller.notify_ports(pending).await;
+            self.registration.pd_controller.notify_ports(pending).await;
             trace!("P{}: Notified service for events: {:#?}", global_port_id.0, events);
         }
 
@@ -319,28 +296,32 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
     /// Finalize a PD alert output
     async fn finalize_pd_alert(
         &self,
-        state: &mut InternalState<N>,
+        state: &mut dyn DynPortState<'_>,
         local_port: LocalPortId,
         alert: Ado,
     ) -> Result<(), Error<<C as Controller>::BusError>> {
-        let global_port_id = self.pd_controller.lookup_global_port(local_port).map_err(Error::Pd)?;
         let port_index = local_port.0 as usize;
+        if port_index >= state.num_ports() {
+            return Err(PdError::InvalidPort.into());
+        }
 
+        let global_port_id = self
+            .registration
+            .pd_controller
+            .lookup_global_port(local_port)
+            .map_err(Error::Pd)?;
+
+        let port_state = &mut state.port_states_mut()[port_index];
         // Buffer the alert
-        let backing = self.backing.lock().await;
-        let channel = backing.pd_alert_channel(port_index).await.ok_or(PdError::InvalidPort)?;
-        channel.0.publish_immediate(alert);
+        port_state.pd_alerts.0.publish_immediate(alert);
 
         // Pend the alert
-        state.port_states[port_index]
-            .pending_events
-            .notification
-            .set_alert(true);
+        port_state.pending_events.notification.set_alert(true);
 
         // Pend this port
         let mut pending = PortPending::none();
         pending.pend_port(global_port_id.0 as usize);
-        self.pd_controller.notify_ports(pending).await;
+        self.registration.pd_controller.notify_ports(pending).await;
         Ok(())
     }
 
@@ -351,13 +332,13 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         &self,
         controller: &mut C,
     ) -> Result<PortEventStreamer, Error<<C as Controller>::BusError>> {
-        if self.state.lock().await.fw_update_state.in_progress() {
+        if self.state.lock().await.controller_state().fw_update_state.in_progress() {
             // Don't process events while firmware update is in progress
             debug!("Firmware update in progress, ignoring port events");
             return pending().await;
         }
 
-        let streaming_state = self.state.lock().await.port_event_streaming_state;
+        let streaming_state = self.state.lock().await.controller_state().port_event_streaming_state;
         if let Some(streamer) = streaming_state {
             // If we're converting the bitfields into an event stream yield first to prevent starving other tasks
             embassy_futures::yield_now().await;
@@ -374,7 +355,7 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                 Either::First(r) => r?,
                 Either::Second(_) => (),
             };
-            let pending: PortPending = FromIterator::from_iter(0..N);
+            let pending: PortPending = FromIterator::from_iter(0..self.registration.num_ports());
             Ok(PortEventStreamer::new(pending.into_iter()))
         }
     }
@@ -389,7 +370,7 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                 select5(
                     self.wait_port_pending(&mut controller),
                     self.wait_power_command(),
-                    self.pd_controller.receive(),
+                    self.registration.pd_controller.receive(),
                     self.wait_cfu_command(),
                     self.wait_sink_ready_timeout(),
                 )
@@ -408,7 +389,7 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
 
                             // No more awaits, modify state here for drop safety
                             let sw_event = core::mem::replace(
-                                &mut state.port_states[port_index].sw_status_event,
+                                &mut state.port_states_mut()[port_index].sw_status_event,
                                 PortStatusChanged::none(),
                             );
                             Ok(hw_event.union(sw_event.into()))
@@ -416,7 +397,11 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                         .await?
                     {
                         let port_id = LocalPortId(port_index as u8);
-                        self.state.lock().await.port_event_streaming_state = Some(stream);
+                        self.state
+                            .lock()
+                            .await
+                            .controller_state_mut()
+                            .port_event_streaming_state = Some(stream);
                         match event {
                             PortEventVariant::StatusChanged(status_event) => {
                                 return Ok(Event::PortStatusChanged(EventPortStatusChanged {
@@ -432,7 +417,11 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                             }
                         }
                     } else {
-                        self.state.lock().await.port_event_streaming_state = None;
+                        self.state
+                            .lock()
+                            .await
+                            .controller_state_mut()
+                            .port_event_streaming_state = None;
                     }
                 }
                 Either5::Second((port, request)) => {
@@ -443,7 +432,7 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                 Either5::Fifth(port) => {
                     // Sink ready timeout event
                     debug!("Port{0}: Sink ready timeout", port.0);
-                    self.state.lock().await.port_states[port.0 as usize].sink_ready_deadline = None;
+                    self.state.lock().await.port_states_mut()[port.0 as usize].sink_ready_deadline = None;
                     let mut status_event = PortStatusChanged::none();
                     status_event.set_sink_ready(true);
                     return Ok(Event::PortStatusChanged(EventPortStatusChanged { port, status_event }));
@@ -492,12 +481,12 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
         let mut state = self.state.lock().await;
         match event {
             Event::PortStatusChanged(EventPortStatusChanged { port, status_event }) => {
-                self.process_port_status_changed(&mut controller, &mut state, port, status_event)
+                self.process_port_status_changed(&mut controller, state.deref_mut().deref_mut(), port, status_event)
                     .await
             }
             Event::PowerPolicyCommand(EventPowerPolicyCommand { port, request }) => {
                 let response = self
-                    .process_power_command(&mut controller, &mut state, port, &request.command)
+                    .process_power_command(&mut controller, state.deref_mut().deref_mut(), port, &request.command)
                     .await;
                 Ok(Output::PowerPolicyCommand(OutputPowerPolicyCommand {
                     port,
@@ -507,18 +496,21 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
             }
             Event::ControllerCommand(request) => {
                 let response = self
-                    .process_pd_command(&mut controller, &mut state, &request.command)
+                    .process_pd_command(&mut controller, state.deref_mut().deref_mut(), &request.command)
                     .await;
                 Ok(Output::ControllerCommand(OutputControllerCommand { request, response }))
             }
             Event::CfuEvent(event) => match event {
                 EventCfu::Request(request) => {
-                    let response = self.process_cfu_command(&mut controller, &mut state, &request).await;
+                    let response = self
+                        .process_cfu_command(&mut controller, state.deref_mut().deref_mut(), &request)
+                        .await;
                     Ok(Output::CfuResponse(response))
                 }
                 EventCfu::RecoveryTick => {
                     // FW Update tick, process timeouts and recovery attempts
-                    self.process_cfu_tick(&mut controller, &mut state).await;
+                    self.process_cfu_tick(&mut controller, state.deref_mut().deref_mut())
+                        .await;
                     Ok(Output::CfuRecovery)
                 }
             },
@@ -540,11 +532,16 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
                 status_event,
                 status,
             }) => {
-                self.finalize_port_status_change(&mut state, port, status_event, status)
+                self.finalize_port_status_change(state.deref_mut().deref_mut(), port, status_event, status)
                     .await
             }
-            Output::PdAlert(OutputPdAlert { port, ado }) => self.finalize_pd_alert(&mut state, port, ado).await,
-            Output::Vdm(vdm) => self.finalize_vdm(&mut state, vdm).await.map_err(Error::Pd),
+            Output::PdAlert(OutputPdAlert { port, ado }) => {
+                self.finalize_pd_alert(state.deref_mut().deref_mut(), port, ado).await
+            }
+            Output::Vdm(vdm) => self
+                .finalize_vdm(state.deref_mut().deref_mut(), vdm)
+                .await
+                .map_err(Error::Pd),
             Output::PowerPolicyCommand(OutputPowerPolicyCommand { request, response, .. }) => {
                 request.respond(response);
                 Ok(())
@@ -585,41 +582,42 @@ impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> 
 
     /// Register all devices with their respective services
     pub async fn register(&'static self) -> Result<(), Error<<C as Controller>::BusError>> {
-        for device in &self.power {
+        for device in self.registration.power_devices {
             policy::register_device(device).await.map_err(|_| {
                 error!(
                     "Controller{}: Failed to register power device {}",
-                    self.pd_controller.id().0,
+                    self.registration.pd_controller.id().0,
                     device.id().0
                 );
                 Error::Pd(PdError::Failed)
             })?;
         }
 
-        controller::register_controller(&self.pd_controller)
+        controller::register_controller(self.registration.pd_controller)
             .await
             .map_err(|_| {
                 error!(
                     "Controller{}: Failed to register PD controller",
-                    self.pd_controller.id().0
+                    self.registration.pd_controller.id().0
                 );
                 Error::Pd(PdError::Failed)
             })?;
 
         //TODO: Remove when we have a more general framework in place
-        embedded_services::cfu::register_device(&self.cfu_device)
+        embedded_services::cfu::register_device(self.registration.cfu_device)
             .await
             .map_err(|_| {
-                error!("Controller{}: Failed to register CFU device", self.pd_controller.id().0);
+                error!(
+                    "Controller{}: Failed to register CFU device",
+                    self.registration.pd_controller.id().0
+                );
                 Error::Pd(PdError::Failed)
             })?;
         Ok(())
     }
 }
 
-impl<'a, const N: usize, C: Controller, BACK: Backing<'a>, V: FwOfferValidator> Object<C>
-    for ControllerWrapper<'a, N, C, BACK, V>
-{
+impl<'a, M: RawMutex, C: Controller, V: FwOfferValidator> Object<C> for ControllerWrapper<'a, M, C, V> {
     fn get_inner(&self) -> impl Future<Output = impl RefGuard<C>> {
         self.controller.lock()
     }


### PR DESCRIPTION
This PR refactors the backing for the controller wrapper with the goal of removing port count generic arguments. The existing backing types that were used to supply certain data structures have been expanded to also include all needed mutable state and service registration objects. This also helps to simplify constructing wrappers a bit. This PR introduces the types `Storage`, `ReferencedStorage`, and `Backing` to accomplish this task. This PR also introduces a `DynPortState` trait that is used to erase the port count generic from the wrapper.

Since the wrapper no longer has to be monomorphized per port count this results in a size reduction of at least ~14K per monomorphized copy removed.

This PR also includes some general clean-up, most notable is that the wrapper now accepts a `M: RawMutex` argument to allow users of this type to the supply the mutex type.