### PR TITLE
type-c-service: Depanic

### DIFF
--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -132,7 +132,11 @@ async fn main(spawner: Spawner) {
     ));
 
     static REFERENCED: StaticCell<ReferencedStorage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
-    let referenced = REFERENCED.init(storage.create_referenced());
+    let referenced = REFERENCED.init(
+        storage
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     info!("Spawining PD controller task");
     static CONTROLLER_MUTEX: StaticCell<Tps6699xMutex<'_>> = StaticCell::new();

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -216,7 +216,11 @@ async fn main(spawner: Spawner) {
     ));
 
     static REFERENCED: StaticCell<ReferencedStorage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
-    let referenced = REFERENCED.init(storage.create_referenced());
+    let referenced = REFERENCED.init(
+        storage
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     info!("Spawining PD controller task");
     static CONTROLLER_MUTEX: StaticCell<Tps6699xMutex<'_>> = StaticCell::new();

--- a/examples/std/src/bin/type_c/external.rs
+++ b/examples/std/src/bin/type_c/external.rs
@@ -29,7 +29,11 @@ async fn controller_task() {
     ));
     static REFERENCED: StaticCell<type_c_service::wrapper::backing::ReferencedStorage<1, GlobalRawMutex>> =
         StaticCell::new();
-    let referenced = REFERENCED.init(backing_storage.create_referenced());
+    let referenced = REFERENCED.init(
+        backing_storage
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static CONTROLLER: StaticCell<Mutex<GlobalRawMutex, mock_controller::Controller>> = StaticCell::new();
     let controller = CONTROLLER.init(Mutex::new(mock_controller::Controller::new(state)));

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -62,7 +62,11 @@ async fn controller_task(state: &'static mock_controller::ControllerState) {
         [(PORT0_ID, POWER0_ID)],
     ));
     static REFERENCED: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let referenced = REFERENCED.init(storage.create_referenced());
