### PR TITLE
embedded-services: Fix cortex-m dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "cfg-if",
  "chrono",
  "cortex-m",
- "cortex-m-rt",
  "critical-section",
  "defmt 0.3.100",
  "document-features",

--- a/embedded-service/Cargo.toml
+++ b/embedded-service/Cargo.toml
@@ -44,8 +44,7 @@ features = ["serde_derive"]
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic.workspace = true
 
-[target.'cfg(target_os = "none")'.dependencies]
-cortex-m-rt.workspace = true
+[target.'cfg(all(target_os = "none", target_arch = "arm"))'.dependencies]
 cortex-m.workspace = true
 
 [dev-dependencies]

--- a/examples/pico-de-gallo/Cargo.lock
+++ b/examples/pico-de-gallo/Cargo.lock
@@ -377,26 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cortex-m-rt"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d4dec46b34c299ccf6b036717ae0fce602faa4f4fe816d9013b9a7c9f5ba6"
-dependencies = [
- "cortex-m-rt-macros",
-]
-
-[[package]]
-name = "cortex-m-rt-macros"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,7 +603,6 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "cortex-m",
- "cortex-m-rt",
  "critical-section",
  "document-features",
  "embassy-futures",

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -642,7 +642,6 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "cortex-m",
- "cortex-m-rt",
  "critical-section",
  "defmt 0.3.100",
  "document-features",

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "cortex-m",
- "cortex-m-rt",
  "critical-section",
  "defmt 0.3.100",
  "document-features",

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -371,26 +371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cortex-m-rt"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d4dec46b34c299ccf6b036717ae0fce602faa4f4fe816d9013b9a7c9f5ba6"
-dependencies = [
- "cortex-m-rt-macros",
-]
-
-[[package]]
-name = "cortex-m-rt-macros"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,7 +771,6 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "cortex-m",
- "cortex-m-rt",
  "critical-section",
  "document-features",
  "embassy-futures",


### PR DESCRIPTION
Removes the cortex-m-rt dependency entirely since this is not needed and risks pulling in conflicting linker scripts depending on where they are in relation to each other in the search graph when embedded-services is used on a different architecture. Then also made cortex-m only included if the architecture is arm to be extra-safe.

Fixes a minor issue I was running into trying to work on a risc-v platform.