### PR TITLE
time-alarm-service: Add no_std mock support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,7 @@ dependencies = [
  "embedded-services",
  "log",
  "odp-service-common",
+ "time-alarm-service",
  "time-alarm-service-messages",
  "tokio",
  "zerocopy",

--- a/time-alarm-service/Cargo.toml
+++ b/time-alarm-service/Cargo.toml
@@ -31,11 +31,13 @@ defmt = [
 ]
 
 log = ["dep:log", "embedded-services/log", "embassy-time/log"]
+mock = []
 
 [lints]
 workspace = true
 
 [dev-dependencies]
+time-alarm-service = { path = ".", features = ["mock"] }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 critical-section = { version = "1.1", features = ["std"] }
 embassy-time = { workspace = true, features = ["std", "generic-queue-8"] }

--- a/time-alarm-service/src/lib.rs
+++ b/time-alarm-service/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 use core::cell::RefCell;
 use embassy_sync::blocking_mutex::Mutex;
@@ -11,6 +11,8 @@ use time_alarm_service_messages::*;
 
 mod timer;
 use timer::Timer;
+#[cfg(feature = "mock")]
+pub mod mock;
 
 // -------------------------------------------------
 

--- a/time-alarm-service/src/mock.rs
+++ b/time-alarm-service/src/mock.rs
@@ -2,50 +2,62 @@
 
 use embedded_mcu_hal::NvramStorage;
 use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError};
-use std::time::SystemTime;
 
-pub(crate) enum MockDatetimeClock {
-    Running { seconds_offset_from_system_time: i64 },
+// Used for `cargo test` runs in an std environment
+#[cfg(test)]
+fn now_seconds() -> u64 {
+    // Panic safety: Only used in tests so panicking is acceptable here
+    #[allow(clippy::expect_used)]
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .expect("System clock was adjusted during test")
+        .as_secs()
+}
+
+// Allows us to use this mock in no_std contexts
+// Note: `get_current_datetime` will always reflect time as starting from the beginning
+// of UNIX time (1970), and not current wall-clock time. This is sufficient for its use case
+// since it provides a consistent baseline and allows time to advance, but is something to be aware of.
+#[cfg(not(test))]
+fn now_seconds() -> u64 {
+    embassy_time::Instant::now().as_secs()
+}
+
+pub enum MockDatetimeClock {
+    Running { seconds_offset: i64 },
     Paused { frozen_time: Datetime },
 }
 
 impl MockDatetimeClock {
-    pub(crate) fn new_running() -> Self {
-        Self::Running {
-            seconds_offset_from_system_time: 0,
-        }
+    /// New `MockDatetimeClock` in which time is advancing.
+    pub fn new_running() -> Self {
+        Self::Running { seconds_offset: 0 }
     }
 
-    pub(crate) fn new_paused() -> Self {
+    /// New `MockDatetimeClock` in which time is paused.
+    pub fn new_paused() -> Self {
         Self::Paused {
-            frozen_time: Datetime::from_unix_time_seconds(
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .expect("System clock was adjusted during test")
-                    .as_secs(),
-            ),
+            frozen_time: Datetime::from_unix_time_seconds(now_seconds()),
         }
     }
 
     /// Stop time from advancing.
-    pub(crate) fn pause(&mut self) {
+    pub fn pause(&mut self) {
         if let Self::Running { .. } = self {
             *self = MockDatetimeClock::Paused {
+                // Panic safety: Mocks aren't used in production code, so panicking is acceptable here
+                #[allow(clippy::unwrap_used)]
                 frozen_time: self.get_current_datetime().unwrap(),
             };
         }
     }
 
     /// Resume time advancing.
-    pub(crate) fn resume(&mut self) {
+    pub fn resume(&mut self) {
         if let Self::Paused { frozen_time } = self {
-            let now = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .expect("System clock was adjusted during test");
             let target_secs = frozen_time.to_unix_time_seconds() as i64;
-            let adjusted_seconds = now.as_secs() as i64;
             *self = MockDatetimeClock::Running {
-                seconds_offset_from_system_time: target_secs - adjusted_seconds,
+                seconds_offset: target_secs - now_seconds() as i64,
             };
         }
     }
@@ -55,13 +67,8 @@ impl DatetimeClock for MockDatetimeClock {
     fn get_current_datetime(&self) -> Result<Datetime, DatetimeClockError> {
         match self {
             MockDatetimeClock::Paused { frozen_time } => Ok(*frozen_time),
-            MockDatetimeClock::Running {
-                seconds_offset_from_system_time,
-            } => {
-                let now = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .expect("System clock was adjusted during test");
-                let adjusted_seconds = now.as_secs() as i64 + seconds_offset_from_system_time;
+            MockDatetimeClock::Running { seconds_offset } => {
+                let adjusted_seconds = now_seconds() as i64 + seconds_offset;
                 Ok(Datetime::from_unix_time_seconds(adjusted_seconds as u64))
             }
         }
@@ -75,12 +82,8 @@ impl DatetimeClock for MockDatetimeClock {
             }
             MockDatetimeClock::Running { .. } => {
                 let target_secs = datetime.to_unix_time_seconds() as i64;
-                let now = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .expect("System clock was adjusted during test");
-
                 *self = MockDatetimeClock::Running {
-                    seconds_offset_from_system_time: target_secs - (now.as_secs() as i64),
+                    seconds_offset: target_secs - now_seconds() as i64,
                 };
                 Ok(())
             }
@@ -92,13 +95,13 @@ impl DatetimeClock for MockDatetimeClock {
     }
 }
 
-pub(crate) struct MockNvramStorage<'a> {
+pub struct MockNvramStorage<'a> {
     value: u32,
     _phantom: core::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> MockNvramStorage<'a> {
-    pub(crate) fn new(initial_value: u32) -> Self {
+    pub fn new(initial_value: u32) -> Self {
         Self {
             value: initial_value,
             _phantom: core::marker::PhantomData,

--- a/time-alarm-service/tests/common/mod.rs
+++ b/time-alarm-service/tests/common/mod.rs
@@ -1,1 +1,0 @@
-pub mod mocks;

--- a/time-alarm-service/tests/tad_test.rs
+++ b/time-alarm-service/tests/tad_test.rs
@@ -2,8 +2,6 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
-mod common;
-
 #[cfg(test)]
 mod test {
     use embassy_time::Timer;
@@ -12,7 +10,7 @@ mod test {
 
     use time_alarm_service_messages as msg;
 
-    use crate::common::mocks::*;
+    use time_alarm_service::mock::*;
 
     #[tokio::test]
     async fn test_get_time() {


### PR DESCRIPTION
This refactors the time and alarm service mocks slightly by making them both std friendly (for `cargo test`ing) and no_std friendly (for use on our EC platforms and testing with our ec-test-app), as well as following the same pattern as battery and thermal. So, mock was moved out of the test folder into the main crate src so it can be used externally too.