### PR TITLE
[RFC] Notification/Standard broadcasting v2

### DIFF
--- a/battery-service-messages/src/lib.rs
+++ b/battery-service-messages/src/lib.rs
@@ -675,3 +675,8 @@ fn safe_put_bytes(buffer: &mut [u8], index: usize, bytes: &[u8]) -> Result<usize
         .copy_from_slice(bytes);
     Ok(bytes.len())
 }
+
+/// Message type for the Battery service.
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct BatteryMessage;

--- a/battery-service/src/lib.rs
+++ b/battery-service/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::{any::Any, convert::Infallible};
 
-use battery_service_messages::{AcpiBatteryError, AcpiBatteryRequest, AcpiBatteryResult};
+use battery_service_messages::{AcpiBatteryError, AcpiBatteryRequest, AcpiBatteryResult, BatteryMessage};
 use context::BatteryEvent;
 use embedded_services::{
     comms::{self, EndpointID},
@@ -107,6 +107,7 @@ impl Default for Service {
 impl embedded_services::relay::mctp::RelayServiceHandlerTypes for Service {
     type RequestType = AcpiBatteryRequest;
     type ResultType = AcpiBatteryResult;
+    type MessageType = BatteryMessage;
 }
 
 impl embedded_services::relay::mctp::RelayServiceHandler for Service {
@@ -117,6 +118,10 @@ impl embedded_services::relay::mctp::RelayServiceHandler for Service {
             error!("Battery service command failed: {:?}", e)
         }
         response
+    }
+
+    fn is_notification(_message: &Self::MessageType) -> bool {
+        true
     }
 }
 

--- a/debug-service-messages/src/lib.rs
+++ b/debug-service-messages/src/lib.rs
@@ -125,3 +125,8 @@ impl SerializableMessage for DebugError {
 }
 
 pub type DebugResult = Result<DebugResponse, DebugError>;
+
+/// Message type for the Debug service.
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DebugMessage;

--- a/debug-service/src/debug_service.rs
+++ b/debug-service/src/debug_service.rs
@@ -1,4 +1,4 @@
-use debug_service_messages::{DebugRequest, DebugResult};
+use debug_service_messages::{DebugMessage, DebugRequest, DebugResult};
 use embassy_sync::{once_lock::OnceLock, signal::Signal};
 use embedded_services::GlobalRawMutex;
 use embedded_services::buffer::{OwnedRef, SharedRef};
@@ -37,6 +37,7 @@ impl Service {
 impl embedded_services::relay::mctp::RelayServiceHandlerTypes for Service {
     type RequestType = DebugRequest;
     type ResultType = DebugResult;
+    type MessageType = DebugMessage;
 }
 
 impl embedded_services::relay::mctp::RelayServiceHandler for Service {
@@ -51,6 +52,10 @@ impl embedded_services::relay::mctp::RelayServiceHandler for Service {
         }
 
         frame_ready_signal().wait().await
+    }
+
+    fn is_notification(_message: &Self::MessageType) -> bool {
+        true
     }
 }
 

--- a/embedded-service/src/broadcaster/mod.rs
+++ b/embedded-service/src/broadcaster/mod.rs
@@ -1,2 +1,3 @@
 //! Module for common event/message broadcasting functionality
 pub mod immediate;
+pub mod single_publisher;

--- a/embedded-service/src/broadcaster/single_publisher.rs
+++ b/embedded-service/src/broadcaster/single_publisher.rs
@@ -1,0 +1,100 @@
+//! Single-publisher broadcast channel.
+//!
+//! A wrapper around [`embassy_sync::pubsub::PubSubChannel`] that enforces exactly one publisher
+//! with any number of subscribers. The inner channel is hardcoded with `PUBS = 1`, so attempting
+//! to create a second publisher returns [`embassy_sync::pubsub::Error::MaximumPublishersReached`].
+
+use embassy_sync::pubsub::{self, DynPublisher, DynSubscriber, PubSubChannel};
+
+use crate::GlobalRawMutex;
+
+/// A broadcast channel that allows only a single publisher and multiple subscribers.
+///
+/// Wraps [`PubSubChannel`] with `PUBS` fixed to `1`. The returned [`DynPublisher`] supports
+/// [`publish`](DynPublisher::publish), [`try_publish`](DynPublisher::try_publish), and
+/// [`publish_immediate`](DynPublisher::publish_immediate).
+pub struct SinglePublisherChannel<T: Clone, const CAP: usize, const SUBS: usize> {
+    inner: PubSubChannel<GlobalRawMutex, T, CAP, SUBS, 1>,
+}
+
+impl<T: Clone, const CAP: usize, const SUBS: usize> SinglePublisherChannel<T, CAP, SUBS> {
+    /// Create a new `SinglePublisherChannel`.
+    pub const fn new() -> Self {
+        Self {
+            inner: PubSubChannel::new(),
+        }
+    }
+
+    /// Obtain the single publisher for this channel.
+    ///
+    /// Returns [`pubsub::Error::MaximumPublishersReached`] if a publisher has already been created.
+    pub fn publisher(&self) -> Result<DynPublisher<'_, T>, pubsub::Error> {
+        self.inner.dyn_publisher()
+    }
+
+    /// Create a subscriber to this channel.
+    ///
+    /// Returns [`pubsub::Error::MaximumSubscribersReached`] if all subscriber slots are in use.
+    pub fn subscriber(&self) -> Result<DynSubscriber<'_, T>, pubsub::Error> {
+        self.inner.dyn_subscriber()
+    }
+}
+
+impl<T: Clone, const CAP: usize, const SUBS: usize> Default for SinglePublisherChannel<T, CAP, SUBS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use super::*;
+    use embassy_sync::pubsub::WaitResult;
+    use static_cell::StaticCell;
+
+    /// Test that a single publisher can send a message received by a subscriber.
+    #[tokio::test]
+    async fn test_publish_and_receive() {
+        static CHANNEL: StaticCell<SinglePublisherChannel<u32, 4, 1>> = StaticCell::new();
+        let channel = CHANNEL.init(SinglePublisherChannel::new());
+
+        let publisher = channel.publisher().unwrap();
+        let mut subscriber = channel.subscriber().unwrap();
+
+        publisher.publish_immediate(42);
+
+        let message = subscriber.next_message().await;
+        assert_eq!(message, WaitResult::Message(42));
+    }
+
+    /// Test that creating a second publisher returns an error.
+    #[tokio::test]
+    async fn test_second_publisher_rejected() {
+        static CHANNEL: StaticCell<SinglePublisherChannel<u32, 4, 1>> = StaticCell::new();
+        let channel = CHANNEL.init(SinglePublisherChannel::new());
+
+        let _publisher = channel.publisher().unwrap();
+        let result = channel.publisher();
+
+        assert!(matches!(result, Err(pubsub::Error::MaximumPublishersReached)));
+    }
+
+    /// Test that multiple subscribers all receive the same broadcasted message.
+    #[tokio::test]
+    async fn test_multiple_subscribers() {
+        static CHANNEL: StaticCell<SinglePublisherChannel<u32, 4, 3>> = StaticCell::new();
+        let channel = CHANNEL.init(SinglePublisherChannel::new());
+
+        let publisher = channel.publisher().unwrap();
+        let mut sub1 = channel.subscriber().unwrap();
+        let mut sub2 = channel.subscriber().unwrap();
+        let mut sub3 = channel.subscriber().unwrap();
+
+        publisher.publish_immediate(99);
+
+        assert_eq!(sub1.next_message().await, WaitResult::Message(99));
+        assert_eq!(sub2.next_message().await, WaitResult::Message(99));
+        assert_eq!(sub3.next_message().await, WaitResult::Message(99));
+    }
+}

