### PR TITLE
Add turbo load voltage and RHF effective fields

### DIFF
--- a/battery-service/src/device.rs
+++ b/battery-service/src/device.rs
@@ -110,6 +110,12 @@ pub struct DynamicBatteryMsgs {
     /// Battery Sustained Power in mW.
     pub sus_power_mw: u32,
 
+    /// Turbo Load Voltage in mV.
+    pub turbo_vload_mv: u32,
+
+    /// Turbo RHF Effective in mOhm.
+    pub turbo_rhf_effective_mohm: u32,
+
     /// Full Charge Capacity in mWh.
     pub full_charge_capacity_mwh: u32,
 


### PR DESCRIPTION
vload voltage and rhf effective is useful for calculating brownout parameters