### PR TITLE
fix: remove unnecessary let binding in defmt-only logging macros

### DIFF
--- a/embedded-service/src/fmt.rs
+++ b/embedded-service/src/fmt.rs
@@ -71,7 +71,6 @@ mod defmt {
     macro_rules! trace {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($s, $( &$x ),*);
                 ::defmt::trace!($s $(, $x)*);
             }
         };
@@ -83,7 +82,6 @@ mod defmt {
     macro_rules! debug {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($s, $( &$x ),*);
                 ::defmt::debug!($s $(, $x)*);
             }
         };
@@ -95,7 +93,6 @@ mod defmt {
     macro_rules! info {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($s, $( &$x ),*);
                 ::defmt::info!($s $(, $x)*);
             }
         };
@@ -107,7 +104,6 @@ mod defmt {
     macro_rules! warn {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($s, $( &$x ),*);
                 ::defmt::warn!($s $(, $x)*);
             }
         };
@@ -119,7 +115,6 @@ mod defmt {
     macro_rules! error {
         ($s:literal $(, $x:expr)* $(,)?) => {
             {
-                let _ = ($s, $( &$x ),*);
                 ::defmt::error!($s $(, $x)*);
             }
         };


### PR DESCRIPTION
A suspected copy-pasted line in a logging macro made each log call slightly bigger, and 45 of them inside one async function added up to enough extra stack usage to silently overwrite battery data on a memory-constrained microcontroller.