--- a/embedded-service/src/lib.rs
+++ b/embedded-service/src/lib.rs
@@ -29,6 +29,7 @@ pub mod sync;
 #[doc(hidden)]
 pub mod _macro_internal {
     pub use bitfield;
+    pub use embassy_sync;
     pub use mctp_rs;
     pub use paste;
 }

--- a/embedded-service/src/relay/mod.rs
+++ b/embedded-service/src/relay/mod.rs
@@ -116,6 +116,9 @@ pub mod mctp {
 
         /// The result type that this service handler processes
         type ResultType: super::SerializableResult;
+
+        /// The message type that this service broadcasts
+        type MessageType;
     }
 
     /// Trait for a service that can be relayed over an external bus (e.g. battery service, thermal service, time-alarm service)
@@ -125,7 +128,10 @@ pub mod mctp {
         fn process_request<'a>(
             &'a self,
             request: Self::RequestType,
-        ) -> impl core::future::Future<Output = Self::ResultType> + Send + 'a;
+        ) -> impl core::future::Future<Output = Self::ResultType> + 'a;
+
+        /// Returns whether the given message should be treated as a relay notification.
+        fn is_notification(message: &Self::MessageType) -> bool;
     }
 
     // Traits below this point are intended for consumption by relay services (e.g. the eSPI service), not individual services that want their messages relayed.
