### PR TITLE
power-policy-service: Fix disconnect flow

### DIFF
--- a/power-policy-service/src/lib.rs
+++ b/power-policy-service/src/lib.rs
@@ -79,7 +79,16 @@ impl PowerPolicy {
 
     async fn process_notify_disconnect(&self, device: &device::Device) -> Result<(), Error> {
         self.context.send_response(Ok(policy::ResponseData::Complete)).await;
-        if let Some(consumer) = self.state.lock().await.current_consumer_state.take() {
+
+        self.remove_connected_provider(device.id()).await;
+        if let Some(consumer) = self
+            .state
+            .lock()
+            .await
+            .current_consumer_state
+            .take_if(|d| d.device_id == device.id())
+        {
+            // Current PSU is disconnected, disconnect chargers, and attempt to select next PSU
             info!("Device{}: Connected consumer disconnected", consumer.device_id.0);
             self.disconnect_chargers().await?;
 
@@ -87,10 +96,10 @@ impl PowerPolicy {
                 data: CommsData::ConsumerDisconnected(consumer.device_id),
             })
             .await;
+
+            self.update_current_consumer().await?;
         }
 
-        self.remove_connected_provider(device.id()).await;
-        self.update_current_consumer().await?;
         Ok(())
     }
 

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -35,7 +35,7 @@ use embedded_services::type_c::controller::{self, Controller, PortStatus};
 use embedded_services::type_c::event::{PortEvent, PortNotificationSingle, PortPending, PortStatusChanged};
 use embedded_services::{debug, error, info, trace, warn};
 use embedded_usb_pd::ado::Ado;
-use embedded_usb_pd::{Error, LocalPortId, PdError};
+use embedded_usb_pd::{Error, LocalPortId, PdError, PowerRole};
 
 use crate::wrapper::backing::DynPortState;
 use crate::wrapper::message::*;

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -69,12 +69,14 @@ where
                 return PdError::Failed.into();
             }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedConsumer>().await {
+            // Staying a consumer, but we have updated capabilities
             if let Err(e) = state.notify_consumer_power_capability(available_sink_contract).await {
                 error!("Error setting power contract: {:?}", e);
                 return PdError::Failed.into();
             }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
-            // We're no longer providing power, so disconnect as a provider
+            // Transition from provider to consumer.
+            // This handles role swaps from source to sink.
             let Ok(state) = state.disconnect().await else {
                 error!("Error disconnecting as provider");
                 return PdError::Failed.into();
@@ -142,6 +144,7 @@ where
             }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
             if let Some(contract) = contract {
+                // Staying a provider, but we have updated capabilities
                 if let Err(e) = state.request_provider_power_capability(contract).await {
                     error!("Error setting power contract: {:?}", e);
                     return PdError::Failed.into();
@@ -154,12 +157,14 @@ where
                 }
             }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedConsumer>().await {
-            // We're no longer consuming power, so disconnect as a consumer
+            // Transition from consumer to provider.
+            // This handles role swaps from sink to source.
             let Ok(state) = state.disconnect().await else {
                 error!("Error disconnecting as consumer");
                 return PdError::Failed.into();
             };
 
+            // If contract is none, we're no longer requesting power on this port
             if let Some(contract) = contract {
                 if let Err(e) = state.request_provider_power_capability(contract).await {
                     error!("Error setting power contract: {:?}", e);

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -35,15 +35,9 @@ where
         let current_state = power.state().await.kind();
         info!("current power state: {:?}", current_state);
 
-        // Recover if we're not in the correct state
-        if status.is_connected() {
-            if let action::device::AnyState::Detached(state) = power.device_action().await {
-                warn!("Power device is detached, attempting to attach");
-                if let Err(e) = state.attach().await {
-                    error!("Error attaching power device: {:?}", e);
-                    return PdError::Failed.into();
-                }
-            }
+        if status.power_role == PowerRole::Source {
+            info!("Port is source, not notifying of consumer contract");
+            return Ok(());
         }
 
         let available_sink_contract = status.available_sink_contract.map(|c| {
@@ -58,6 +52,17 @@ where
             c
         });
 
+        // Recover if we're not in the correct state
+        if status.is_connected() {
+            if let action::device::AnyState::Detached(state) = power.device_action().await {
+                warn!("Power device is detached, attempting to attach");
+                if let Err(e) = state.attach().await {
+                    error!("Error attaching power device: {:?}", e);
+                    return PdError::Failed.into();
+                }
+            }
+        }
+
         if let Ok(state) = power.try_device_action::<action::Idle>().await {
             if let Err(e) = state.notify_consumer_power_capability(available_sink_contract).await {
                 error!("Error setting power contract: {:?}", e);
@@ -69,6 +74,12 @@ where
                 return PdError::Failed.into();
             }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
+            // We're no longer providing power, so disconnect as a provider
+            let Ok(state) = state.disconnect().await else {
+                error!("Error disconnecting as provider");
+                return PdError::Failed.into();
+            };
+
             if let Err(e) = state.notify_consumer_power_capability(available_sink_contract).await {
                 error!("Error setting power contract: {:?}", e);
                 return PdError::Failed.into();
@@ -92,6 +103,17 @@ where
         let current_state = power.state().await.kind();
         info!("current power state: {:?}", current_state);
 
+        let contract = status.available_source_contract.map(|c| {
+            let mut c: ProviderPowerCapability = c.into();
+            c.flags.set_psu_type(PsuType::TypeC);
+            c
+        });
+
+        if status.power_role == PowerRole::Sink {
+            info!("Port is sink, not notifying of provider contract");
+            return Ok(());
+        }
+
         if let action::device::AnyState::ConnectedConsumer(state) = power.device_action().await {
             info!("ConnectedConsumer");
             if let Err(e) = state.detach().await {
@@ -111,11 +133,6 @@ where
             }
         }
 
-        let contract = status.available_source_contract.map(|c| {
-            let mut c: ProviderPowerCapability = c.into();
-            c.flags.set_psu_type(PsuType::TypeC);
-            c
-        });
         if let Ok(state) = power.try_device_action::<action::Idle>().await {
             if let Some(contract) = contract {
                 if let Err(e) = state.request_provider_power_capability(contract).await {
@@ -132,6 +149,19 @@ where
             } else {
                 // No longer need to source, so disconnect
                 if let Err(e) = state.disconnect().await {
+                    error!("Error setting power contract: {:?}", e);
+                    return PdError::Failed.into();
+                }
+            }
+        } else if let Ok(state) = power.try_device_action::<action::ConnectedConsumer>().await {
+            // We're no longer consuming power, so disconnect as a consumer
+            let Ok(state) = state.disconnect().await else {
+                error!("Error disconnecting as consumer");
+                return PdError::Failed.into();
+            };
+
+            if let Some(contract) = contract {
+                if let Err(e) = state.request_provider_power_capability(contract).await {
                     error!("Error setting power contract: {:?}", e);
                     return PdError::Failed.into();
                 }

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -149,7 +149,7 @@ where
             } else {
                 // No longer need to source, so disconnect
                 if let Err(e) = state.disconnect().await {
-                    error!("Error setting power contract: {:?}", e);
+                    error!("Error disconnecting as provider: {:?}", e);
                     return PdError::Failed.into();
                 }
             }


### PR DESCRIPTION
The current logic is incorrect and any disconnect will make the power policy think the currently connected consumer has disconnected. Also fix a type-C bug where our internal view of the port's power role could mismatch the role reported by hardware.