### PR TITLE
type-c-service: Don't restart sink ready timeout if contract is same

### DIFF
--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -262,10 +262,7 @@ where
             state,
             &status,
             local_port_id,
-            status_event
-                .new_power_contract_as_consumer()
-                .then_some(status.available_sink_contract)
-                .flatten(),
+            status_event.new_power_contract_as_consumer(),
             status_event.sink_ready(),
         )?;
 


### PR DESCRIPTION
In certain cases, we can receive repeated source capabilities messages. This will reset the sink ready timeout and lead to a situation where we are never able to sink from the source. Only restart the timer if we get a different contract.