### PR TITLE
Thermal service refactor

### DIFF
--- a/thermal-service/src/context.rs
+++ b/thermal-service/src/context.rs
@@ -16,7 +16,7 @@ pub(crate) struct Context {
 }
 
 impl Context {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             sensors: intrusive_list::IntrusiveList::new(),
             fans: intrusive_list::IntrusiveList::new(),

--- a/thermal-service/src/task.rs
+++ b/thermal-service/src/task.rs
@@ -1,17 +1,18 @@
 use embedded_services::{comms, error};
 
-use crate::{self as ts, mptf::process_request};
+use crate::mptf::process_request;
 
-pub async fn handle_requests() {
+pub async fn handle_requests(service: &'static crate::Service) {
     loop {
-        let request = ts::wait_mptf_request().await;
-        let result = process_request(&request).await;
-        let send_result = ts::send_service_msg(
-            // TODO we should probably respond to the endpoint that requested us rather than hardcoding the return address like this
-            comms::EndpointID::External(comms::External::Host),
-            &result,
-        )
-        .await;
+        let request = service.wait_mptf_request().await;
+        let result = process_request(&request, service).await;
+        let send_result = service
+            .send_service_msg(
+                // TODO we should probably respond to the endpoint that requested us rather than hardcoding the return address like this
+                comms::EndpointID::External(comms::External::Host),
+                &result,
+            )
+            .await;
 
         if send_result.is_err() {
             error!("Failed to send response to MPTF request!");
@@ -21,12 +22,19 @@ pub async fn handle_requests() {
 
 pub async fn fan_task<T: crate::fan::Controller, const SAMPLE_BUF_LEN: usize>(
     fan: &'static crate::fan::Fan<T, SAMPLE_BUF_LEN>,
+    thermal_service: &'static crate::Service,
 ) {
-    let _ = embassy_futures::join::join3(fan.handle_rx(), fan.handle_sampling(), fan.handle_auto_control()).await;
+    let _ = embassy_futures::join::join3(
+        fan.handle_rx(),
+        fan.handle_sampling(),
+        fan.handle_auto_control(thermal_service),
+    )
+    .await;
 }
 
 pub async fn sensor_task<T: crate::sensor::Controller, const SAMPLE_BUF_LEN: usize>(
     sensor: &'static crate::sensor::Sensor<T, SAMPLE_BUF_LEN>,
+    thermal_service: &'static crate::Service,
 ) {
-    let _ = embassy_futures::join::join(sensor.handle_rx(), sensor.handle_sampling()).await;
+    let _ = embassy_futures::join::join(sensor.handle_rx(), sensor.handle_sampling(thermal_service)).await;
 }


### PR DESCRIPTION
Depends on #700 

Thermal service refactor

- Enforce initialization order by forcing registration of all objects before a Service instance can be constructed
- Replace free functions with methods on the Service
- All tasks need an instance of Service to be initialized before any message passing logic starts
- Updated std example