### PR TITLE
keyboard-service: fix syntax error in task macro

### DIFF
--- a/keyboard-service/src/task.rs
+++ b/keyboard-service/src/task.rs
@@ -16,7 +16,7 @@ pub async fn reports_task<T: embedded_hal::digital::OutputPin>(keyboard_interrup
 // this must be a macro until statics are removed.
 #[macro_export]
 macro_rules! impl_host_request_task {
-    ($kb_int_ty:ty) => {
+    ($i2c_slave_ty:ty) => {
         async fn host_requests_task(kb_i2c: $i2c_slave_ty) {
             // Revisit: Make this buffer size configurable?
             embedded_services::define_static_buffer!(hid_buf, u8, [0u8; 256]);


### PR DESCRIPTION
#594 moved the responsibility for declaring async tasks from embedded-services to the application layer.  To support this, some tasks that needed to be generic over a type (which is not directly supported by embassy) made into macros that emit a function that uses a concrete type.  The application layer is required to call that macro and then implement a task that invokes the generated function.

However, in the case of the keyboard service, there appears to be a typo causing the name of the type identifier being passed into the macro to not match the name of the type identifier that is actually used in the macro, resulting in a compilation error whenever a user tries to actually invoke the macro.  This change fixes the typo.