+    let referenced = REFERENCED.init(
+        storage
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static CONTROLLER: StaticCell<Mutex<GlobalRawMutex, mock_controller::Controller>> = StaticCell::new();
     let controller = CONTROLLER.init(Mutex::new(mock_controller::Controller::new(state)));

--- a/examples/std/src/bin/type_c/ucsi.rs
+++ b/examples/std/src/bin/type_c/ucsi.rs
@@ -30,7 +30,11 @@ async fn opm_task(spawner: Spawner) {
     static STORAGE0: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
     let storage0 = STORAGE0.init(Storage::new(CONTROLLER0_ID, CFU0_ID, [(PORT0_ID, POWER0_ID)]));
     static REFERENCED0: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let referenced0 = REFERENCED0.init(storage0.create_referenced());
+    let referenced0 = REFERENCED0.init(
+        storage0
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static STATE0: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state0 = STATE0.init(mock_controller::ControllerState::new());
@@ -46,7 +50,11 @@ async fn opm_task(spawner: Spawner) {
     static STORAGE1: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
     let storage1 = STORAGE1.init(Storage::new(CONTROLLER1_ID, CFU1_ID, [(PORT1_ID, POWER1_ID)]));
     static REFERENCED1: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let referenced1 = REFERENCED1.init(storage1.create_referenced());
+    let referenced1 = REFERENCED1.init(
+        storage1
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static STATE1: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state1 = STATE1.init(mock_controller::ControllerState::new());

--- a/examples/std/src/bin/type_c/unconstrained.rs
+++ b/examples/std/src/bin/type_c/unconstrained.rs
@@ -48,7 +48,11 @@ async fn task(spawner: Spawner) {
     static STORAGE: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
     let storage = STORAGE.init(Storage::new(CONTROLLER0_ID, CFU0_ID, [(PORT0_ID, POWER0_ID)]));
     static REFERENCED: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let referenced = REFERENCED.init(storage.create_referenced());
+    let referenced = REFERENCED.init(
+        storage
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static STATE0: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state0 = STATE0.init(mock_controller::ControllerState::new());
@@ -68,7 +72,11 @@ async fn task(spawner: Spawner) {
     static STORAGE1: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
     let storage1 = STORAGE1.init(Storage::new(CONTROLLER1_ID, CFU1_ID, [(PORT1_ID, POWER1_ID)]));
     static REFERENCED1: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let referenced1 = REFERENCED1.init(storage1.create_referenced());
+    let referenced1 = REFERENCED1.init(
+        storage1
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static STATE1: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state1 = STATE1.init(mock_controller::ControllerState::new());
@@ -88,7 +96,11 @@ async fn task(spawner: Spawner) {
     static STORAGE2: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
     let storage2 = STORAGE2.init(Storage::new(CONTROLLER2_ID, CFU2_ID, [(PORT2_ID, POWER2_ID)]));
     static REFERENCED2: StaticCell<ReferencedStorage<1, GlobalRawMutex>> = StaticCell::new();
-    let referenced2 = REFERENCED2.init(storage2.create_referenced());
+    let referenced2 = REFERENCED2.init(
+        storage2
+            .create_referenced()
+            .expect("Failed to create referenced storage"),
+    );
 
     static STATE2: StaticCell<mock_controller::ControllerState> = StaticCell::new();
     let state2 = STATE2.init(mock_controller::ControllerState::new());

--- a/type-c-service/src/service/mod.rs
+++ b/type-c-service/src/service/mod.rs
@@ -104,22 +104,17 @@ impl<'a> Service<'a> {
 
     /// Get the cached port status
     pub async fn get_cached_port_status(&self, port_id: GlobalPortId) -> Result<PortStatus, Error> {
-        if port_id.0 as usize >= MAX_SUPPORTED_PORTS {
-            return Err(Error::InvalidPort);
-        }
-
         let state = self.state.lock().await;
-        Ok(state.port_status[port_id.0 as usize])
+        Ok(*state.port_status.get(port_id.0 as usize).ok_or(Error::InvalidPort)?)
     }
 
     /// Set the cached port status
     async fn set_cached_port_status(&self, port_id: GlobalPortId, status: PortStatus) -> Result<(), Error> {
-        if port_id.0 as usize >= MAX_SUPPORTED_PORTS {
-            return Err(Error::InvalidPort);
-        }
-
         let mut state = self.state.lock().await;
-        state.port_status[port_id.0 as usize] = status;
+        *state
+            .port_status
+            .get_mut(port_id.0 as usize)
+            .ok_or(Error::InvalidPort)? = status;
         Ok(())
     }
 

--- a/type-c-service/src/wrapper/cfu.rs
+++ b/type-c-service/src/wrapper/cfu.rs
@@ -126,7 +126,15 @@ where
         state: &mut dyn DynPortState<'_>,
         content: &FwUpdateContentCommand,
     ) -> InternalResponseData {
-        let data = &content.data[0..content.header.data_length as usize];
+        let data = if let Some(data) = content.data.get(0..content.header.data_length as usize) {
+            data
+        } else {
+            return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                content.header.sequence_num,
+                CfuUpdateContentResponseStatus::ErrorPrepare,
+            ));
+        };
+
         debug!("Got content {:#?}", content);
         if content.header.flags & FW_UPDATE_FLAG_FIRST_BLOCK != 0 {
             debug!("Got first block");

--- a/type-c-service/src/wrapper/vdm.rs
+++ b/type-c-service/src/wrapper/vdm.rs
@@ -41,7 +41,12 @@ where
         let Output { port, kind } = output;
         let global_port_id = self.registration.pd_controller.lookup_global_port(port)?;
         let port_index = port.0 as usize;
-        let notification = &mut state.port_states_mut()[port_index].pending_events.notification;
+        let notification = &mut state
+            .port_states_mut()
+            .get_mut(port_index)
+            .ok_or(PdError::InvalidPort)?
+            .pending_events
+            .notification;
         match kind {
             OutputKind::Entered(_) => notification.set_custom_mode_entered(true),
             OutputKind::Exited(_) => notification.set_custom_mode_exited(true),


### PR DESCRIPTION
# Breaking
Breaking due to `Storage::create_referenced` now returning an `Option<_>`. Migration is to handle the returned option appropriately.