@@ -168,7 +174,10 @@ pub mod mctp {
         fn process_request<'a>(
             &'a self,
             message: Self::RequestEnumType,
-        ) -> impl core::future::Future<Output = Self::ResultEnumType> + Send + 'a;
+        ) -> impl core::future::Future<Output = Self::ResultEnumType> + 'a;
+
+        /// Wait for a notification from any service and return the associated service notification ID.
+        fn wait_for_notification<'a>(&'a mut self) -> impl core::future::Future<Output = u8> + 'a;
     }
 
     /// This macro generates a relay type over a collection of message types, which can be used by a relay service to
@@ -184,11 +193,12 @@ pub mod mctp {
     ///   relay_type_name: The name of the relay type to generate. This is arbitrary. The macro will emit a type with this name.
     ///
     /// Followed by a list of any number of service entries, which are specified by the following inputs:
-    ///   service_name:         A name to assign to generated identifiers associated with the service, e.g. "Battery".
-    ///                         This can be arbitrary.
-    ///   service_id:           A unique u8 that addresses that service on the EC.
-    ///   service_handler_type: A type that implements the RelayServiceHandler trait, which will be used to process messages
-    ///                         for this service.
+    ///   service_name:            A name to assign to generated identifiers associated with the service, e.g. "Battery".
+    ///                            This can be arbitrary.
+    ///   service_id:              A unique u8 that addresses that service on the EC.
+    ///   service_notification_id: A unique u8 identifying notifications from this service, distinct from service_id.
+    ///   service_handler_type:    A type that implements the RelayServiceHandler trait, which will be used to process messages
+    ///                            for this service.
     ///
     /// Example usage:
     ///
@@ -196,8 +206,8 @@ pub mod mctp {
     ///
     ///     impl_odp_mctp_relay_handler!(
     ///         MyRelayHanderType;
-    ///         Battery,   0x9, battery_service::Service<'static>;
-    ///         TimeAlarm, 0xB, time_alarm_service::Service<'static>;
+    ///         Battery,   0x9, 0, battery_service::Service<'static>;
+    ///         TimeAlarm, 0xB, 1, time_alarm_service::Service<'static>;
     ///     );
     ///
     ///     let relay_handler = MyRelayHandlerType::new(battery_service_instance, time_alarm_service_instance);
@@ -213,6 +223,7 @@ pub mod mctp {
             $(
                 $service_name:ident,
                 $service_id:expr,
+                $service_notification_id:expr,
                 $service_handler_type:ty;
             )+
         ) => {
@@ -451,6 +462,7 @@ pub mod mctp {
                     pub struct $relay_type_name<'hw> {
                         $(
                             [<$service_name:snake _handler>]: &'hw $service_handler_type,
+                            [<$service_name:snake _subscriber>]: $crate::_macro_internal::embassy_sync::pubsub::DynSubscriber<'hw, <$service_handler_type as $crate::relay::mctp::RelayServiceHandlerTypes>::MessageType>,
                         )+
                     }
 
@@ -458,11 +470,13 @@ pub mod mctp {
                         pub fn new(
                             $(
                                 [<$service_name:snake _handler>]: &'hw $service_handler_type,
+                                [<$service_name:snake _subscriber>]: $crate::_macro_internal::embassy_sync::pubsub::DynSubscriber<'hw, <$service_handler_type as $crate::relay::mctp::RelayServiceHandlerTypes>::MessageType>,
                             )+
                         ) -> Self {
                             Self {
                                 $(
                                     [<$service_name:snake _handler>],
+                                    [<$service_name:snake _subscriber>],
                                 )+
                             }
                         }
@@ -477,7 +491,7 @@ pub mod mctp {
                         fn process_request<'a>(
                             &'a self,
                             message: HostRequest,
-                        ) -> impl core::future::Future<Output = HostResult> + Send + 'a {
+                        ) -> impl core::future::Future<Output = HostResult> + 'a {
                             async move {
                                 match message {
                                     $(
@@ -486,6 +500,49 @@ pub mod mctp {
                                             HostResult::$service_name(result)
                                         }
                                     )+
+                                }
+                            }
+                        }
+
+                        // This waits for any relayable service to publish a message, then it checks if the message is a notification.
+                        // If it is, it returns associated notification ID as defined by the macro.
+                        // The relay service can then use this ID to determine how to notify the host SoC.
+                        fn wait_for_notification<'a>(&'a mut self) -> impl core::future::Future<Output = u8> + 'a {
+                            async move {
+                                loop {
+                                    $(
+                                        let mut [<$service_name:snake _fut>] = core::pin::pin!(
+                                            self.[<$service_name:snake _subscriber>].next_message()
+                                        );
+                                    )+
+
+                                    let result = core::future::poll_fn(|cx| {
+                                        $(
+                                            if let core::task::Poll::Ready(wait_result) = [<$service_name:snake _fut>].as_mut().poll(cx) {
+                                                match wait_result {
+                                                    $crate::_macro_internal::embassy_sync::pubsub::WaitResult::Message(msg) => {
+                                                        if <$service_handler_type as $crate::relay::mctp::RelayServiceHandler>::is_notification(&msg) {
+                                                            return core::task::Poll::Ready(Some($service_notification_id));
+                                                        } else {
+                                                            return core::task::Poll::Ready(None);
+                                                        }
+                                                    }
+                                                    $crate::_macro_internal::embassy_sync::pubsub::WaitResult::Lagged(count) => {
+                                                        // Revisit: This can only happen if other services use a `publish_immediate` on their channel, which can result in older messages getting discarded.
+                                                        // We really don't want notifications potentially getting lost, so we could change `SinglePublisherChannel` to not allow immediate publishing,
+                                                        // or we could just keep the burden on services so they have the flexibility to use `publish_immediate` if they want to at the risk of their own notifications being lost.
+                                                        $crate::error!("[Relay] {} subscriber lagged by {} messages, notifications may have been lost", stringify!($service_name), count);
+                                                        return core::task::Poll::Ready(None);
+                                                    }
+                                                }
+                                            }
+                                        )+
+                                        core::task::Poll::Pending
+                                    }).await;
+
+                                    if let Some(id) = result {
+                                        return id;
+                                    }
                                 }
                             }
                         }

