### PR TITLE
power-policy-service/tests: Introduce dedicated Test trait

### DIFF
--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -73,47 +73,23 @@ async fn power_policy_task<'device, 'sender, const N: usize>(
     }
 }
 
-/// This trait is a workaround for Rust's current limitations on closures returning a generic future.
+/// Trait for runnable tests.
 ///
-/// The trait we want to express for `run_test` is something like:
-/// ```
-/// for<'a> F: FnOnce(
-/// &'a ServiceMutex<'a, 'a>,
-/// &'a Mutex<GlobalRawMutex, Mock<'a, DynamicSender<'a, EventData>>>,
-/// &'a Signal<GlobalRawMutex, (usize, FnCall)>,
-/// &'a Mutex<GlobalRawMutex, Mock<'a, DynamicSender<'a, EventData>>>,
-/// &'a Signal<GlobalRawMutex, (usize, FnCall)>
-/// ) -> impl (Future<Output = ()> + 'a)
-/// ```
-/// However, `impl (Future<Output = ()> + 'a)` is not real syntax. This could be done with the unstable feature type_alias_impl_trait,
-/// but we use this helper trait so as to not require use of nightly.
-pub trait TestArgsFnOnce<'a, Arg0: 'a, Arg1: 'a, Arg2: 'a, Arg3: 'a, Arg4: 'a, Arg5: 'a>:
-    FnOnce(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5) -> Self::Fut
-{
-    type Fut: Future<Output = ()>;
+/// This exists because there are lifetime issues with being generic over FnOnce or FnMut.
+/// Those can be resolved, but having a dedicated trait is simpler.
+pub trait Test {
+    fn run<'a>(
+        &mut self,
+        service: &'a ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &'a DeviceType<'a>,
+        device0_signal: &'a Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &'a DeviceType<'a>,
+        device1_signal: &'a Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) -> impl Future<Output = ()>;
 }
 
-impl<'a, Arg0: 'a, Arg1: 'a, Arg2: 'a, Arg3: 'a, Arg4: 'a, Arg5: 'a, F, Fut>
-    TestArgsFnOnce<'a, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5> for F
-where
-    F: FnOnce(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5) -> Fut,
-    Fut: Future<Output = ()>,
-{
-    type Fut = Fut;
-}
-
-pub async fn run_test<F>(timeout: Duration, test: F, config: Config)
-where
-    for<'a> F: TestArgsFnOnce<
-            'a,
-            &'a ServiceMutex<'a, 'a>,
-            DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-            &'a DeviceType<'a>,
-            &'a Signal<GlobalRawMutex, (usize, FnCall)>,
-            &'a DeviceType<'a>,
-            &'a Signal<GlobalRawMutex, (usize, FnCall)>,
-        >,
-{
+pub async fn run_test(timeout: Duration, mut test: impl Test, config: Config) {
     // Tokio runs tests in parallel, but logging is global so we need to run tests sequentially to avoid interleaved logs.
     static TEST_MUTEX: OnceLock<Mutex<GlobalRawMutex, ()>> = OnceLock::new();
     let test_mutex = TEST_MUTEX.get_or_init(|| Mutex::new(()));
@@ -138,11 +114,8 @@ where
     let service_context = power_policy_service::service::context::Context::new();
     let completion_signal = Signal::new();
 
-    // Ideally F would have two lifetime arguments: 'device and 'sender because the event type requires 'device: 'sender.
-    // But Rust doesn't currently support syntax like `for<'device, 'sender> ... where 'device: 'sender`. So we just
-    // use a single lifetime. However, the unified lifetime makes the drop-checker think that dropping the channel
-    // could be unsafe. We use ManuallyDrop to disable the drop and make the drop-checker happy. None of the types
-    // here do any clean-up in their Drop impls so we don't have to worry about any sort of leaks.
+    // For simplicity, Test::run is only generic over a single lifetime. But this causes issues with the drop checker because
+    // the device lifetime doesn't outlive the channel lifetime from its perspective. Use ManuallyDrop to work around this.
     let service_event_channel: ManuallyDrop<
         Channel<GlobalRawMutex, ServiceEvent<'_, DeviceType<'_>>, EVENT_CHANNEL_SIZE>,
     > = ManuallyDrop::new(Channel::new());
@@ -168,7 +141,7 @@ where
                 ArrayEventReceivers::new([&device0, &device1], [device0_receiver, device1_receiver]),
             ),
             async {
-                test(
+                test.run(
                     &power_policy,
                     service_receiver,
                     &device0,

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -92,7 +92,7 @@ impl Test for TestSingle {
 }
 
 /// Test swapping to a higher powered device.
-pub struct TestSwapHigher;
+struct TestSwapHigher;
 
 impl Test for TestSwapHigher {
     async fn run<'a>(

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -14,6 +14,7 @@ use power_policy_service::service::config::Config;
 
 use crate::common::DeviceType;
 use crate::common::MINIMAL_POWER;
+use crate::common::Test;
 use crate::common::assert_no_event;
 use crate::common::{
     DEFAULT_TIMEOUT, HIGH_POWER, assert_consumer_connected, assert_consumer_disconnected, mock::FnCall, run_test,
@@ -24,449 +25,473 @@ const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 const MIN_CONSUMER_THRESHOLD_MW: u32 = 7500;
 
 /// Test the basic consumer flow with a single device.
-async fn test_single<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    _device1: &DeviceType<'a>,
-    _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_single");
-    // Test initial connection
-    {
-        device0
-            .lock()
-            .await
-            .simulate_consumer_connection(LOW_POWER.into())
-            .await;
+struct TestSingle;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+impl Test for TestSingle {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        _device1: &DeviceType<'a>,
+        _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_single");
+        // Test initial connection
+        {
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
+            .await;
 
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+        // Test detach
+        {
+            device0.lock().await.simulate_detach().await;
 
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+            // Power policy shouldn't call any functions on detach so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device0_signal.reset();
+
+            assert_consumer_disconnected(service_receiver, device0).await;
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+
+        assert_no_event(service_receiver);
     }
-    // Test detach
-    {
-        device0.lock().await.simulate_detach().await;
-
-        // Power policy shouldn't call any functions on detach so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device0_signal.reset();
-
-        assert_consumer_disconnected(service_receiver, device0).await;
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
-
-    assert_no_event(service_receiver);
 }
 
 /// Test swapping to a higher powered device.
-async fn test_swap_higher<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    device1: &DeviceType<'a>,
-    device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_swap_higher");
-    // Device0 connection at low power
-    {
-        device0
-            .lock()
-            .await
-            .simulate_consumer_connection(LOW_POWER.into())
-            .await;
+pub struct TestSwapHigher;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+impl Test for TestSwapHigher {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_swap_higher");
+        // Device0 connection at low power
+        {
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
-
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
-    // Device1 connection at high power
-    {
-        device1
-            .lock()
-            .await
-            .simulate_consumer_connection(HIGH_POWER.into())
             .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (1, FnCall::Disconnect)
-        );
-        device0_signal.reset();
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+        // Device1 connection at high power
+        {
+            device1
+                .lock()
+                .await
+                .simulate_consumer_connection(HIGH_POWER.into())
+                .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (1, FnCall::Disconnect)
+            );
+            device0_signal.reset();
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: HIGH_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            // Should receive a disconnect event from device0 first
+            assert_consumer_disconnected(service_receiver, device0).await;
+
+            assert_consumer_connected(
+                service_receiver,
+                device1,
+                ConsumerPowerCapability {
                     capability: HIGH_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device1_signal.reset();
+            .await;
 
-        // Should receive a disconnect event from device0 first
-        assert_consumer_disconnected(service_receiver, device0).await;
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+        // Test detach device1, should reconnect device0
+        {
+            device1.lock().await.simulate_detach().await;
 
-        assert_consumer_connected(
-            service_receiver,
-            device1,
-            ConsumerPowerCapability {
-                capability: HIGH_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
+            // Power policy shouldn't call any functions on detach so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
+                Err(TimeoutError)
+            );
 
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
-    // Test detach device1, should reconnect device0
-    {
-        device1.lock().await.simulate_detach().await;
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
 
-        // Power policy shouldn't call any functions on detach so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
-            Err(TimeoutError)
-        );
+            // Should receive a disconnect event from device1 first
+            assert_consumer_disconnected(service_receiver, device1).await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
+            .await;
 
-        // Should receive a disconnect event from device1 first
-        assert_consumer_disconnected(service_receiver, device1).await;
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
 
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        assert_no_event(service_receiver);
     }
-
-    assert_no_event(service_receiver);
 }
 
 /// Test a disconnect initiated by the current consumer.
-async fn test_disconnect<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    device1: &DeviceType<'a>,
-    device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_disconnect");
-    // Device0 connection at low power
-    {
-        device0
-            .lock()
-            .await
-            .simulate_consumer_connection(LOW_POWER.into())
-            .await;
+struct TestDisconnect;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+impl Test for TestDisconnect {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_disconnect");
+        // Device0 connection at low power
+        {
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
-
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
-    // Device1 connection at high power
-    {
-        device1
-            .lock()
-            .await
-            .simulate_consumer_connection(HIGH_POWER.into())
             .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (1, FnCall::Disconnect)
-        );
-        device0_signal.reset();
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+        // Device1 connection at high power
+        {
+            device1
+                .lock()
+                .await
+                .simulate_consumer_connection(HIGH_POWER.into())
+                .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (1, FnCall::Disconnect)
+            );
+            device0_signal.reset();
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: HIGH_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            // Should receive a disconnect event from device0 first
+            assert_consumer_disconnected(service_receiver, device0).await;
+
+            assert_consumer_connected(
+                service_receiver,
+                device1,
+                ConsumerPowerCapability {
                     capability: HIGH_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device1_signal.reset();
+            .await;
 
-        // Should receive a disconnect event from device0 first
-        assert_consumer_disconnected(service_receiver, device0).await;
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
 
-        assert_consumer_connected(
-            service_receiver,
-            device1,
-            ConsumerPowerCapability {
-                capability: HIGH_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
+        // Test disconnect device1, should reconnect device0
+        {
+            device1.lock().await.simulate_disconnect().await;
 
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
+            // Power policy shouldn't call any functions on disconnect so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
+                Err(TimeoutError)
+            );
 
-    // Test disconnect device1, should reconnect device0
-    {
-        device1.lock().await.simulate_disconnect().await;
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
 
-        // Power policy shouldn't call any functions on disconnect so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
-            Err(TimeoutError)
-        );
+            // Consume the disconnect event generated by `simulate_disconnect`
+            assert_consumer_disconnected(service_receiver, device1).await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
+            .await;
 
-        // Consume the disconnect event generated by `simulate_disconnect`
-        assert_consumer_disconnected(service_receiver, device1).await;
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
 
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        assert_no_event(service_receiver);
     }
-
-    assert_no_event(service_receiver);
 }
 
 /// Test minimum consumer power logic.
 ///
 /// Config for this test uses [`MIN_CONSUMER_THRESHOLD_MW`].
-async fn test_min_consumer_power<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    _device1: &DeviceType<'a>,
-    _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_min_consumer_power");
-    // Connect with power below the minimum threshold.
-    {
-        device0
-            .lock()
-            .await
-            .simulate_consumer_connection(MINIMAL_POWER.into())
-            .await;
+struct TestMinConsumerPower;
 
-        // Power policy shouldn't connect, so this call should timeout.
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device0_signal.reset();
+impl Test for TestMinConsumerPower {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        _device1: &DeviceType<'a>,
+        _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_min_consumer_power");
+        // Connect with power below the minimum threshold.
+        {
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(MINIMAL_POWER.into())
+                .await;
 
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+            // Power policy shouldn't connect, so this call should timeout.
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device0_signal.reset();
+
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+
+        // Service shouldn't broadcast any events in this case.
+        assert_no_event(service_receiver);
     }
-
-    // Service shouldn't broadcast any events in this case.
-    assert_no_event(service_receiver);
 }
 
 /// Test that we won't swap if the capabilities are the same
-async fn test_no_swap<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    device1: &DeviceType<'a>,
-    device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_no_swap");
-    // Device0 connection at low power
-    {
-        device0
-            .lock()
-            .await
-            .simulate_consumer_connection(LOW_POWER.into())
-            .await;
+struct TestNoSwap;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+impl Test for TestNoSwap {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_no_swap");
+        // Device0 connection at low power
+        {
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
-
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        // Ensure consumer change doesn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
-    // Device1 connection at low power, should not cause a swap since capabilities are the same
-    {
-        device1
-            .lock()
-            .await
-            .simulate_consumer_connection(LOW_POWER.into())
             .await;
 
-        // These should timeout since we shouldn't swap
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device0_signal.reset();
+            // Ensure consumer change doesn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+        // Device1 connection at low power, should not cause a swap since capabilities are the same
+        {
+            device1
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device1_signal.reset();
+            // These should timeout since we shouldn't swap
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device0_signal.reset();
 
-        // Shouldn't affect provider power computation
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device1_signal.reset();
+
+            // Shouldn't affect provider power computation
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+
+        // Service shouldn't broadcast any events in this case since we shouldn't swap.
+        assert_no_event(service_receiver);
     }
-
-    // Service shouldn't broadcast any events in this case since we shouldn't swap.
-    assert_no_event(service_receiver);
 }
-
 #[tokio::test]
 async fn run_test_swap_higher() {
-    run_test(DEFAULT_TIMEOUT, test_swap_higher, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestSwapHigher, Default::default()).await;
 }
 
 #[tokio::test]
 async fn run_test_single() {
-    run_test(DEFAULT_TIMEOUT, test_single, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default()).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect() {
-    run_test(DEFAULT_TIMEOUT, test_disconnect, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default()).await;
 }
 
 #[tokio::test]
 async fn run_test_min_consumer_power() {
     run_test(
         DEFAULT_TIMEOUT,
-        test_min_consumer_power,
+        TestMinConsumerPower,
         Config {
             min_consumer_threshold_mw: Some(MIN_CONSUMER_THRESHOLD_MW),
             ..Default::default()
@@ -477,5 +502,5 @@ async fn run_test_min_consumer_power() {
 
 #[tokio::test]
 async fn run_test_no_swap() {
-    run_test(DEFAULT_TIMEOUT, test_no_swap, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestNoSwap, Default::default()).await;
 }

--- a/power-policy-service/tests/provider.rs
+++ b/power-policy-service/tests/provider.rs
@@ -14,282 +14,298 @@ use power_policy_interface::service::event::Event as ServiceEvent;
 
 use crate::common::DeviceType;
 use crate::common::HIGH_POWER;
+use crate::common::Test;
 use crate::common::assert_no_event;
 use crate::common::{DEFAULT_TIMEOUT, assert_provider_connected, assert_provider_disconnected, mock::FnCall, run_test};
 
 const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 
 /// Test the basic provider flow with a single device.
-async fn test_single<'a>(
-    _service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    _device1: &DeviceType<'a>,
-    _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_single");
-    // Test initial connection
-    {
-        device0.lock().await.simulate_provider_connection(LOW_POWER).await;
+struct TestSingle;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectProvider(ProviderPowerCapability {
+impl Test for TestSingle {
+    async fn run<'a>(
+        &mut self,
+        _service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        _device1: &DeviceType<'a>,
+        _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_single");
+        // Test initial connection
+        {
+            device0.lock().await.simulate_provider_connection(LOW_POWER).await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectProvider(ProviderPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ProviderFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_provider_connected(
+                service_receiver,
+                device0,
+                ProviderPowerCapability {
                     capability: LOW_POWER,
                     flags: ProviderFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
+            .await;
+        }
+        // Test detach
+        {
+            device0.lock().await.simulate_detach().await;
 
-        assert_provider_connected(
-            service_receiver,
-            device0,
-            ProviderPowerCapability {
-                capability: LOW_POWER,
-                flags: ProviderFlags::none(),
-            },
-        )
-        .await;
+            // Power policy shouldn't call any functions on detach so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device0_signal.reset();
+
+            assert_provider_disconnected(service_receiver, device0).await;
+        }
+
+        assert_no_event(service_receiver);
     }
-    // Test detach
-    {
-        device0.lock().await.simulate_detach().await;
-
-        // Power policy shouldn't call any functions on detach so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device0_signal.reset();
-
-        assert_provider_disconnected(service_receiver, device0).await;
-    }
-
-    assert_no_event(service_receiver);
 }
 
 /// Test provider flow involving multiple devices and upgrading a provider's power capability.
-async fn test_upgrade<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    device1: &DeviceType<'a>,
-    device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_upgrade");
-    {
-        // Connect device0 at high power, default service config should allow this
-        device0.lock().await.simulate_provider_connection(HIGH_POWER).await;
+struct TestUpgrade;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectProvider(ProviderPowerCapability {
+impl Test for TestUpgrade {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_upgrade");
+        {
+            // Connect device0 at high power, default service config should allow this
+            device0.lock().await.simulate_provider_connection(HIGH_POWER).await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectProvider(ProviderPowerCapability {
+                        capability: HIGH_POWER,
+                        flags: ProviderFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_provider_connected(
+                service_receiver,
+                device0,
+                ProviderPowerCapability {
                     capability: HIGH_POWER,
                     flags: ProviderFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
-
-        assert_provider_connected(
-            service_receiver,
-            device0,
-            ProviderPowerCapability {
-                capability: HIGH_POWER,
-                flags: ProviderFlags::none(),
-            },
-        )
-        .await;
-
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 15000);
-    }
-
-    {
-        // Connect device1 at low power, default service config should allow this
-        device1.lock().await.simulate_provider_connection(LOW_POWER).await;
-
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectProvider(ProviderPowerCapability {
-                    capability: LOW_POWER,
-                    flags: ProviderFlags::none(),
-                })
-            )
-        );
-        device1_signal.reset();
-
-        assert_provider_connected(
-            service_receiver,
-            device1,
-            ProviderPowerCapability {
-                capability: LOW_POWER,
-                flags: ProviderFlags::none(),
-            },
-        )
-        .await;
-
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 22500);
-    }
-
-    {
-        // Attempt to upgrade device1 to high power, power policy should reject this since device0 is already connected at high power
-        // Power policy will instead allow us to connect at low power
-        device1
-            .lock()
-            .await
-            .simulate_update_requested_provider_power_capability(Some(HIGH_POWER.into()))
             .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectProvider(ProviderPowerCapability {
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 15000);
+        }
+
+        {
+            // Connect device1 at low power, default service config should allow this
+            device1.lock().await.simulate_provider_connection(LOW_POWER).await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectProvider(ProviderPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ProviderFlags::none(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            assert_provider_connected(
+                service_receiver,
+                device1,
+                ProviderPowerCapability {
                     capability: LOW_POWER,
                     flags: ProviderFlags::none(),
-                })
+                },
             )
-        );
-        device1_signal.reset();
-
-        assert_provider_connected(
-            service_receiver,
-            device1,
-            ProviderPowerCapability {
-                capability: LOW_POWER,
-                flags: ProviderFlags::none(),
-            },
-        )
-        .await;
-
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 22500);
-    }
-
-    {
-        // Detach device0, this should allow us to upgrade device1 to high power
-        device0.lock().await.simulate_detach().await;
-
-        // Power policy shouldn't call any functions on detach so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device0_signal.reset();
-
-        assert_provider_disconnected(service_receiver, device0).await;
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 7500);
-    }
-
-    {
-        // Attempt to upgrade device1 to high power should now succeed
-        device1
-            .lock()
-            .await
-            .simulate_update_requested_provider_power_capability(Some(HIGH_POWER.into()))
             .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectProvider(ProviderPowerCapability {
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 22500);
+        }
+
+        {
+            // Attempt to upgrade device1 to high power, power policy should reject this since device0 is already connected at high power
+            // Power policy will instead allow us to connect at low power
+            device1
+                .lock()
+                .await
+                .simulate_update_requested_provider_power_capability(Some(HIGH_POWER.into()))
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectProvider(ProviderPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ProviderFlags::none(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            assert_provider_connected(
+                service_receiver,
+                device1,
+                ProviderPowerCapability {
+                    capability: LOW_POWER,
+                    flags: ProviderFlags::none(),
+                },
+            )
+            .await;
+
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 22500);
+        }
+
+        {
+            // Detach device0, this should allow us to upgrade device1 to high power
+            device0.lock().await.simulate_detach().await;
+
+            // Power policy shouldn't call any functions on detach so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device0_signal.reset();
+
+            assert_provider_disconnected(service_receiver, device0).await;
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 7500);
+        }
+
+        {
+            // Attempt to upgrade device1 to high power should now succeed
+            device1
+                .lock()
+                .await
+                .simulate_update_requested_provider_power_capability(Some(HIGH_POWER.into()))
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectProvider(ProviderPowerCapability {
+                        capability: HIGH_POWER,
+                        flags: ProviderFlags::none(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            assert_provider_connected(
+                service_receiver,
+                device1,
+                ProviderPowerCapability {
                     capability: HIGH_POWER,
                     flags: ProviderFlags::none(),
-                })
+                },
             )
-        );
-        device1_signal.reset();
+            .await;
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 15000);
+        }
 
-        assert_provider_connected(
-            service_receiver,
-            device1,
-            ProviderPowerCapability {
-                capability: HIGH_POWER,
-                flags: ProviderFlags::none(),
-            },
-        )
-        .await;
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 15000);
+        assert_no_event(service_receiver);
     }
-
-    assert_no_event(service_receiver);
 }
 
 /// Test the provider disconnect flow
-async fn test_disconnect<'a>(
-    service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    _device1: &DeviceType<'a>,
-    _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_disconnect");
-    // Test initial connection
-    {
-        device0.lock().await.simulate_provider_connection(LOW_POWER).await;
+struct TestDisconnect;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectProvider(ProviderPowerCapability {
+impl Test for TestDisconnect {
+    async fn run<'a>(
+        &mut self,
+        service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        _device1: &DeviceType<'a>,
+        _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_disconnect");
+        // Test initial connection
+        {
+            device0.lock().await.simulate_provider_connection(LOW_POWER).await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectProvider(ProviderPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ProviderFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_provider_connected(
+                service_receiver,
+                device0,
+                ProviderPowerCapability {
                     capability: LOW_POWER,
                     flags: ProviderFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
+            .await;
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 7500);
+        }
+        // Test disconnect
+        {
+            device0.lock().await.simulate_disconnect().await;
 
-        assert_provider_connected(
-            service_receiver,
-            device0,
-            ProviderPowerCapability {
-                capability: LOW_POWER,
-                flags: ProviderFlags::none(),
-            },
-        )
-        .await;
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 7500);
+            // Power policy shouldn't call any functions on disconnect so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
+                Err(TimeoutError)
+            );
+            device0_signal.reset();
+
+            assert_provider_disconnected(service_receiver, device0).await;
+            assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
+        }
+
+        assert_no_event(service_receiver);
     }
-    // Test disconnect
-    {
-        device0.lock().await.simulate_disconnect().await;
-
-        // Power policy shouldn't call any functions on disconnect so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await,
-            Err(TimeoutError)
-        );
-        device0_signal.reset();
-
-        assert_provider_disconnected(service_receiver, device0).await;
-        assert_eq!(service.lock().await.compute_total_provider_power_mw().await, 0);
-    }
-
-    assert_no_event(service_receiver);
 }
 
 #[tokio::test]
 async fn run_test_single() {
-    run_test(DEFAULT_TIMEOUT, test_single, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default()).await;
 }
 
 #[tokio::test]
 async fn run_test_upgrade() {
-    run_test(DEFAULT_TIMEOUT, test_upgrade, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestUpgrade, Default::default()).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect() {
-    run_test(DEFAULT_TIMEOUT, test_disconnect, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default()).await;
 }

--- a/power-policy-service/tests/unconstrained.rs
+++ b/power-policy-service/tests/unconstrained.rs
@@ -18,155 +18,160 @@ use crate::common::{
     DEFAULT_TIMEOUT, assert_consumer_connected, assert_consumer_disconnected, assert_no_event, assert_unconstrained,
     mock::FnCall, run_test,
 };
-use crate::common::{DeviceType, ServiceMutex};
+use crate::common::{DeviceType, ServiceMutex, Test};
 
 const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 
 /// Test unconstrained consumer flow with multiple devices.
-async fn test_unconstrained<'a>(
-    _service: &ServiceMutex<'a, 'a>,
-    service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
-    device0: &DeviceType<'a>,
-    device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-    device1: &DeviceType<'a>,
-    device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
-) {
-    info!("Running test_unconstrained");
-    {
-        // Connect device0, without unconstrained,
-        device0
-            .lock()
-            .await
-            .simulate_consumer_connection(LOW_POWER.into())
-            .await;
+struct TestUnconstrained;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+impl Test for TestUnconstrained {
+    async fn run<'a>(
+        &mut self,
+        _service: &ServiceMutex<'a, 'a>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_unconstrained");
+        {
+            // Connect device0, without unconstrained,
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
-
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        // Should not have any unconstrained events
-        assert!(service_receiver.try_receive().is_err());
-    }
-
-    {
-        // Connect device1 with unconstrained at HIGH_POWER to force power policy to select this consumer.
-        device1
-            .lock()
-            .await
-            .simulate_consumer_connection(ConsumerPowerCapability {
-                capability: HIGH_POWER,
-                flags: ConsumerFlags::none().with_unconstrained_power(),
-            })
             .await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (1, FnCall::Disconnect)
-        );
-        device0_signal.reset();
+            // Should not have any unconstrained events
+            assert!(service_receiver.try_receive().is_err());
+        }
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+        {
+            // Connect device1 with unconstrained at HIGH_POWER to force power policy to select this consumer.
+            device1
+                .lock()
+                .await
+                .simulate_consumer_connection(ConsumerPowerCapability {
                     capability: HIGH_POWER,
                     flags: ConsumerFlags::none().with_unconstrained_power(),
                 })
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (1, FnCall::Disconnect)
+            );
+            device0_signal.reset();
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: HIGH_POWER,
+                        flags: ConsumerFlags::none().with_unconstrained_power(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            // Should receive a disconnect event from device0 first
+            assert_consumer_disconnected(service_receiver, device0).await;
+
+            assert_consumer_connected(
+                service_receiver,
+                device1,
+                ConsumerPowerCapability {
+                    capability: HIGH_POWER,
+                    flags: ConsumerFlags::none().with_unconstrained_power(),
+                },
             )
-        );
-        device1_signal.reset();
+            .await;
 
-        // Should receive a disconnect event from device0 first
-        assert_consumer_disconnected(service_receiver, device0).await;
+            assert_unconstrained(
+                service_receiver,
+                UnconstrainedState {
+                    unconstrained: true,
+                    available: 1,
+                },
+            )
+            .await;
+        }
 
-        assert_consumer_connected(
-            service_receiver,
-            device1,
-            ConsumerPowerCapability {
-                capability: HIGH_POWER,
-                flags: ConsumerFlags::none().with_unconstrained_power(),
-            },
-        )
-        .await;
+        {
+            // Test detach device1, unconstrained state should change
+            device1.lock().await.simulate_detach().await;
 
-        assert_unconstrained(
-            service_receiver,
-            UnconstrainedState {
-                unconstrained: true,
-                available: 1,
-            },
-        )
-        .await;
-    }
+            // Power policy shouldn't call any functions on detach so we'll timeout
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
+                Err(TimeoutError)
+            );
 
-    {
-        // Test detach device1, unconstrained state should change
-        device1.lock().await.simulate_detach().await;
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
 
-        // Power policy shouldn't call any functions on detach so we'll timeout
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await,
-            Err(TimeoutError)
-        );
+            // Should receive a disconnect event from device1 first
+            assert_consumer_disconnected(service_receiver, device1).await;
 
-        assert_eq!(
-            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
-            (
-                1,
-                FnCall::ConnectConsumer(ConsumerPowerCapability {
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
                     capability: LOW_POWER,
                     flags: ConsumerFlags::none(),
-                })
+                },
             )
-        );
-        device0_signal.reset();
+            .await;
 
-        // Should receive a disconnect event from device1 first
-        assert_consumer_disconnected(service_receiver, device1).await;
+            assert_unconstrained(
+                service_receiver,
+                UnconstrainedState {
+                    unconstrained: false,
+                    available: 0,
+                },
+            )
+            .await;
+        }
 
-        assert_consumer_connected(
-            service_receiver,
-            device0,
-            ConsumerPowerCapability {
-                capability: LOW_POWER,
-                flags: ConsumerFlags::none(),
-            },
-        )
-        .await;
-
-        assert_unconstrained(
-            service_receiver,
-            UnconstrainedState {
-                unconstrained: false,
-                available: 0,
-            },
-        )
-        .await;
+        assert_no_event(service_receiver);
     }
-
-    assert_no_event(service_receiver);
 }
 
 #[tokio::test]
 async fn run_test_unconstrained() {
-    run_test(DEFAULT_TIMEOUT, test_unconstrained, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestUnconstrained, Default::default()).await;
 }


### PR DESCRIPTION
The existing traits used to resolve lifetime issues with test closures are messy and difficult to understand. Introduce a dedicated `Test` trait to make things cleaner.

This PR is smaller than it seems, but a lot of lines were touched due to the formatting changes required with moving the previously free functions into traits.