### PR TITLE
Charger: cache power capability sent from power policy if charger is still initializing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,14 +201,6 @@ dependencies = [
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238#2f79d238149049d458199a9a9129b54be7893aee"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "bit-register"
-version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
 dependencies = [
  "num-traits",
@@ -246,17 +238,6 @@ name = "bitfield-macros"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52511b09931f7d5fe3a14f23adefbc23e5725b184013e96c8419febb61f14734"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "bitfield-struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -687,24 +668,11 @@ dependencies = [
 
 [[package]]
 name = "embedded-batteries"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e14d288a59ef41f4e05468eae9b1c9fef6866977cea86d3f1a1ced295b6cab"
-dependencies = [
- "bitfield-struct 0.10.1",
- "bitflags 2.9.4",
- "defmt 0.3.100",
- "embedded-hal 1.0.0",
- "zerocopy",
-]
-
-[[package]]
-name = "embedded-batteries"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40f975432b4e146342a1589c563cffab6b7a692024cb511bf87b6bfe78c84125"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct",
  "bitflags 2.9.4",
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
@@ -717,9 +685,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3bf0e4be67770cfc31f1cea8b73baf98c0baf2c57d6bd8c3a4c315acb1d8bd4"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct",
  "defmt 0.3.100",
- "embedded-batteries 0.3.4",
+ "embedded-batteries",
  "embedded-hal 1.0.0",
 ]
 
@@ -913,9 +881,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#8cdd61095471903b1b438dbb0eee142676cc3d74"
+source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#9805f13c044b0e314d415410c57a8a59a40eabeb"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238)",
+ "bit-register",
  "bitflags 2.9.4",
  "num-traits",
  "num_enum",
@@ -1255,11 +1223,11 @@ dependencies = [
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/dymk/mctp-rs#4456c65131366acd5e605c7d88a707881fa9e9f0"
+source = "git+https://github.com/dymk/mctp-rs#3d941ba5205ca7781bf37e3dc7c5dfdc99a082d6"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
+ "bit-register",
  "defmt 0.3.100",
- "embedded-batteries 0.2.1",
+ "embedded-batteries",
  "espi-device",
  "num_enum",
  "smbus-pec",

--- a/embedded-service/src/power/policy/charger.rs
+++ b/embedded-service/src/power/policy/charger.rs
@@ -8,8 +8,6 @@ use crate::{
     power::{self, policy::ConsumerPowerCapability},
 };
 
-use super::PowerCapability;
-
 /// Charger controller trait that device drivers may use to integrate with internal messaging system
 pub trait ChargeController: embedded_batteries_async::charger::Charger {
     /// Type of error returned by the bus
@@ -153,7 +151,7 @@ pub struct InternalState {
     /// Charger device state
     pub state: State,
     /// Current charger capability
-    pub capability: Option<PowerCapability>,
+    pub capability: Option<ConsumerPowerCapability>,
 }
 
 /// Channel size for device requests


### PR DESCRIPTION
Cache power capability sent from power policy if charger is still initializing. After initialization completes, write cached power capability to the charger hardware.