### PR TITLE
Add LED support to keyboard-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
 name = "keyboard-service"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.9.4",
  "defmt 0.3.100",
  "embassy-executor",
  "embassy-futures",

--- a/keyboard-service/Cargo.toml
+++ b/keyboard-service/Cargo.toml
@@ -17,6 +17,7 @@ embassy-time.workspace = true
 embedded-services.workspace = true
 embedded-hal.workspace = true
 static_cell.workspace = true
+bitflags.workspace = true
 hid-service = { path = "../hid-service" }
 keyberon = { git = "https://github.com/TeXitoi/keyberon" }
 


### PR DESCRIPTION
Adds support for key LEDs (and port's Surface code for handling HID output reports, almost a direct one for one copy so I do not take credit for writing it).

The HID spec defines quite a few usage IDs for LED types, but it would be difficult to handle all of those generically. So I just narrow it down to 3 that seem reasonable for modern laptop keyboards. Things like Fn lock key LEDs are not part of HID spec and will be handled by a separate Fn lock handling PR.

HID LED reports only views LED status as On/Off, so this is designed to view LEDs as output pins. If a keyboard is designed where brightness of these LEDs is modified via PWM (and the brightness is controlled via a mechanism outside HID), one can impl OutputPin for a PWM type where set_low/set_high can disable/enable PWM respectively and its duty cycle/brightness controlled elsewhere (such as tied to keyboard backlight, which can be controlled by separate HID report).