### PR TITLE
buffer: Audit for panics and refactor

### DIFF
--- a/embedded-service/src/hid/command.rs
+++ b/embedded-service/src/hid/command.rs
@@ -485,7 +485,7 @@ impl<'a> Command<'a> {
                 len += register_len;
             }
             Command::SetReport(report_type, report_id, data) => {
-                let borrow = data.borrow();
+                let borrow = data.borrow().map_err(|_| Error::InvalidData)?;
                 let data: &[u8] = borrow.borrow();
 
                 let (command_len, buf) = Self::encode_common(buf, Opcode::SetReport, Some(*report_type), *report_id)?;

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -62,6 +62,14 @@ pub type SyncCell<T> = critical_section_cell::CriticalSectionCell<T>;
 #[cfg(all(not(test), target_os = "none", target_arch = "arm"))]
 pub type SyncCell<T> = thread_mode_cell::ThreadModeCell<T>;
 
+/// Until the Never type (`!`) is stable, the best we have is `Infallible`.
+///
+/// Although they mean the same thing for the most part from the type system pov,
+/// `Never` typically reads better than `Infallible` in some cases.
+///
+/// For example, a result that should never return unless there is an error: `Result<Never, Error>`.
+pub type Never = core::convert::Infallible;
+
 /// initialize all service static interfaces as required. Ideally, this is done before subsystem initialization
 #[allow(clippy::unused_async)]
 pub async fn init() {

--- a/espi-service/src/task.rs
+++ b/espi-service/src/task.rs
@@ -4,7 +4,10 @@ use embedded_services::{comms, ec_type, info};
 
 use crate::{ESPI_SERVICE, Service, process_controller_event};
 
-pub async fn espi_service(mut espi: espi::Espi<'static>, memory_map_buffer: &'static mut [u8]) {
+pub async fn espi_service(
+    mut espi: espi::Espi<'static>,
+    memory_map_buffer: &'static mut [u8],
+) -> Result<embedded_services::Never, crate::espi_service::Error> {
     info!("Reserved eSPI memory map buffer size: {}", memory_map_buffer.len());
     info!("eSPI MemoryMap size: {}", size_of::<ec_type::structure::ECMemory>());
 
@@ -35,7 +38,7 @@ pub async fn espi_service(mut espi: espi::Espi<'static>, memory_map_buffer: &'st
 
         match event {
             embassy_futures::select::Either::First(controller_event) => {
-                process_controller_event(&mut espi, espi_service, controller_event).await
+                process_controller_event(&mut espi, espi_service, controller_event).await?
             }
             embassy_futures::select::Either::Second(host_msg) => {
                 espi_service.process_subsystem_msg(&mut espi, host_msg).await

--- a/examples/rt633/src/bin/espi.rs
+++ b/examples/rt633/src/bin/espi.rs
@@ -98,8 +98,8 @@ unsafe extern "C" {
 
 #[embassy_executor::task]
 async fn espi_service_task(espi: embassy_imxrt::espi::Espi<'static>, memory_map_buffer: &'static mut [u8]) -> ! {
-    espi_service::task::espi_service(espi, memory_map_buffer).await;
-    unreachable!()
+    let Err(e) = espi_service::task::espi_service(espi, memory_map_buffer).await;
+    panic!("espi_service_task error: {e:?}");
 }
 
 #[embassy_executor::main]

--- a/examples/rt633/src/bin/espi_battery.rs
+++ b/examples/rt633/src/bin/espi_battery.rs
@@ -239,8 +239,8 @@ async fn wrapper_task(wrapper: Wrapper<'static, Bq40z50Controller>) {
 
 #[embassy_executor::task]
 async fn espi_service_task(espi: embassy_imxrt::espi::Espi<'static>, memory_map_buffer: &'static mut [u8]) -> ! {
-    espi_service::task::espi_service(espi, memory_map_buffer).await;
-    unreachable!()
+    let Err(e) = espi_service::task::espi_service(espi, memory_map_buffer).await;
+    panic!("espi_service_task error: {e:?}");
 }
 
 #[embassy_executor::task]

--- a/examples/std/src/bin/buffer.rs
+++ b/examples/std/src/bin/buffer.rs
@@ -27,7 +27,7 @@ mod sender {
 
         pub async fn send(&self, even: bool) {
             {
-                let mut borrow = self.buffer.borrow_mut();
+                let mut borrow = self.buffer.borrow_mut().unwrap();
                 let data: &mut [u8] = borrow.borrow_mut();
                 let data = &mut data[0..4];
                 if even {
@@ -69,7 +69,7 @@ mod receiver {
                 .get::<SharedRef<'_, u8>>()
                 .ok_or(comms::MailboxDelegateError::MessageNotFound)?;
 
-            let borrow = data.borrow();
+            let borrow = data.borrow().unwrap();
             let data: &[u8] = borrow.borrow();
             info!("Received data: {data:?}");
 

--- a/examples/std/src/bin/keyboard.rs
+++ b/examples/std/src/bin/keyboard.rs
@@ -25,7 +25,7 @@ mod device {
 
         pub async fn key_down(&self, key: Key) {
             {
-                let mut borrow = self.event_buffer.borrow_mut();
+                let mut borrow = self.event_buffer.borrow_mut().unwrap();
                 let buf: &mut [KeyEvent] = borrow.borrow_mut();
 
                 buf[0] = KeyEvent::Make(key);
@@ -33,14 +33,17 @@ mod device {
 
             keyboard::broadcast_message(
                 self.id,
-                MessageData::Event(Event::KeyEvent(self.id, self.event_buffer.reference().slice(0..1))),
+                MessageData::Event(Event::KeyEvent(
+                    self.id,
+                    self.event_buffer.reference().slice(0..1).unwrap(),
+                )),
             )
             .await;
         }
 
         pub async fn key_up(&self, key: Key) {
             {
-                let mut borrow = self.event_buffer.borrow_mut();
+                let mut borrow = self.event_buffer.borrow_mut().unwrap();
                 let buf: &mut [KeyEvent] = borrow.borrow_mut();
 
                 buf[0] = KeyEvent::Break(key);
@@ -48,7 +51,10 @@ mod device {
 
             keyboard::broadcast_message(
                 self.id,
-                MessageData::Event(Event::KeyEvent(self.id, self.event_buffer.reference().slice(0..1))),
+                MessageData::Event(Event::KeyEvent(
+                    self.id,
+                    self.event_buffer.reference().slice(0..1).unwrap(),
+                )),
             )
             .await;
         }
@@ -84,7 +90,7 @@ mod host {
 
             match &message.data {
                 MessageData::Event(Event::KeyEvent(id, events)) => {
-                    let borrow = events.borrow();
+                    let borrow = events.borrow().unwrap();
                     let buf: &[KeyEvent] = borrow.borrow();
 
                     for event in buf {

--- a/hid-service/src/lib.rs
+++ b/hid-service/src/lib.rs
@@ -9,5 +9,8 @@ pub mod i2c;
 pub enum Error<B> {
     /// Error from the underlying bus
     Bus(B),
+    /// HID error
     Hid(hid::Error),
+    /// Error from the underlying buffer
+    Buffer(embedded_services::buffer::Error),
 }

--- a/keyboard-service/src/gpio_kb.rs
+++ b/keyboard-service/src/gpio_kb.rs
@@ -526,7 +526,7 @@ impl<
         match report_type {
             // Received a set output report for LEDs
             hid::ReportType::Output if report_id.0 == REPORT_ID => {
-                let buf = buf.borrow();
+                let buf = buf.borrow().map_err(super::KeyboardError::Buffer)?;
                 let leds: &[u8] = buf.borrow();
                 let flags = LedFlags::from_bits_retain(leds[0]);
 

--- a/keyboard-service/src/lib.rs
+++ b/keyboard-service/src/lib.rs
@@ -25,6 +25,8 @@ pub enum KeyboardError {
     Ghosting,
     /// Command error
     Command,
+    /// Buffer error
+    Buffer(embedded_services::buffer::Error),
 }
 
 /// A slice of a HID report.

--- a/power-policy-service/src/task.rs
+++ b/power-policy-service/src/task.rs
@@ -1,5 +1,3 @@
-use core::convert::Infallible;
-
 use embassy_sync::once_lock::OnceLock;
 use embedded_services::{comms, error, info};
 
@@ -14,7 +12,7 @@ pub enum InitError {
     RegistrationFailed,
 }
 
-pub async fn task(config: config::Config) -> Result<Infallible, InitError> {
+pub async fn task(config: config::Config) -> Result<embedded_services::Never, InitError> {
     info!("Starting power policy task");
     static POLICY: OnceLock<PowerPolicy> = OnceLock::new();
     let policy = if let Some(policy) = PowerPolicy::create(config) {


### PR DESCRIPTION
Removed panic paths from the `buffer` module. Instead made methods fallible and introduced an `Error` type.

Because certain traits are used with methods that assume infallibility (such as the drop and borrow traits), I couldn't just make these return a result. Instead, I added a `Poisoned` status so in the off chance that a `drop` or `borrow` call would have panicked originally, the buffer is marked poisoned and will return a `Poisoned` error on future accesses.

This also breaks the interfaces of a few services. For these I added a `Buffer` error and made methods fallible if necessary. I'm not a fan of this since any buffer errors represent an internal programming bug to the service and not something the user should expect/handle, and this breaks encapsulation. I do not want to silently just ignore buffer errors, so I'm not sure what other alternative there is here (open to suggestions).

*Edit*: Thinking about maybe renaming the `Buffer` error variant of these services to `Internal` or something. I'd prefer to make it more clear when an error represents an internal invariant being broken that is not something meant to be handled by the caller in any practical manner. It would act as a catchall since the specifics of what caused the error are implementation details that could change any time and not something the caller should be concerned with.

Also introduced a `Never` type alias which is useful now that some functions represent never-ending tasks which should never return unless there is an error (see related discussion: https://github.com/OpenDevicePartnership/embedded-services/pull/634#discussion_r2615419765).

Resolves #659 