### PR TITLE
[RFC] Zerocopy for serializing/deserializing ODP service messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ dependencies = [
  "embedded-services",
  "num_enum",
  "uuid",
+ "zerocopy",
 ]
 
 [[package]]

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "embedded-services",
  "num_enum",
  "uuid",
+ "zerocopy",
 ]
 
 [[package]]

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "embedded-services",
  "num_enum",
  "uuid",
+ "zerocopy",
 ]
 
 [[package]]

--- a/examples/std/src/bin/thermal.rs
+++ b/examples/std/src/bin/thermal.rs
@@ -12,7 +12,9 @@ use static_cell::StaticCell;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use thermal_service as ts;
-use thermal_service_messages::ThermalRequest;
+use thermal_service_messages::{
+    ThermalGetTmpRequest, ThermalGetVarRequest, ThermalRequest, ThermalSetThrsRequest, ThermalSetVarRequest,
+};
 use ts::mptf;
 
 // Mock host service
@@ -21,7 +23,7 @@ mod host {
     use embedded_services::comms::{self, Endpoint, EndpointID, External, MailboxDelegate};
     use log::{info, warn};
     use thermal_service as ts;
-    use thermal_service_messages::{ThermalResponse, ThermalResult};
+    use thermal_service_messages::{ThermalGetTmpResponse, ThermalGetVarResponse, ThermalResponse, ThermalResult};
     use ts::mptf;
 
     pub struct Host {
@@ -39,10 +41,10 @@ mod host {
 
         fn handle_response(&self, response: ThermalResponse) {
             match response {
-                ThermalResponse::ThermalGetTmpResponse { temperature } => {
+                ThermalResponse::ThermalGetTmpResponse(ThermalGetTmpResponse { temperature }) => {
                     info!("Host received temperature: {} °C", ts::utils::dk_to_c(temperature))
                 }
-                ThermalResponse::ThermalGetVarResponse { val } => {
+                ThermalResponse::ThermalGetVarResponse(ThermalGetVarResponse { val }) => {
                     info!("Host received fan RPM: {val}")
                 }
                 _ => info!("Received MPTF response: {response:?}"),
@@ -219,12 +221,12 @@ async fn host() {
     host.tp
         .send(
             thermal_id,
-            &ThermalRequest::ThermalSetThrsRequest {
+            &ThermalRequest::ThermalSetThrsRequest(ThermalSetThrsRequest {
                 instance_id: 0,
-                timeout: 0,
-                low: 0,
-                high: 3131,
-            },
+                timeout: 0.into(),
+                low: 0.into(),
+                high: 3131.into(),
+            }),
         )
         .await
         .unwrap();
@@ -234,12 +236,12 @@ async fn host() {
     host.tp
         .send(
             thermal_id,
-            &ThermalRequest::ThermalSetVarRequest {
+            &ThermalRequest::ThermalSetVarRequest(ThermalSetVarRequest {
                 instance_id: 0,
-                len: 4,
+                len: 4.into(),
                 var_uuid: mptf::uuid_standard::FAN_ON_TEMP,
-                set_var: 3131,
-            },
+                set_var: 3131.into(),
+            }),
         )
         .await
         .unwrap();
@@ -249,12 +251,12 @@ async fn host() {
     host.tp
         .send(
             thermal_id,
-            &ThermalRequest::ThermalSetVarRequest {
+            &ThermalRequest::ThermalSetVarRequest(ThermalSetVarRequest {
                 instance_id: 0,
-                len: 4,
+                len: 4.into(),
                 var_uuid: mptf::uuid_standard::FAN_RAMP_TEMP,
-                set_var: 3231,
-            },
+                set_var: 3231.into(),
+            }),
         )
         .await
         .unwrap();
@@ -264,12 +266,12 @@ async fn host() {
     host.tp
         .send(
             thermal_id,
-            &ThermalRequest::ThermalSetVarRequest {
+            &ThermalRequest::ThermalSetVarRequest(ThermalSetVarRequest {
                 instance_id: 0,
-                len: 4,
+                len: 4.into(),
                 var_uuid: mptf::uuid_standard::FAN_MAX_TEMP,
-                set_var: 3531,
-            },
+                set_var: 3531.into(),
+            }),
         )
         .await
         .unwrap();
@@ -281,7 +283,10 @@ async fn host() {
 
         info!("Host requesting temperature in response to threshold alert");
         host.tp
-            .send(thermal_id, &ThermalRequest::ThermalGetTmpRequest { instance_id: 0 })
+            .send(
+                thermal_id,
+                &ThermalRequest::ThermalGetTmpRequest(ThermalGetTmpRequest { instance_id: 0 }),
+            )
             .await
             .unwrap();
 
@@ -292,11 +297,11 @@ async fn host() {
         host.tp
             .send(
                 thermal_id,
-                &ThermalRequest::ThermalGetVarRequest {
+                &ThermalRequest::ThermalGetVarRequest(ThermalGetVarRequest {
                     instance_id: 0,
-                    len: 4,
+                    len: 4.into(),
                     var_uuid: mptf::uuid_standard::FAN_CURRENT_RPM,
-                },
+                }),
             )
             .await
             .unwrap();

--- a/thermal-service-messages/Cargo.toml
+++ b/thermal-service-messages/Cargo.toml
@@ -10,6 +10,7 @@ defmt = { workspace = true, optional = true }
 embedded-services.workspace = true
 num_enum.workspace = true
 uuid.workspace = true
+zerocopy.workspace = true
 
 [lints]
 workspace = true

--- a/thermal-service/src/utils.rs
+++ b/thermal-service/src/utils.rs
@@ -42,10 +42,11 @@ impl<const N: usize> SampleBuf<u16, N> {
 
 /// Convert deciKelvin to degrees Celsius
 pub const fn dk_to_c(dk: thermal_service_messages::DeciKelvin) -> f32 {
-    (dk as f32 / 10.0) - 273.15
+    (dk.get() as f32 / 10.0) - 273.15
 }
 
 /// Convert degrees Celsius to deciKelvin
 pub const fn c_to_dk(c: f32) -> thermal_service_messages::DeciKelvin {
-    ((c + 273.15) * 10.0) as thermal_service_messages::DeciKelvin
+    let dk = ((c + 273.15) * 10.0) as u32;
+    thermal_service_messages::DeciKelvin::new(dk)
 }


### PR DESCRIPTION
This PR demonstrates using zerocopy for serializing instead of doing it manually for thermal service messages (and can be used for all services if this approach seems okay).

Notes:
- Zerocopy is tricky when it comes to alignment and representations. Talking with Billy and we agreed it's pretty hard to get it working on the `ThermalRequest`/`ThermalResponse` enums themselves, so I derived the appropriate traits for structs which the enums wrapped, then just pattern match over the enum.
- Had to use the `zerocopy::byteorder::U<N>` types to ensure LE representation on the wire (in the very rare case this is running on BE-native hardware) and to force alignment of fields to 1 (since zerocopy does not allow padding and a `#repr(packed)` could cause issues when accessing the fields from Rust code).
- Those `U<N>` types unfortunately don't impl `defmt::Format` so had to manually do it (might try to upstream defmt support)
- The `mctp_rs` trait methods require serializing into a buffer, instead of just returning a `&[u8]`, so because of that, we lose the zero-copy benefit from zerocopy (and are really just using it for its serialization abilities)

The goal is also eventually to have these service message crates be useable from other areas than just the EC (such as host-side secure services).


