### PR TITLE
v0.2.0 mergeback: 01-09-2026 bincode CI regression

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ ignore = [
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2024-0436", reason = "there are no suitable replacements for paste right now; paste has been archived as read-only. It only affects compile time concatenation in macros. We will allow it for now" },
     { id = "RUSTSEC-2023-0089", reason = "this is a deprecation warning for a dependency of a dependency. https://github.com/jamesmunns/postcard/issues/223 tracks fixing the dependency; until that's resolved, we can accept the deprecated code as it has no known vulnerabilities." },
+    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained, planning on migrating to an alternative." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Mergeback commit c7f8e86c33f81da6bbdfd1f80effdb9bfa3dcad0 from #669 into v0.2.0 , which is failing CI.