### PR TITLE
Power policy refactor

### DIFF
--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -5,7 +5,7 @@ pub mod device;
 pub mod flags;
 pub mod policy;
 
-pub use policy::{init, register_device};
+pub use policy::init;
 
 use crate::power::policy::charger::ChargerError;
 

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -1,5 +1,4 @@
 //! Context for any power policy implementations
-use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::GlobalRawMutex;
 use crate::broadcaster::immediate as broadcaster;
@@ -11,9 +10,6 @@ use super::device::{self};
 use super::{DeviceId, Error, action, charger};
 use crate::power::policy::charger::ChargerResponseData::Ack;
 use crate::{error, intrusive_list};
-
-/// Number of slots for policy requests
-const POLICY_CHANNEL_SIZE: usize = 1;
 
 /// Data for a power policy request
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,212 +68,200 @@ pub struct Response {
 type InternalResponseData = Result<ResponseData, Error>;
 
 /// Power policy context
-struct Context {
+pub struct Context<const POLICY_CHANNEL_SIZE: usize> {
     /// Registered devices
-    devices: intrusive_list::IntrusiveList,
+    power_devices: intrusive_list::IntrusiveList,
     /// Policy request
     policy_request: Channel<GlobalRawMutex, Request, POLICY_CHANNEL_SIZE>,
     /// Policy response
     policy_response: Channel<GlobalRawMutex, InternalResponseData, POLICY_CHANNEL_SIZE>,
     /// Registered chargers
-    chargers: intrusive_list::IntrusiveList,
+    charger_devices: intrusive_list::IntrusiveList,
     /// Message broadcaster
     broadcaster: broadcaster::Immediate<CommsMessage>,
 }
 
-impl Context {
-    const fn new() -> Self {
+impl<const POLICY_CHANNEL_SIZE: usize> Default for Context<POLICY_CHANNEL_SIZE> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const POLICY_CHANNEL_SIZE: usize> Context<POLICY_CHANNEL_SIZE> {
+    /// Construct a new power policy Context
+    pub const fn new() -> Self {
         Self {
-            devices: intrusive_list::IntrusiveList::new(),
-            chargers: intrusive_list::IntrusiveList::new(),
+            power_devices: intrusive_list::IntrusiveList::new(),
+            charger_devices: intrusive_list::IntrusiveList::new(),
             policy_request: Channel::new(),
             policy_response: Channel::new(),
             broadcaster: broadcaster::Immediate::new(),
         }
     }
-}
 
-static CONTEXT: Context = Context::new();
-
-/// Init power policy service
-pub fn init() {}
-
-/// Register a device with the power policy service
-pub fn register_device(device: &'static impl device::DeviceContainer) -> Result<(), intrusive_list::Error> {
-    let device = device.get_power_policy_device();
-    if get_device(device.id()).is_some() {
-        return Err(intrusive_list::Error::NodeAlreadyInList);
-    }
-
-    CONTEXT.devices.push(device)
-}
-
-/// Register a charger with the power policy service
-pub fn register_charger(device: &'static impl charger::ChargerContainer) -> Result<(), intrusive_list::Error> {
-    let device = device.get_charger();
-    if get_charger(device.id()).is_some() {
-        return Err(intrusive_list::Error::NodeAlreadyInList);
-    }
-
-    CONTEXT.chargers.push(device)
-}
-
-/// Find a device by its ID
-fn get_device(id: DeviceId) -> Option<&'static device::Device> {
-    for device in &CONTEXT.devices {
-        if let Some(data) = device.data::<device::Device>() {
-            if data.id() == id {
-                return Some(data);
-            }
-        } else {
-            error!("Non-device located in devices list");
+    /// Register a device with the power policy service
+    pub fn register_device(
+        &self,
+        device: &'static impl device::DeviceContainer<POLICY_CHANNEL_SIZE>,
+    ) -> Result<(), intrusive_list::Error> {
+        let device = device.get_power_policy_device();
+        if self.get_device(device.id()).is_ok() {
+            return Err(intrusive_list::Error::NodeAlreadyInList);
         }
+
+        self.power_devices.push(device)
     }
 
-    None
-}
+    /// Register a charger with the power policy service
+    pub fn register_charger(
+        &self,
+        device: &'static impl charger::ChargerContainer,
+    ) -> Result<(), intrusive_list::Error> {
+        let device = device.get_charger();
+        if self.get_charger(device.id()).is_ok() {
+            return Err(intrusive_list::Error::NodeAlreadyInList);
+        }
 
-/// Returns the total amount of power that is being supplied to external devices
-pub async fn compute_total_provider_power_mw() -> u32 {
-    let mut total = 0;
-    for device in CONTEXT.devices.iter_only::<device::Device>() {
-        if let Some(capability) = device.provider_capability().await {
-            if device.is_provider().await {
-                total += capability.capability.max_power_mw();
+        self.charger_devices.push(device)
+    }
+
+    /// Get a device by its ID
+    pub fn get_device(&self, id: DeviceId) -> Result<&'static device::Device<POLICY_CHANNEL_SIZE>, Error> {
+        for device in &self.power_devices {
+            if let Some(data) = device.data::<device::Device<POLICY_CHANNEL_SIZE>>() {
+                if data.id() == id {
+                    return Ok(data);
+                }
+            } else {
+                error!("Non-device located in devices list");
             }
         }
-    }
-    total
-}
 
-/// Find a device by its ID
-fn get_charger(id: charger::ChargerId) -> Option<&'static charger::Device> {
-    for charger in &CONTEXT.chargers {
-        if let Some(data) = charger.data::<charger::Device>() {
-            if data.id() == id {
-                return Some(data);
+        Err(Error::InvalidDevice)
+    }
+
+    /// Returns the total amount of power that is being supplied to external devices
+    pub async fn compute_total_provider_power_mw(&self) -> u32 {
+        let mut total = 0;
+        for device in self.power_devices.iter_only::<device::Device<POLICY_CHANNEL_SIZE>>() {
+            if let Some(capability) = device.provider_capability().await {
+                if device.is_provider().await {
+                    total += capability.capability.max_power_mw();
+                }
             }
-        } else {
-            error!("Non-device located in charger list");
         }
+        total
     }
 
-    None
-}
-
-/// Convenience function to send a request to the power policy service
-pub(super) async fn send_request(from: DeviceId, request: RequestData) -> Result<ResponseData, Error> {
-    CONTEXT
-        .policy_request
-        .send(Request {
-            id: from,
-            data: request,
-        })
-        .await;
-    CONTEXT.policy_response.receive().await
-}
-
-/// Initialize chargers in hardware
-pub async fn init_chargers() -> ChargerResponse {
-    for charger in &CONTEXT.chargers {
-        if let Some(data) = charger.data::<charger::Device>() {
-            data.execute_command(charger::PolicyEvent::InitRequest)
-                .await
-                .inspect_err(|e| error!("Charger {:?} failed InitRequest: {:?}", data.id(), e))?;
+    /// Get a charger by its ID
+    pub fn get_charger(&self, id: charger::ChargerId) -> Result<&'static charger::Device, Error> {
+        for charger in &self.charger_devices {
+            if let Some(data) = charger.data::<charger::Device>() {
+                if data.id() == id {
+                    return Ok(data);
+                }
+            } else {
+                error!("Non-device located in charger list");
+            }
         }
+
+        Err(Error::InvalidDevice)
     }
-    Ok(Ack)
-}
 
-/// Check if charger hardware is ready for communications.
-pub async fn check_chargers_ready() -> ChargerResponse {
-    for charger in &CONTEXT.chargers {
-        if let Some(data) = charger.data::<charger::Device>() {
-            data.execute_command(charger::PolicyEvent::CheckReady)
-                .await
-                .inspect_err(|e| error!("Charger {:?} failed CheckReady: {:?}", data.id(), e))?;
-        }
+    /// Convenience function to send a request to the power policy service
+    pub(super) async fn send_request(&self, from: DeviceId, request: RequestData) -> Result<ResponseData, Error> {
+        self.policy_request
+            .send(Request {
+                id: from,
+                data: request,
+            })
+            .await;
+        self.policy_response.receive().await
     }
-    Ok(Ack)
-}
 
-/// Register a message receiver for power policy messages
-pub fn register_message_receiver(
-    receiver: &'static broadcaster::Receiver<'_, CommsMessage>,
-) -> intrusive_list::Result<()> {
-    CONTEXT.broadcaster.register_receiver(receiver)
-}
-
-/// Singleton struct to give access to the power policy context
-pub struct ContextToken(());
-
-impl ContextToken {
-    /// Create a new context token, returning None if this function has been called before
-    pub fn create() -> Option<Self> {
-        static INIT: AtomicBool = AtomicBool::new(false);
-        if INIT.load(Ordering::SeqCst) {
-            return None;
+    /// Initialize chargers in hardware
+    pub async fn init_chargers(&self) -> ChargerResponse {
+        for charger in &self.charger_devices {
+            if let Some(data) = charger.data::<charger::Device>() {
+                data.execute_command(charger::PolicyEvent::InitRequest)
+                    .await
+                    .inspect_err(|e| error!("Charger {:?} failed InitRequest: {:?}", data.id(), e))?;
+            }
         }
+        Ok(Ack)
+    }
 
-        INIT.store(true, Ordering::SeqCst);
-        Some(ContextToken(()))
+    /// Check if charger hardware is ready for communications.
+    pub async fn check_chargers_ready(&self) -> ChargerResponse {
+        for charger in &self.charger_devices {
+            if let Some(data) = charger.data::<charger::Device>() {
+                data.execute_command(charger::PolicyEvent::CheckReady)
+                    .await
+                    .inspect_err(|e| error!("Charger {:?} failed CheckReady: {:?}", data.id(), e))?;
+            }
+        }
+        Ok(Ack)
+    }
+
+    /// Register a message receiver for power policy messages
+    pub fn register_message_receiver(
+        &self,
+        receiver: &'static broadcaster::Receiver<'_, CommsMessage>,
+    ) -> intrusive_list::Result<()> {
+        self.broadcaster.register_receiver(receiver)
     }
 
     /// Initialize Policy charger devices
-    pub async fn init() -> Result<(), Error> {
+    pub async fn init(&self) -> Result<(), Error> {
         // Check if the chargers are powered and able to communicate
-        check_chargers_ready().await?;
+        self.check_chargers_ready().await?;
         // Initialize chargers
-        init_chargers().await?;
+        self.init_chargers().await?;
 
         Ok(())
     }
 
     /// Wait for a power policy request
     pub async fn wait_request(&self) -> Request {
-        CONTEXT.policy_request.receive().await
+        self.policy_request.receive().await
     }
 
     /// Send a response to a power policy request
     pub async fn send_response(&self, response: Result<ResponseData, Error>) {
-        CONTEXT.policy_response.send(response).await
-    }
-
-    /// Get a device by its ID
-    pub fn get_device(&self, id: DeviceId) -> Result<&'static device::Device, Error> {
-        get_device(id).ok_or(Error::InvalidDevice)
+        self.policy_response.send(response).await
     }
 
     /// Provides access to the device list
     pub fn devices(&self) -> &intrusive_list::IntrusiveList {
-        &CONTEXT.devices
-    }
-
-    /// Get a charger by its ID
-    pub fn get_charger(&self, id: charger::ChargerId) -> Result<&'static charger::Device, Error> {
-        get_charger(id).ok_or(Error::InvalidDevice)
+        &self.power_devices
     }
 
     /// Provides access to the charger list
     pub fn chargers(&self) -> &intrusive_list::IntrusiveList {
-        &CONTEXT.chargers
+        &self.charger_devices
     }
 
     /// Try to provide access to the actions available to the policy for the given state and device
     pub async fn try_policy_action<S: action::Kind>(
         &self,
         id: DeviceId,
-    ) -> Result<action::policy::Policy<'_, S>, Error> {
+    ) -> Result<action::policy::Policy<'_, S, POLICY_CHANNEL_SIZE>, Error> {
         self.get_device(id)?.try_policy_action().await
     }
 
     /// Provide access to current policy actions
-    pub async fn policy_action(&self, id: DeviceId) -> Result<action::policy::AnyState<'_>, Error> {
+    pub async fn policy_action(
+        &self,
+        id: DeviceId,
+    ) -> Result<action::policy::AnyState<'_, POLICY_CHANNEL_SIZE>, Error> {
         Ok(self.get_device(id)?.policy_action().await)
     }
 
     /// Broadcast a power policy message to all subscribers
     pub async fn broadcast_message(&self, message: CommsMessage) {
-        CONTEXT.broadcaster.broadcast(message).await;
+        self.broadcaster.broadcast(message).await;
     }
 }
+
+/// Init power policy service
+pub fn init() {}

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -47,7 +47,7 @@ impl type_c_service::wrapper::FwOfferValidator for Validator {
 type BusMaster<'a> = I2cMaster<'a, Async>;
 type BusDevice<'a> = I2cDevice<'a, GlobalRawMutex, BusMaster<'a>>;
 type Tps6699xMutex<'a> = Mutex<GlobalRawMutex, tps6699x_drv::Tps6699x<'a, GlobalRawMutex, BusDevice<'a>>>;
-type Wrapper<'a> = ControllerWrapper<'a, GlobalRawMutex, Tps6699xMutex<'a>, Validator>;
+type Wrapper<'a> = ControllerWrapper<'a, GlobalRawMutex, Tps6699xMutex<'a>, Validator, POLICY_CHANNEL_SIZE>;
 type Controller<'a> = tps6699x::controller::Controller<GlobalRawMutex, BusDevice<'a>>;
 type Interrupt<'a> = tps6699x::Interrupt<'a, GlobalRawMutex, BusDevice<'a>>;
 
@@ -58,6 +58,8 @@ const PORT0_ID: GlobalPortId = GlobalPortId(0);
 const PORT1_ID: GlobalPortId = GlobalPortId(1);
 const PORT0_PWR_ID: PowerId = PowerId(0);
 const PORT1_PWR_ID: PowerId = PowerId(1);
+
+const POLICY_CHANNEL_SIZE: usize = 1;
 
 #[embassy_executor::task]
 async fn pd_controller_task(controller: &'static Wrapper<'static>) {
@@ -154,10 +156,14 @@ async fn fw_update_task() {
 }
 
 #[embassy_executor::task]
-async fn power_policy_service_task() {
-    power_policy_service::task::task(Default::default())
-        .await
-        .expect("Failed to start power policy service task");
+async fn power_policy_service_task(policy: &'static power_policy_service::PowerPolicy<POLICY_CHANNEL_SIZE>) {
+    power_policy_service::task::task(
+        policy,
+        None::<[&rt685s_evk_example::DummyPowerDevice<POLICY_CHANNEL_SIZE>; 0]>,
+        None::<[&rt685s_evk_example::DummyCharger; 0]>,
+    )
+    .await
+    .expect("Failed to start power policy service task");
 }
 
 #[embassy_executor::task]
@@ -165,6 +171,7 @@ async fn service_task(
     controller_context: &'static Context,
     controllers: &'static IntrusiveList,
     wrappers: [&'static Wrapper<'static>; NUM_PD_CONTROLLERS],
+    power_policy_context: &'static embedded_services::power::policy::policy::Context<POLICY_CHANNEL_SIZE>,
 ) -> ! {
     info!("Starting type-c task");
 
@@ -187,7 +194,7 @@ async fn service_task(
     static SERVICE: StaticCell<Service> = StaticCell::new();
     let service = SERVICE.init(service);
 
-    type_c_service::task::task(service, wrappers).await;
+    type_c_service::task::task(service, wrappers, power_policy_context).await;
     unreachable!()
 }
 
@@ -199,7 +206,13 @@ async fn main(spawner: Spawner) {
     embedded_services::init().await;
 
     info!("Spawining power policy task");
-    spawner.must_spawn(power_policy_service_task());
+
+    static POWER_POLICY_SERVICE: StaticCell<power_policy_service::PowerPolicy<POLICY_CHANNEL_SIZE>> = StaticCell::new();
+    let power_service = POWER_POLICY_SERVICE.init(power_policy_service::PowerPolicy::new(
+        power_policy_service::Config::default(),
+    ));
+
+    spawner.must_spawn(power_policy_service_task(power_service));
 
     static CONTROLLER_LIST: StaticCell<IntrusiveList> = StaticCell::new();
     let controllers = CONTROLLER_LIST.init(IntrusiveList::new());
@@ -238,15 +251,17 @@ async fn main(spawner: Spawner) {
         .await
         .unwrap();
 
-    static STORAGE: StaticCell<Storage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
+    static STORAGE: StaticCell<Storage<TPS66994_NUM_PORTS, GlobalRawMutex, POLICY_CHANNEL_SIZE>> = StaticCell::new();
     let storage = STORAGE.init(Storage::new(
         controller_context,
         CONTROLLER0_ID,
         CONTROLLER0_CFU_ID,
         [(PORT0_ID, PORT0_PWR_ID), (PORT1_ID, PORT1_PWR_ID)],
+        &power_service.context,
     ));
 
-    static REFERENCED: StaticCell<ReferencedStorage<TPS66994_NUM_PORTS, GlobalRawMutex>> = StaticCell::new();
+    static REFERENCED: StaticCell<ReferencedStorage<TPS66994_NUM_PORTS, GlobalRawMutex, POLICY_CHANNEL_SIZE>> =
+        StaticCell::new();
     let referenced = REFERENCED.init(
         storage
             .create_referenced()
@@ -262,7 +277,12 @@ async fn main(spawner: Spawner) {
         WRAPPER.init(ControllerWrapper::try_new(controller_mutex, Default::default(), referenced, Validator).unwrap());
 
     info!("Spawning type-c service task");
-    spawner.must_spawn(service_task(controller_context, controllers, [wrapper]));
+    spawner.must_spawn(service_task(
+        controller_context,
+        controllers,
+        [wrapper],
+        &power_service.context,
+    ));
 
     spawner.must_spawn(pd_controller_task(wrapper));
 

--- a/examples/rt685s-evk/src/lib.rs
+++ b/examples/rt685s-evk/src/lib.rs
@@ -18,3 +18,21 @@ static BOOT_IMAGE_VERSION: u32 = 0x01000000;
 #[unsafe(link_section = ".keystore")]
 #[used]
 static KEYSTORE: [u8; 2048] = [0; 2048];
+
+pub struct DummyCharger(embedded_services::power::policy::charger::Device);
+impl embedded_services::power::policy::charger::ChargerContainer for DummyCharger {
+    fn get_charger(&self) -> &embedded_services::power::policy::charger::Device {
+        &self.0
+    }
+}
+
+pub struct DummyPowerDevice<const POLICY_CHANNEL_SIZE: usize>(
+    embedded_services::power::policy::device::Device<POLICY_CHANNEL_SIZE>,
+);
+impl<const POLICY_CHANNEL_SIZE: usize> embedded_services::power::policy::device::DeviceContainer<POLICY_CHANNEL_SIZE>
+    for DummyPowerDevice<POLICY_CHANNEL_SIZE>
+{
+    fn get_power_policy_device(&self) -> &embedded_services::power::policy::device::Device<POLICY_CHANNEL_SIZE> {
+        &self.0
+    }
+}

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -18,6 +18,8 @@ use embedded_usb_pd::{type_c::ConnectionState, ucsi::lpm};
 use log::{debug, info, trace};
 use std::cell::Cell;
 
+const POWER_POLICY_CHANNEL_SIZE: usize = 1;
+
 pub struct ControllerState {
     events: Signal<GlobalRawMutex, PortEvent>,
     status: Mutex<GlobalRawMutex, PortStatus>,
@@ -336,5 +338,10 @@ impl type_c_service::wrapper::FwOfferValidator for Validator {
     }
 }
 
-pub type Wrapper<'a> =
-    type_c_service::wrapper::ControllerWrapper<'a, GlobalRawMutex, Mutex<GlobalRawMutex, Controller<'a>>, Validator>;
+pub type Wrapper<'a> = type_c_service::wrapper::ControllerWrapper<
+    'a,
+    GlobalRawMutex,
+    Mutex<GlobalRawMutex, Controller<'a>>,
+    Validator,
+    POWER_POLICY_CHANNEL_SIZE,
+>;

--- a/examples/std/src/lib/type_c/mod.rs
+++ b/examples/std/src/lib/type_c/mod.rs
@@ -1,1 +1,19 @@
 pub mod mock_controller;
+
+pub struct DummyCharger(embedded_services::power::policy::charger::Device);
+impl embedded_services::power::policy::charger::ChargerContainer for DummyCharger {
+    fn get_charger(&self) -> &embedded_services::power::policy::charger::Device {
+        &self.0
+    }
+}
+
+pub struct DummyPowerDevice<const POLICY_CHANNEL_SIZE: usize>(
+    embedded_services::power::policy::device::Device<POLICY_CHANNEL_SIZE>,
+);
+impl<const POLICY_CHANNEL_SIZE: usize> embedded_services::power::policy::device::DeviceContainer<POLICY_CHANNEL_SIZE>
+    for DummyPowerDevice<POLICY_CHANNEL_SIZE>
+{
+    fn get_power_policy_device(&self) -> &embedded_services::power::policy::device::Device<POLICY_CHANNEL_SIZE> {
+        &self.0
+    }
+}

--- a/power-policy-service/src/provider.rs
+++ b/power-policy-service/src/provider.rs
@@ -25,7 +25,7 @@ pub(super) struct State {
     state: PowerState,
 }
 
-impl PowerPolicy {
+impl<const POLICY_CHANNEL_SIZE: usize> PowerPolicy<POLICY_CHANNEL_SIZE> {
     /// Attempt to connect the requester as a provider
     pub(super) async fn connect_provider(&self, requester_id: DeviceId) {
         trace!("Device{}: Attempting to connect as provider", requester_id.0);
@@ -48,7 +48,11 @@ impl PowerPolicy {
         let mut total_power_mw = 0;
 
         // Determine total requested power draw
-        for device in self.context.devices().iter_only::<device::Device>() {
+        for device in self
+            .context
+            .devices()
+            .iter_only::<device::Device<POLICY_CHANNEL_SIZE>>()
+        {
             let target_provider_cap = if device.id() == requester_id {
                 // Use the requester's requested power capability
                 // this handles both new connections and upgrade requests

--- a/power-policy-service/src/task.rs
+++ b/power-policy-service/src/task.rs
@@ -1,30 +1,77 @@
-use embassy_sync::once_lock::OnceLock;
-use embedded_services::{comms, error, info};
+use embedded_services::{
+    comms, error, info,
+    power::policy::{charger, device},
+};
 
-use crate::{PowerPolicy, config};
+use crate::PowerPolicy;
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum InitError {
-    /// Power policy singleton has already been initialized
-    AlreadyInitialized,
     /// Comms registration failed
     RegistrationFailed,
+    /// Power device registration failed
+    PowerDeviceRegistrationFailed,
+    /// Charger device registration failed
+    ChargerDeviceRegistrationFailed,
 }
 
-pub async fn task(config: config::Config) -> Result<embedded_services::Never, InitError> {
+/// Initializes and runs the power policy task.
+///
+/// This task function initializes the power policy service by registering its endpoint
+/// with the comms layer, registering any provided **non Type-C** power devices and charger devices,
+/// and then continuously processes incoming power policy requests. It should be run as its own task
+/// that never returns.
+///
+/// # Generic Parameters
+///
+/// * `POLICY_CHANNEL_SIZE` - The capacity of the channel used for power policy messages.
+/// * `NUM_POWER_DEVICES` - The number of **non Type-C** power devices to be managed by power policy.
+/// * `NUM_CHARGERS` - The number of charger devices to be managed by power policy.
+///
+/// # Arguments
+///
+/// * `policy` - A static reference to the [`PowerPolicy`] instance that manages power policies.
+/// * `power_devices` - An optional array of static references to **non Type-C** power device containers.
+///   If provided, each device will be registered with the policy context.
+/// * `charger_devices` - An optional array of static references to charger device containers.
+///   If provided, each charger will be registered with the policy context.
+///
+/// # Returns
+///
+/// Returns `Result<embedded_services::Never, InitError>`. The `Never` type indicates that
+/// this function runs indefinitely once initialized. The function returns an error if
+/// initialization fails at any stage:
+/// - [`InitError::RegistrationFailed`] - if comms endpoint registration fails
+/// - [`InitError::PowerDeviceRegistrationFailed`] - if power device registration fails
+/// - [`InitError::ChargerDeviceRegistrationFailed`] - if charger device registration fails
+pub async fn task<const POLICY_CHANNEL_SIZE: usize, const NUM_POWER_DEVICES: usize, const NUM_CHARGERS: usize>(
+    policy: &'static PowerPolicy<POLICY_CHANNEL_SIZE>,
+    power_devices: Option<[&'static impl device::DeviceContainer<POLICY_CHANNEL_SIZE>; NUM_POWER_DEVICES]>,
+    charger_devices: Option<[&'static impl charger::ChargerContainer; NUM_CHARGERS]>,
+) -> Result<embedded_services::Never, InitError> {
     info!("Starting power policy task");
-    static POLICY: OnceLock<PowerPolicy> = OnceLock::new();
-    let policy = if let Some(policy) = PowerPolicy::create(config) {
-        POLICY.get_or_init(|| policy)
-    } else {
-        error!("Power policy service already initialized");
-        return Err(InitError::AlreadyInitialized);
-    };
-
     if comms::register_endpoint(policy, &policy.tp).await.is_err() {
         error!("Failed to register power policy endpoint");
         return Err(InitError::RegistrationFailed);
+    }
+
+    if let Some(power_devices) = power_devices {
+        for device in power_devices {
+            policy
+                .context
+                .register_device(device)
+                .map_err(|_| InitError::PowerDeviceRegistrationFailed)?;
+        }
+    }
+
+    if let Some(charger_devices) = charger_devices {
+        for device in charger_devices {
+            policy
+                .context
+                .register_charger(device)
+                .map_err(|_| InitError::ChargerDeviceRegistrationFailed)?;
+        }
     }
 
     loop {

--- a/type-c-service/src/service/mod.rs
+++ b/type-c-service/src/service/mod.rs
@@ -252,8 +252,11 @@ impl<'a> Service<'a> {
     }
 
     /// Register the Type-C service with the power policy service
-    pub fn register_comms(&'static self) -> Result<(), intrusive_list::Error> {
-        power_policy::policy::register_message_receiver(&self.power_policy_event_publisher)
+    pub fn register_comms<const POLICY_CHANNEL_SIZE: usize>(
+        &'static self,
+        power_policy_context: &power_policy::policy::Context<POLICY_CHANNEL_SIZE>,
+    ) -> Result<(), intrusive_list::Error> {
+        power_policy_context.register_message_receiver(&self.power_policy_event_publisher)
     }
 
     pub(crate) fn controllers(&self) -> &'a intrusive_list::IntrusiveList {

--- a/type-c-service/src/task.rs
+++ b/type-c-service/src/task.rs
@@ -4,9 +4,19 @@ use embedded_services::{error, info};
 use crate::{service::Service, wrapper::ControllerWrapper};
 
 /// Task to run the Type-C service, takes a closure to customize the event loop
-pub async fn task_closure<'a, M, C, V, Fut: Future<Output = ()>, F: Fn(&'a Service) -> Fut, const N: usize>(
+pub async fn task_closure<
+    'a,
+    M,
+    C,
+    V,
+    Fut: Future<Output = ()>,
+    F: Fn(&'a Service) -> Fut,
+    const N: usize,
+    const POLICY_CHANNEL_SIZE: usize,
+>(
     service: &'static Service<'a>,
-    wrappers: [&'a ControllerWrapper<'a, M, C, V>; N],
+    wrappers: [&'a ControllerWrapper<'a, M, C, V, POLICY_CHANNEL_SIZE>; N],
+    power_policy_context: &'a embedded_services::power::policy::policy::Context<POLICY_CHANNEL_SIZE>,
     f: F,
 ) where
     M: embassy_sync::blocking_mutex::raw::RawMutex,
@@ -16,13 +26,17 @@ pub async fn task_closure<'a, M, C, V, Fut: Future<Output = ()>, F: Fn(&'a Servi
 {
     info!("Starting type-c task");
 
-    if service.register_comms().is_err() {
+    if service.register_comms(power_policy_context).is_err() {
         error!("Failed to register type-c service endpoint");
         return;
     }
 
     for controller_wrapper in wrappers {
-        if controller_wrapper.register(service.controllers()).await.is_err() {
+        if controller_wrapper
+            .register(service.controllers(), power_policy_context)
+            .await
+            .is_err()
+        {
             error!("Failed to register a controller");
             return;
         }
@@ -34,16 +48,17 @@ pub async fn task_closure<'a, M, C, V, Fut: Future<Output = ()>, F: Fn(&'a Servi
 }
 
 /// Task to run the Type-C service, running the default event loop
-pub async fn task<'a, M, C, V, const N: usize>(
+pub async fn task<'a, M, C, V, const N: usize, const POLICY_CHANNEL_SIZE: usize>(
     service: &'static Service<'a>,
-    wrappers: [&'a ControllerWrapper<'a, M, C, V>; N],
+    wrappers: [&'a ControllerWrapper<'a, M, C, V, POLICY_CHANNEL_SIZE>; N],
+    power_policy_context: &'a embedded_services::power::policy::policy::Context<POLICY_CHANNEL_SIZE>,
 ) where
     M: embassy_sync::blocking_mutex::raw::RawMutex,
     C: embedded_services::sync::Lockable,
     V: crate::wrapper::FwOfferValidator,
     <C as embedded_services::sync::Lockable>::Inner: embedded_services::type_c::controller::Controller,
 {
-    task_closure(service, wrappers, |service: &Service| async {
+    task_closure(service, wrappers, power_policy_context, |service: &Service| async {
         if let Err(e) = service.process_next_event().await {
             error!("Type-C service processing error: {:#?}", e);
         }

--- a/type-c-service/src/wrapper/cfu.rs
+++ b/type-c-service/src/wrapper/cfu.rs
@@ -29,7 +29,8 @@ impl FwUpdateState {
     }
 }
 
-impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator> ControllerWrapper<'device, M, C, V>
+impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator, const POLICY_CHANNEL_SIZE: usize>
+    ControllerWrapper<'device, M, C, V, POLICY_CHANNEL_SIZE>
 where
     <C as Lockable>::Inner: Controller,
 {

--- a/type-c-service/src/wrapper/dp.rs
+++ b/type-c-service/src/wrapper/dp.rs
@@ -4,7 +4,8 @@ use embassy_sync::blocking_mutex::raw::RawMutex;
 use embedded_services::{sync::Lockable, trace, type_c::controller::Controller};
 use embedded_usb_pd::{Error, LocalPortId};
 
-impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator> ControllerWrapper<'device, M, C, V>
+impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator, const POLICY_CHANNEL_SIZE: usize>
+    ControllerWrapper<'device, M, C, V, POLICY_CHANNEL_SIZE>
 where
     <C as Lockable>::Inner: Controller,
 {

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -9,7 +9,8 @@ use embedded_usb_pd::ucsi::{self, lpm};
 
 use super::*;
 
-impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator> ControllerWrapper<'device, M, C, V>
+impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator, const POLICY_CHANNEL_SIZE: usize>
+    ControllerWrapper<'device, M, C, V, POLICY_CHANNEL_SIZE>
 where
     <C as Lockable>::Inner: Controller,
 {

--- a/type-c-service/src/wrapper/vdm.rs
+++ b/type-c-service/src/wrapper/vdm.rs
@@ -13,7 +13,8 @@ use crate::wrapper::{DynPortState, message::vdm::OutputKind};
 
 use super::{ControllerWrapper, FwOfferValidator, message::vdm::Output};
 
-impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator> ControllerWrapper<'device, M, C, V>
+impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator, const POLICY_CHANNEL_SIZE: usize>
+    ControllerWrapper<'device, M, C, V, POLICY_CHANNEL_SIZE>
 where
     <C as Lockable>::Inner: Controller,
 {


### PR DESCRIPTION
Part of the larger embedded-services refactor work.

Power policy v0.2.0 refactor

- Make power policy context explicit, generic, and injectable
- Remove all global/singleton usage, making the context generic over channel size and requiring explicit passing of context references
- Updates all examples and Type-C service code to use explicit, generic policy context parameters