--- a/espi-service/src/espi_service.rs
+++ b/espi-service/src/espi_service.rs
@@ -1,6 +1,6 @@
 use core::slice;
 
-use embassy_futures::select::select;
+use embassy_futures::select::{Either3, select3};
 use embassy_imxrt::espi;
 use embassy_sync::channel::Channel;
 use embassy_sync::mutex::Mutex;
@@ -44,7 +44,7 @@ impl<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler> Default fo
 
 /// Service runner for the eSPI service.  Users must call the run() method on the runner for the service to start processing events.
 pub struct Runner<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler> {
-    inner: &'hw ServiceInner<'hw, RelayHandler>,
+    inner: &'hw mut ServiceInner<'hw, RelayHandler>,
 }
 
 impl<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler>
@@ -57,7 +57,7 @@ impl<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler>
 }
 
 pub struct Service<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler> {
-    _inner: &'hw ServiceInner<'hw, RelayHandler>,
+    _phantom: core::marker::PhantomData<&'hw RelayHandler>,
 }
 
 impl<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler> odp_service_common::runnable_service::Service<'hw>
@@ -73,7 +73,12 @@ impl<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler> odp_servic
         params: InitParams<'hw, RelayHandler>,
     ) -> Result<(Self, Self::Runner), core::convert::Infallible> {
         let inner = resources.inner.insert(ServiceInner::new(params).await);
-        Ok((Self { _inner: inner }, Runner { inner }))
+        Ok((
+            Self {
+                _phantom: core::marker::PhantomData,
+            },
+            Runner { inner },
+        ))
     }
 }
 
