### PR TITLE
time-alarm-service-messages: Make discriminants pub

### DIFF
--- a/time-alarm-service-messages/src/lib.rs
+++ b/time-alarm-service-messages/src/lib.rs
@@ -28,7 +28,7 @@ pub enum AcpiTimeAlarmRequest {
 #[derive(Clone, Copy, Debug, PartialEq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive)]
 #[repr(u16)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-enum AcpiTimeAlarmRequestDiscriminant {
+pub enum AcpiTimeAlarmRequestDiscriminant {
     GetCapabilities = 1,
     GetRealTime = 2,
     SetRealTime = 3,
@@ -249,7 +249,7 @@ pub enum AcpiTimeAlarmResponse {
 
 #[derive(Copy, Clone, Debug, PartialEq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive)]
 #[repr(u16)]
-enum AcpiTimeAlarmResponseDiscriminant {
+pub enum AcpiTimeAlarmResponseDiscriminant {
     Capabilities = 1,
     RealTime = 2,
     TimerStatus = 3,


### PR DESCRIPTION
If we want to deserialize a time-alarm response, we need to know the discriminant: https://github.com/OpenDevicePartnership/embedded-services/blob/16c4364c8c8c6b61c9c01661c8d1488cb55fd6aa/time-alarm-service-messages/src/lib.rs#L292

However, we can't call the trait method `discriminant()` yet since we don't have a constructed `AcpiTimeAlarmResponse`. So, make the `Discriminant` enums public so we can use that to pass a value into `deserialize` for the response type we are expecting.

This is needed for ec-test-app, e.g.:

```rust
impl RtcSource for Serial {
    fn get_capabilities(&self) -> Result<TimeAlarmDeviceCapabilities> {
        let request = AcpiTimeAlarmRequest::GetCapabilities;
        let response = self.send(
            Destination::TimeAlarm,
            request,
            // Need to pass in the expected discriminant to deserialize (which send() calls)
            // If not pub, then we would need to hardcode values here
            AcpiTimeAlarmResponseDiscriminant::Capabilities.into(),
        )?;

        if let AcpiTimeAlarmResponse::Capabilities(capabilities) = response {
            Ok(capabilities)
        } else {
            Err(eyre!("GET_CAPABILITIES received wrong response"))
        }
    }
}
```