### PR TITLE
Add audit for assert_approx_eq crate

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -21,6 +21,11 @@ who = "jerrysxie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.2.1"
 
+[[audits.assert_approx_eq]]
+who = "Douglas Cheah <douglascheah@microsoft.com>"
+criteria = "safe-to-run"
+version = "1.1.0"
+
 [[audits.backtrace]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-run"


### PR DESCRIPTION
The assert_approx_eq crate introduce an assertation check for float types which checks float value within a tolerance. This is useful for testing and is currently already used in some drivers. Those repo currently does not have vetting enabled yet so adding this to ODP's centralize list. 

Audit"
The assert_approx_eq macro compares the 2 float value and ensure the difference is within tolerance.