### PR TITLE
Add temporary exception for bincode in deny.toml (#669)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ ignore = [
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2024-0436", reason = "there are no suitable replacements for paste right now; paste has been archived as read-only. It only affects compile time concatenation in macros. We will allow it for now" },
     { id = "RUSTSEC-2023-0089", reason = "this is a deprecation warning for a dependency of a dependency. https://github.com/jamesmunns/postcard/issues/223 tracks fixing the dependency; until that's resolved, we can accept the deprecated code as it has no known vulnerabilities." },
+    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained, planning on migrating to an alternative." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Per Matteo:
I saw a regression in our stable/deny CI job. The `bincode` crate is unmaintained and ⁠[it has just been marked as
such](https://github.com/rustsec/advisory-db/pull/2574).

This PR adds an exception to our deny.toml to unblock our CI for now, but we should try to migrate to another serde crate like postcard soon.

Luckily only 2 of our crates use bincode so migration is straightforward:

-
[⁠embedded-usb-pd](https://github.com/OpenDevicePartnership/embedded-usb-pd)
- [tps6699x](https://github.com/OpenDevicePartnership/tps6699x)

Cherry-pick of commit 66c758d72849e41f8994bdae7a532dd4a3264416