@@ -99,33 +104,32 @@ impl<'hw, RelayHandler: embedded_services::relay::mctp::RelayHandler> ServiceInn
         }
     }
 
-    async fn run(&self) -> embedded_services::Never {
+    async fn run(&mut self) -> embedded_services::Never {
         let mut espi = self.espi.lock().await;
         loop {
-            let event = select(espi.wait_for_event(), self.host_tx_queue.receive()).await;
+            let event = select3(
+                espi.wait_for_event(),
+                self.host_tx_queue.receive(),
+                self.relay_handler.wait_for_notification(),
+            )
+            .await;
 
             match event {
-                embassy_futures::select::Either::First(controller_event) => {
+                Either3::First(controller_event) => {
                     self.process_controller_event(&mut espi, controller_event)
                         .await
                         .unwrap_or_else(|e| {
                             error!("Critical error processing eSPI controller event: {:?}", e);
                         });
                 }
-                embassy_futures::select::Either::Second(host_msg) => {
-                    self.process_response_to_host(&mut espi, host_msg).await
+                Either3::Second(host_msg) => self.process_response_to_host(&mut espi, host_msg).await,
+                Either3::Third(notification_offset) => {
+                    espi.irq_push(notification_offset).await;
+                    info!("espi: Notification offset {} sent to Host!", notification_offset);
                 }
             }
         }
     }
-
-    // TODO The notification system was not actually used, so this is currently dead code.
-    //      We need to implement some interface for triggering notifications from other subsystems, and it may do something like this:
-    //
-    // async fn process_notification_to_host(&self, espi: &mut espi::Espi<'_>, notification: &NotificationMsg) {
-    //     espi.irq_push(notification.offset).await;
-    //     info!("espi: Notification id {} sent to Host!", notification.offset);
-    // }
 
     fn write_to_hw(&self, espi: &mut espi::Espi<'hw>, packet: &[u8]) -> Result<(), embassy_imxrt::espi::Error> {
         // Send packet via your transport medium

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -608,25 +608,13 @@ dependencies = [
 
 [[package]]
 name = "embedded-batteries"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e14d288a59ef41f4e05468eae9b1c9fef6866977cea86d3f1a1ced295b6cab"
-dependencies = [
- "bitfield-struct",
- "bitflags 2.9.4",
- "defmt 0.3.100",
- "embedded-hal 1.0.0",
- "zerocopy",
-]
-
-[[package]]
-name = "embedded-batteries"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b8996d7168535579180a0eead82efaba718ebd598782f986bfd635458259df2"
 dependencies = [
  "bitfield-struct",
  "bitflags 2.9.4",
+ "defmt 0.3.100",
  "embedded-hal 1.0.0",
  "zerocopy",
 ]
@@ -638,14 +626,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6465f32edac01ccd4d55931896177b3a61a5286205c5269f30b91ce7dbf51b5e"
 dependencies = [
  "bitfield-struct",
- "embedded-batteries 0.3.1",
+ "embedded-batteries",
  "embedded-hal 1.0.0",
 ]
 
 [[package]]
 name = "embedded-cfu-protocol"
 version = "0.2.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#a4cc8707842b878048447abbf2af4efa79fed368"
+source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#e0d776017cf34c902c9f2a2be0c75fe73a3a4dda"
 dependencies = [
  "defmt 0.3.100",
  "embedded-io-async",
@@ -788,7 +776,7 @@ dependencies = [
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#e9c43ec493ba9c4e3db84c73530f919448c07b6d"
+source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#79e24eca20cfe0d32b491fd4d0562bc87aa358ca"
 dependencies = [
  "bit-register",
  "bitflags 2.9.4",
@@ -1027,11 +1015,11 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/dymk/mctp-rs#f3121512468e4776c4b1d2d648b54c7271b97bd9"
+source = "git+https://github.com/dymk/mctp-rs#3d941ba5205ca7781bf37e3dc7c5dfdc99a082d6"
 dependencies = [
  "bit-register",
  "defmt 0.3.100",
- "embedded-batteries 0.2.1",
+ "embedded-batteries",
  "espi-device",
  "num_enum",
  "smbus-pec",

--- a/examples/rt685s-evk/src/bin/time_alarm.rs
+++ b/examples/rt685s-evk/src/bin/time_alarm.rs
@@ -5,9 +5,12 @@ use embedded_mcu_hal::{
     Nvram,
     time::{Datetime, Month, UncheckedDatetime},
 };
+use embedded_services::broadcaster::single_publisher::SinglePublisherChannel;
 use embedded_services::info;
 use static_cell::StaticCell;
-use time_alarm_service_messages::{AcpiDaylightSavingsTimeStatus, AcpiTimeZone, AcpiTimeZoneOffset, AcpiTimestamp};
+use time_alarm_service_messages::{
+    AcpiDaylightSavingsTimeStatus, AcpiTimeZone, AcpiTimeZoneOffset, AcpiTimestamp, TimeAlarmMessage,
+};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -23,6 +26,13 @@ async fn main(spawner: embassy_executor::Spawner) {
     embedded_services::init().await;
     info!("services initialized");
 
+    // All services will basically need to create a SinglePublisherChannel for themsevles.
+    // The idea is they consume the sole DynPublisher while anyone who wants to listen to the service
+    // will then consume a DynSubscriber from this channel.
+    static TIME_ALARM_CHANNEL: SinglePublisherChannel<TimeAlarmMessage, 1, 1> = SinglePublisherChannel::new();
+    let time_alarm_publisher = TIME_ALARM_CHANNEL.publisher().unwrap();
+    let time_alarm_subscriber = TIME_ALARM_CHANNEL.subscriber().unwrap();
+
     let time_service = odp_service_common::spawn_service!(
         spawner,
         time_alarm_service::Service<'static>,
@@ -32,18 +42,25 @@ async fn main(spawner: embassy_executor::Spawner) {
             ac_expiration_storage: ac_expiration,
             ac_policy_storage: ac_policy,
             dc_expiration_storage: dc_expiration,
-            dc_policy_storage: dc_policy
+            dc_policy_storage: dc_policy,
+            message_publisher: time_alarm_publisher
         }
     )
     .expect("Failed to spawn time alarm service");
 
+    // Now in the macro we need to associate a notification ID with each service specified here.
+    // This is distinct from service_id (which, in this example, is 0x0B for the time alarm service),
+    // since the service_id is used for routing purposes whereas the notification_id is used
+    // to identify, for example, which IRQ offset to use in the espi service
     use embedded_services::relay::mctp::impl_odp_mctp_relay_handler;
     impl_odp_mctp_relay_handler!(
         EspiRelayHandler;
-        TimeAlarm, 0x0B, time_alarm_service::Service<'static>;
+        TimeAlarm, 0x0B, 1 /* Notification id example */, time_alarm_service::Service<'static>;
     );
 
-    let _relay_handler = EspiRelayHandler::new(&time_service);
+    // Here we pass a subscriber into the relay handler so it can listen for notifications from the time alarm service
+    // and then relay those to the host SoC over eSPI when they occur
+    let _relay_handler = EspiRelayHandler::new(&time_service, time_alarm_subscriber);
 
     // Here, you'd normally pass _relay_handler to your relay service (e.g. eSPI service).
     // In this example, we're not leveraging a relay service, so we'll just demonstrate some direct calls.

--- a/thermal-service-messages/src/lib.rs
+++ b/thermal-service-messages/src/lib.rs
@@ -328,3 +328,8 @@ fn safe_put_uuid(buffer: &mut [u8], index: usize, uuid: uuid::Bytes) -> Result<u
         .copy_from_slice(&uuid);
     Ok(16)
 }
+
+/// Message type for the Thermal service.
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ThermalMessage;

--- a/thermal-service/src/lib.rs
+++ b/thermal-service/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 
 use embedded_sensors_hal_async::temperature::DegreesCelsius;
-use thermal_service_messages::{ThermalRequest, ThermalResult};
+use thermal_service_messages::{ThermalMessage, ThermalRequest, ThermalResult};
 
 mod context;
 pub mod fan;
@@ -93,10 +93,15 @@ impl<'hw> Service<'hw> {
 impl<'hw> embedded_services::relay::mctp::RelayServiceHandlerTypes for Service<'hw> {
     type RequestType = ThermalRequest;
     type ResultType = ThermalResult;
+    type MessageType = ThermalMessage;
 }
 
 impl<'hw> embedded_services::relay::mctp::RelayServiceHandler for Service<'hw> {
     async fn process_request(&self, request: Self::RequestType) -> Self::ResultType {
         mptf::process_request(&request, self).await
+    }
+
+    fn is_notification(_message: &Self::MessageType) -> bool {
+        true
     }
 }

--- a/time-alarm-service-messages/src/lib.rs
+++ b/time-alarm-service-messages/src/lib.rs
@@ -386,3 +386,10 @@ fn safe_get_u32(buffer: &[u8], index: usize) -> Result<u32, MessageSerialization
         .map_err(|_| MessageSerializationError::BufferTooSmall)?;
     Ok(u32::from_le_bytes(bytes))
 }
+
+/// Notification type for the Time Alarm service.
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TimeAlarmMessage {
+    TimerExpired,
+}

--- a/time-alarm-service/src/lib.rs
+++ b/time-alarm-service/src/lib.rs
@@ -2,6 +2,7 @@
 
 use core::cell::RefCell;
 use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::pubsub::DynPublisher;
 use embassy_sync::signal::Signal;
 use embedded_mcu_hal::NvramStorage;
 use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError};
@@ -110,6 +111,7 @@ pub struct InitParams<'hw> {
     pub ac_policy_storage: &'hw mut dyn NvramStorage<'hw, u32>,
     pub dc_expiration_storage: &'hw mut dyn NvramStorage<'hw, u32>,
     pub dc_policy_storage: &'hw mut dyn NvramStorage<'hw, u32>,
+    pub message_publisher: DynPublisher<'hw, TimeAlarmMessage>,
 }
 
 /// The main service implementation.  Users will interact with this via the Service struct, which is a thin wrapper around this that allows
@@ -123,6 +125,8 @@ struct ServiceInner<'hw> {
     timers: Timers<'hw>,
 
     capabilities: TimeAlarmDeviceCapabilities,
+
+    message_publisher: DynPublisher<'hw, TimeAlarmMessage>,
 }
 
 impl<'hw> ServiceInner<'hw> {
@@ -153,6 +157,7 @@ impl<'hw> ServiceInner<'hw> {
                 caps.set_dc_s5_wake_supported(true);
                 caps
             },
+            message_publisher: init_params.message_publisher,
         }
     }
 
@@ -284,7 +289,9 @@ impl<'hw> ServiceInner<'hw> {
                 "[Time/Alarm] Timer {:?} expired and would trigger a wake now, but the power service is not yet implemented so will currently do nothing",
                 timer_id
             );
-            // TODO [COMMS] We can't currently trigger a wake because the power service isn't implemented yet - when it is, we need to notify it here
+
+            // TAS notifies anyone who is interested that a timer has expired (including relay and power service)
+            self.message_publisher.publish(TimeAlarmMessage::TimerExpired).await;
         }
     }
 }
@@ -397,6 +404,7 @@ impl<'hw> odp_service_common::runnable_service::Service<'hw> for Service<'hw> {
 impl<'hw> embedded_services::relay::mctp::RelayServiceHandlerTypes for Service<'hw> {
     type RequestType = AcpiTimeAlarmRequest;
     type ResultType = AcpiTimeAlarmResult;
+    type MessageType = TimeAlarmMessage;
 }
 
 impl<'hw> embedded_services::relay::mctp::RelayServiceHandler for Service<'hw> {
@@ -431,5 +439,9 @@ impl<'hw> embedded_services::relay::mctp::RelayServiceHandler for Service<'hw> {
                 Ok(AcpiTimeAlarmResponse::TimerSeconds(self.get_timer_value(timer_id)?))
             }
         }
+    }
+
+    fn is_notification(message: &Self::MessageType) -> bool {
+        matches!(message, TimeAlarmMessage::TimerExpired)
     }
 }


### PR DESCRIPTION
This RFC is another attempt at designing a notification system (see #741) that's hopefully a bit more closely aligned to what everyone's thinking. Additionally, tried to attempt a form of standardization for service message broadcasting based on some discussions I had offline with Billy.

At a high level, basically what I'm thinking is:

- Have a wrapper around a `PubSubChannel` I call `SinglePublisherChannel` that only allows a single `DynPublisher` (intended to be consumed by a single service) but `SUBS` number of `DynSubscriber`s. The dyn variants were used since the cost of dynamic dispatch seems minimal and this helps prevent needing `CAPS` and `SUBS` generics to bleed into everything using this broadcasting system.
- In the service-messages crates, add a new `ServiceMessage` enum type (e.g. `TimeAlarmServiceMessage`) that is used by the service's broadcasting channel.
- During service setup on a platform, we create a new `SinglePublisherChannel` for every service that wants to broadcast messages. Those services will have a field in their structs for a `DynPublisher` that we pass into their constructor.  Services that want to subscribe to another service will then need to update their structs to hold a field for a DynPublisher of each service they want to subscribe to (e.g. the power policy service might want to hold a `DynSubscriber<TimeAlarmMessage>` to receive timer expired messages).

Then for notifications:
- We piggy back off the broadcasting system by similarly holding a `DynSubscriber` for each Service provided in the relay macro in the generated relay struct.
- We then add a `wait_notification` method to the `Relay` trait which the macro implements by waiting for a message to be received on any of the `DynSubscribers` it holds.
- To determine if any of these messages are a notification, the `RelayServiceTrait` now has a `is_notification` method that each service needs to implement to match a message variant to a notification.
- This is just a bool since the relay service will discard the payload (if any). Instead, the macro now requires an additional notification id associated with each service. Basically, if the relay handler receives a notification, it discards the payload and returns the associated notification id for the service the notification id belongs to, and the relay service can then directly use this id without needing to know anything about which service produced it.

I've updated the time-alarm-service and espi-service to show how these might be used and also updated the time-alarm example to show how it would all be integrated together. eSPI service had some little changes due to the fact wait_for_notification needs an `&mut self` but will look into a way to make wait_for_notification take only an `&self`.

@RobertZ2011 and @williampMSFT curious to see if this is closer to how you were envisioning message broadcasting. I've looked at the existing `broadcaster/immediate.rs` to see if it could be reworked with intrusive list removed but to be honest, I don't know the context behind its design and it's not clear to me yet exactly what it is trying to solve over a raw `PubSubChannel` broadcaster. But I'm open to seeing if we can make use of that instead.