### PR TITLE
Fix examples for embassy-executor 0.10 and update dependencies

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -22,7 +22,7 @@ jobs:
     name: vet-dependencies
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.10.1
+      CARGO_VET_VERSION: 0.10.2
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.88"]
+        msrv: ["1.90"]
         target: [x86_64-unknown-linux-gnu, thumbv8m.main-none-eabihf]
     name: ubuntu / ${{ matrix.msrv }} / ${{ matrix.target }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-batteries-async",
  "embedded-services",
@@ -321,7 +321,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
@@ -430,7 +430,7 @@ dependencies = [
  "bbq2",
  "critical-section",
  "defmt 0.3.100",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embedded-services",
  "log",
  "rtt-target",
@@ -535,13 +535,13 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
+checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
- "embassy-hal-internal",
- "embassy-sync 0.7.2",
+ "embassy-hal-internal 0.4.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
@@ -576,9 +576,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-hal-internal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#4699b3c023cd9276a7589c5cbdec8f6523a11739"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#d95ffe560071e942d917b422bbdea7e73f6c4602"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -588,8 +597,8 @@ dependencies = [
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
- "embassy-hal-internal",
- "embassy-sync 0.7.2",
+ "embassy-hal-internal 0.3.0",
+ "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -614,21 +623,6 @@ dependencies = [
 
 [[package]]
 name = "embassy-sync"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
-dependencies = [
- "cfg-if",
- "critical-section",
- "defmt 1.0.1",
- "embedded-io-async 0.6.1",
- "futures-core",
- "futures-sink",
- "heapless 0.8.0",
-]
-
-[[package]]
-name = "embassy-sync"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
@@ -645,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -664,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]
@@ -811,10 +805,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#458f99699831ef5fbb557175334195cca7440f49"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt 1.0.1",
+ "num_enum",
 ]
 
 [[package]]
@@ -848,7 +844,7 @@ dependencies = [
  "critical-section",
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
  "embedded-batteries-async",
@@ -930,7 +926,7 @@ dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
  "embassy-imxrt",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embedded-services",
  "log",
  "mctp-rs",
@@ -1066,7 +1062,7 @@ name = "hid-service"
 version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -1189,7 +1185,7 @@ dependencies = [
  "bitflags 2.9.4",
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-services",
@@ -1468,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1478,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1510,7 +1506,7 @@ dependencies = [
  "block-device-driver",
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embedded-storage-async",
  "partition-manager-macros",
 ]
@@ -1582,7 +1578,7 @@ dependencies = [
  "crc",
  "defmt 0.3.100",
  "embassy-imxrt",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-services",
  "log",
@@ -1611,7 +1607,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-services",
  "heapless 0.8.0",
@@ -1690,9 +1686,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "regex"
@@ -1936,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#458f99699831ef5fbb557175334195cca7440f49"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#528045934782abc704531aa423169c75016e7727"
 
 [[package]]
 name = "subenum"
@@ -1984,7 +1980,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-fans-async",
  "embedded-sensors-hal-async",
@@ -2113,7 +2109,7 @@ dependencies = [
  "bitfield 0.19.2",
  "defmt 0.3.100",
  "device-driver",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -2194,7 +2190,7 @@ dependencies = [
  "critical-section",
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
  "embedded-cfu-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude = ["examples/*"]
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.90"
 license = "MIT"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ embedded-services = { path = "./embedded-service" }
 embedded-storage-async = "0.4.1"
 embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false }
 mctp-rs = { git = "https://github.com/dymk/mctp-rs" }
-num_enum = { version = "0.7.4", default-features = false }
+num_enum = { version = "0.7.5", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
 heapless = "0.8.*"
 log = "0.4"

--- a/battery-service/Cargo.toml
+++ b/battery-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Battery fuel gauge and charger embedded service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [package.metadata.cargo-machete]

--- a/embedded-service/Cargo.toml
+++ b/embedded-service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 description = "Embedded Service Layer for IPC, Feature Customization and Extension in Embedded Devices."
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/embedded-service/src/comms.rs
+++ b/embedded-service/src/comms.rs
@@ -319,9 +319,10 @@ async fn route(message: Message<'_>) -> Result<(), Infallible> {
 
     for rxq in list {
         if let Some(endpoint) = rxq.data::<Endpoint>()
-            && message.to == endpoint.id {
-                endpoint.process(&message);
-            }
+            && message.to == endpoint.id
+        {
+            endpoint.process(&message);
+        }
     }
 
     Ok(())

--- a/embedded-service/src/comms.rs
+++ b/embedded-service/src/comms.rs
@@ -318,11 +318,10 @@ async fn route(message: Message<'_>) -> Result<(), Infallible> {
     let list = get_list(message.to).get().await;
 
     for rxq in list {
-        if let Some(endpoint) = rxq.data::<Endpoint>() {
-            if message.to == endpoint.id {
+        if let Some(endpoint) = rxq.data::<Endpoint>()
+            && message.to == endpoint.id {
                 endpoint.process(&message);
             }
-        }
     }
 
     Ok(())

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -141,11 +141,10 @@ fn get_device(id: DeviceId) -> Option<&'static device::Device> {
 pub async fn compute_total_provider_power_mw() -> u32 {
     let mut total = 0;
     for device in CONTEXT.devices.iter_only::<device::Device>() {
-        if let Some(capability) = device.provider_capability().await {
-            if device.is_provider().await {
+        if let Some(capability) = device.provider_capability().await
+            && device.is_provider().await {
                 total += capability.capability.max_power_mw();
             }
-        }
     }
     total
 }

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -142,9 +142,10 @@ pub async fn compute_total_provider_power_mw() -> u32 {
     let mut total = 0;
     for device in CONTEXT.devices.iter_only::<device::Device>() {
         if let Some(capability) = device.provider_capability().await
-            && device.is_provider().await {
-                total += capability.capability.max_power_mw();
-            }
+            && device.is_provider().await
+        {
+            total += capability.capability.max_power_mw();
+        }
     }
     total
 }

--- a/espi-service/Cargo.toml
+++ b/espi-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "eSPI embedded service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [package.metadata.cargo-machete]

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aquamarine"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,10 +193,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "cortex-m"
@@ -382,10 +411,11 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
+ "cordyceps",
  "cortex-m",
  "critical-section",
  "defmt 1.0.1",
@@ -396,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -746,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixed"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +816,21 @@ name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "half"
@@ -870,10 +921,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "mctp-rs"
@@ -888,6 +979,12 @@ dependencies = [
  "smbus-pec",
  "thiserror",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimxrt600-fcb"
@@ -940,6 +1037,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -960,14 +1066,20 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "panic-probe"
@@ -984,6 +1096,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -1044,6 +1162,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rt633-examples"
 version = "0.1.0"
 dependencies = [
@@ -1082,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1256,27 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smbus-pec"
@@ -1218,6 +1380,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1498,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/examples/rt633/Cargo.toml
+++ b/examples/rt633/Cargo.toml
@@ -33,8 +33,8 @@ embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt"
 ] }
 
 embassy-sync = { version = "0.8", features = ["defmt"] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-cortex-m",
     "executor-thread",
     "executor-interrupt",
     "defmt",

--- a/examples/rt633/src/bin/espi.rs
+++ b/examples/rt633/src/bin/espi.rs
@@ -154,11 +154,11 @@ async fn main(spawner: Spawner) {
         slice::from_raw_parts_mut(start_espi_data, espi_data_len)
     };
 
-    spawner.must_spawn(espi_service_task(espi, memory_map_buffer));
+    spawner.spawn(espi_service_task(espi, memory_map_buffer).unwrap());
 
     battery_service::init().await;
 
-    spawner.spawn(battery_service::battery_update_service()).unwrap();
+    spawner.spawn(battery_service::battery_update_service().unwrap());
 
     loop {
         embassy_time::Timer::after_secs(10).await;

--- a/examples/rt633/src/bin/espi_battery.rs
+++ b/examples/rt633/src/bin/espi_battery.rs
@@ -302,7 +302,7 @@ async fn main(spawner: Spawner) {
         slice::from_raw_parts_mut(start_espi_data, espi_data_len)
     };
 
-    spawner.must_spawn(espi_service_task(espi, memory_map_buffer));
+    spawner.spawn(espi_service_task(espi, memory_map_buffer).unwrap());
 
     let config = embassy_imxrt::i2c::master::Config {
         speed: embassy_imxrt::i2c::master::Speed::Standard,
@@ -332,12 +332,12 @@ async fn main(spawner: Spawner) {
         },
     );
 
-    spawner.must_spawn(wrapper_task(wrap));
-    spawner.must_spawn(battery_service_task());
+    spawner.spawn(wrapper_task(wrap).unwrap());
+    spawner.spawn(battery_service_task().unwrap());
 
     battery_service::register_fuel_gauge(fg).unwrap();
 
-    spawner.must_spawn(battery_publish_task(fg));
+    spawner.spawn(battery_publish_task(fg).unwrap());
 
     if let Err(e) = battery_service::execute_event(BatteryEvent {
         device_id: DeviceId(0),

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +239,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +261,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
 ]
 
 [[package]]
@@ -493,10 +522,11 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
+ "cordyceps",
  "cortex-m",
  "critical-section",
  "defmt 1.0.1",
@@ -507,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -855,6 +885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixed"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +925,21 @@ name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "half"
@@ -1024,10 +1075,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
 name = "litrs"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "mctp-rs"
@@ -1131,6 +1222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1215,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1251,6 +1351,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-service"
@@ -1346,6 +1452,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rt685s-evk-example"
 version = "0.1.0"
 dependencies = [
@@ -1401,6 +1524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1575,27 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smbus-pec"
@@ -1569,6 +1719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tps6699x"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/tps6699x#aa3425136216dccfb107bff6b172a49b8972bb70"
@@ -1585,6 +1744,67 @@ dependencies = [
  "embedded-usb-pd",
  "heapless 0.8.0",
  "itertools 0.14.0",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1643,6 +1863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1899,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -35,8 +35,8 @@ embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt"
 embassy-embedded-hal = { version = "0.6.0", features = ["defmt"] }
 
 embassy-sync = { version = "0.8", features = ["defmt"] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-cortex-m",
     "executor-thread",
     "executor-interrupt",
     "defmt",

--- a/examples/rt685s-evk/src/bin/keyboard.rs
+++ b/examples/rt685s-evk/src/bin/keyboard.rs
@@ -150,10 +150,10 @@ async fn main(spawner: Spawner) {
     info!("Service initialization complete...");
 
     // create an activity service subscriber
-    spawner.spawn(activity_example::backlight::task()).unwrap();
+    spawner.spawn(activity_example::backlight::task().unwrap());
 
     // create an activity service publisher
-    spawner.spawn(activity_example::publisher::keyboard_task()).unwrap();
+    spawner.spawn(activity_example::publisher::keyboard_task().unwrap());
 
     info!("Subsystem initialization complete...");
 

--- a/examples/rt685s-evk/src/bin/mock_espi_service.rs
+++ b/examples/rt685s-evk/src/bin/mock_espi_service.rs
@@ -182,9 +182,9 @@ async fn main(spawner: Spawner) {
 
     info!("Service initialization complete...");
 
-    spawner.spawn(espi_service::espi_service()).unwrap();
+    spawner.spawn(espi_service::espi_service().unwrap());
 
-    spawner.spawn(battery_service::battery_service_task()).unwrap();
+    spawner.spawn(battery_service::battery_service_task().unwrap());
 
     info!("Subsystem initialization complete...");
 }

--- a/examples/rt685s-evk/src/bin/power_button.rs
+++ b/examples/rt685s-evk/src/bin/power_button.rs
@@ -129,8 +129,8 @@ async fn main(spawner: Spawner) {
     let config_b = ButtonConfig::default();
 
     // Spawn the button tasks
-    spawner.must_spawn(button_task(button_a, config_a));
-    spawner.must_spawn(button_task(button_b, config_b));
+    spawner.spawn(button_task(button_a, config_a).unwrap());
+    spawner.spawn(button_task(button_b, config_b).unwrap());
 
     static RECEIVER: StaticCell<receiver::Receiver> = StaticCell::new();
     let receiver = RECEIVER.init(receiver::Receiver::new());

--- a/examples/rt685s-evk/src/bin/reset.rs
+++ b/examples/rt685s-evk/src/bin/reset.rs
@@ -50,7 +50,7 @@ async fn main(spawner: embassy_executor::Spawner) {
         // when immediately calling reset below
         blocker.register().expect("Infallible");
 
-        spawner.must_spawn(reset_watcher(blocker));
+        spawner.spawn(reset_watcher(blocker).unwrap());
     }
 
     // perform reset

--- a/examples/rt685s-evk/src/bin/transport.rs
+++ b/examples/rt685s-evk/src/bin/transport.rs
@@ -156,8 +156,8 @@ async fn main(spawner: Spawner) {
 
     info!("Service initialization complete...");
 
-    spawner.spawn(simple_example::receiver()).unwrap();
-    spawner.spawn(simple_example::sender()).unwrap();
+    spawner.spawn(simple_example::receiver().unwrap());
+    spawner.spawn(simple_example::sender().unwrap());
 
     info!("Subsystem initialization complete...");
 

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -87,10 +87,10 @@ async fn main(spawner: Spawner) {
     type_c::controller::init();
 
     info!("Spawining power policy task");
-    spawner.must_spawn(power_policy_service_task());
+    spawner.spawn(power_policy_service_task().unwrap());
 
     info!("Spawining type-c service task");
-    spawner.must_spawn(type_c_service_task());
+    spawner.spawn(type_c_service_task().unwrap());
 
     let int_in = Input::new(p.PIO1_7, Pull::Up, Inverter::Disabled);
     static BUS: StaticCell<Mutex<GlobalRawMutex, BusMaster<'static>>> = StaticCell::new();
@@ -109,7 +109,7 @@ async fn main(spawner: Spawner) {
     tps6699x.reset(&mut delay).await.unwrap();
 
     info!("Spawining interrupt task");
-    spawner.must_spawn(interrupt_task(int_in, interrupt));
+    spawner.spawn(interrupt_task(int_in, interrupt).unwrap());
 
     // These aren't enabled by default
     tps6699x
@@ -152,7 +152,7 @@ async fn main(spawner: Spawner) {
         WRAPPER.init(ControllerWrapper::try_new(controller_mutex, Default::default(), referenced, Validator).unwrap());
 
     wrapper.register().await.unwrap();
-    spawner.must_spawn(pd_controller_task(wrapper));
+    spawner.spawn(pd_controller_task(wrapper).unwrap());
 
     // Sync our internal state with the hardware
     type_c::external::sync_controller_state(CONTROLLER0_ID).await.unwrap();

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -172,10 +172,10 @@ async fn main(spawner: Spawner) {
     type_c::controller::init();
 
     info!("Spawining power policy task");
-    spawner.must_spawn(power_policy_service_task());
+    spawner.spawn(power_policy_service_task().unwrap());
 
     info!("Spawining type-c service task");
-    spawner.must_spawn(type_c_service_task());
+    spawner.spawn(type_c_service_task().unwrap());
 
     let int_in = Input::new(p.PIO1_7, Pull::Up, Inverter::Disabled);
     static BUS: StaticCell<Mutex<GlobalRawMutex, BusMaster<'static>>> = StaticCell::new();
@@ -194,7 +194,7 @@ async fn main(spawner: Spawner) {
     tps6699x.reset(&mut delay).await.unwrap();
 
     info!("Spawining interrupt task");
-    spawner.must_spawn(interrupt_task(int_in, interrupt));
+    spawner.spawn(interrupt_task(int_in, interrupt).unwrap());
 
     // These aren't enabled by default
     tps6699x
@@ -236,7 +236,7 @@ async fn main(spawner: Spawner) {
         WRAPPER.init(ControllerWrapper::try_new(controller_mutex, Default::default(), referenced, Validator).unwrap());
 
     wrapper.register().await.unwrap();
-    spawner.must_spawn(pd_controller_task(wrapper));
+    spawner.spawn(pd_controller_task(wrapper).unwrap());
 
-    spawner.must_spawn(fw_update_task());
+    spawner.spawn(fw_update_task().unwrap());
 }

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -490,10 +490,11 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-executor"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
+ "cordyceps",
  "critical-section",
  "document-features",
  "embassy-executor-macros",
@@ -503,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1222,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1232,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -17,8 +17,8 @@ workspace = true
 [dependencies]
 embassy-sync = { version = "0.8", features = ["log", "std"] }
 embassy-time = { version = "0.5.0", features = ["log", "std"] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-std",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-std",
     "executor-thread",
     "log",
 ] }

--- a/examples/std/src/bin/battery.rs
+++ b/examples/std/src/bin/battery.rs
@@ -500,7 +500,7 @@ async fn main(spawner: Spawner) {
 
     battery_service::register_fuel_gauge(dev).unwrap();
 
-    spawner.must_spawn(espi_service::task());
-    spawner.must_spawn(wrapper_task(wrap));
-    spawner.must_spawn(battery_service_task());
+    spawner.spawn(espi_service::task().unwrap());
+    spawner.spawn(wrapper_task(wrap).unwrap());
+    spawner.spawn(battery_service_task().unwrap());
 }

--- a/examples/std/src/bin/buffer.rs
+++ b/examples/std/src/bin/buffer.rs
@@ -109,6 +109,6 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(task()).unwrap();
+        spawner.spawn(task().unwrap());
     });
 }

--- a/examples/std/src/bin/cfu_buffer.rs
+++ b/examples/std/src/bin/cfu_buffer.rs
@@ -173,7 +173,7 @@ async fn run(spawner: Spawner) {
         )
     });
     cfu::register_device(device0).await.unwrap();
-    spawner.must_spawn(device_task(device0));
+    spawner.spawn(device_task(device0).unwrap());
 
     info!("Creating buffer");
     static BUFFER: OnceLock<buffer::Buffer<'static>> = OnceLock::new();
@@ -190,7 +190,7 @@ async fn run(spawner: Spawner) {
         )
     });
     buffer.register().await.unwrap();
-    spawner.must_spawn(buffer_task(buffer));
+    spawner.spawn(buffer_task(buffer).unwrap());
 
     info!("Getting FW version");
     let response = route_request(CFU_BUFFER_ID, RequestData::FwVersionRequest)
@@ -256,7 +256,7 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(cfu_service_task());
-        spawner.must_spawn(run(spawner));
+        spawner.spawn(cfu_service_task().unwrap());
+        spawner.spawn(run(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/cfu_client.rs
+++ b/examples/std/src/bin/cfu_client.rs
@@ -40,14 +40,14 @@ async fn run(spawner: Spawner) {
     subs[0] = Some(2);
     let device0 = DEVICE0.get_or_init(|| CfuComponentDefault::new(1, true, subs, CfuWriterNop {}));
     cfu::register_device(device0).await.unwrap();
-    spawner.must_spawn(device_task0(device0));
+    spawner.spawn(device_task0(device0).unwrap());
 
     info!("Creating device 1");
     static DEVICE1: OnceLock<CfuComponentDefault<CfuWriterNop>> = OnceLock::new();
     let device1 =
         DEVICE1.get_or_init(|| CfuComponentDefault::new(2, false, [None; MAX_SUBCMPT_COUNT], CfuWriterNop {}));
     cfu::register_device(device1).await.unwrap();
-    spawner.must_spawn(device_task1(device1));
+    spawner.spawn(device_task1(device1).unwrap());
 
     let dummy_offer0 = FwUpdateOffer::new(
         HostToken::Driver,
@@ -102,7 +102,7 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(cfu_service_task());
-        spawner.must_spawn(run(spawner));
+        spawner.spawn(cfu_service_task().unwrap());
+        spawner.spawn(run(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/cfu_splitter.rs
+++ b/examples/std/src/bin/cfu_splitter.rs
@@ -191,7 +191,7 @@ async fn run(spawner: Spawner) {
         )
     });
     cfu::register_device(device0).await.unwrap();
-    spawner.must_spawn(device_task(device0));
+    spawner.spawn(device_task(device0).unwrap());
 
     info!("Creating device 1");
     static DEVICE1: OnceLock<mock::Device> = OnceLock::new();
@@ -206,7 +206,7 @@ async fn run(spawner: Spawner) {
         )
     });
     cfu::register_device(device1).await.unwrap();
-    spawner.must_spawn(device_task(device1));
+    spawner.spawn(device_task(device1).unwrap());
 
     info!("Creating splitter");
     static SPLITTER: OnceLock<splitter::Splitter<'static, mock::Customization>> = OnceLock::new();
@@ -214,7 +214,7 @@ async fn run(spawner: Spawner) {
     let customization = mock::Customization {};
     let splitter = SPLITTER.get_or_init(|| splitter::Splitter::new(CFU_SPLITTER_ID, &DEVICES, customization).unwrap());
     splitter.register().await.unwrap();
-    spawner.must_spawn(splitter_task(splitter));
+    spawner.spawn(splitter_task(splitter).unwrap());
 
     info!("Getting FW version");
     let response = route_request(CFU_SPLITTER_ID, RequestData::FwVersionRequest)
@@ -274,7 +274,7 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(cfu_service_task());
-        spawner.must_spawn(run(spawner));
+        spawner.spawn(cfu_service_task().unwrap());
+        spawner.spawn(run(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/debug.rs
+++ b/examples/std/src/bin/debug.rs
@@ -1,4 +1,33 @@
 /// This example is supposed to init a debug service and a mock eSPI service to demonstrate sending defmt messages from the debug service to the eSPI service
+// On Windows the MSVC linker does not process defmt's ELF linker script (`defmt.x`), so the
+// `__DEFMT_MARKER_*` section-boundary symbols that defmt 1.0.x requires for log-level filtering
+// are undefined at link time.  Provide no-op stubs here so the binary links successfully.
+// Log-level filtering will be non-functional (all levels treated as enabled), which is
+// acceptable for a std development example.
+#[cfg(windows)]
+mod _defmt_linker_stubs {
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_TRACE_START: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_TRACE_END: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_DEBUG_START: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_DEBUG_END: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_INFO_START: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_INFO_END: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_WARN_START: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_WARN_END: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_ERROR_START: u32 = 0;
+    #[unsafe(no_mangle)]
+    pub static __DEFMT_MARKER_ERROR_END: u32 = 0;
+}
+
 use embassy_executor::{Executor, Spawner};
 use embedded_services::comms::{Endpoint, EndpointID, External};
 use embedded_services::info;
@@ -175,15 +204,15 @@ async fn init_task(spawner: Spawner) {
     info!("init espi service");
     espi_service::init().await;
     // Spawn eSPI request task to drive the OOB request/response flow
-    spawner.must_spawn(espi_service::request_task());
+    spawner.spawn(espi_service::request_task().unwrap());
 
     info!("spawn debug service");
-    spawner.must_spawn(debug_service());
+    spawner.spawn(debug_service().unwrap());
 
     info!("spawn defmt_to_host_task");
-    spawner.must_spawn(defmt_to_host_task());
+    spawner.spawn(defmt_to_host_task().unwrap());
 
-    spawner.must_spawn(defmt_frames_task());
+    spawner.spawn(defmt_frames_task().unwrap());
 }
 
 #[embassy_executor::task]
@@ -206,6 +235,6 @@ fn main() {
 
     executor.run(|spawner| {
         // Spawn debug-service tasks and mock eSPI service
-        spawner.must_spawn(init_task(spawner));
+        spawner.spawn(init_task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/hid.rs
+++ b/examples/std/src/bin/hid.rs
@@ -78,13 +78,13 @@ async fn run(spawner: Spawner) {
     let dev1 = DEVICE1.get_or_init(|| Device::new(DEV1_ID));
     comms::register_endpoint(dev1, &dev1.tp).await.unwrap();
     info!("Spawning host task");
-    spawner.spawn(host()).unwrap();
+    spawner.spawn(host().unwrap());
 }
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 fn main() {
     env_logger::builder().filter_level(log::LevelFilter::Info).init();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(run(spawner)).unwrap();
+        spawner.spawn(run(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/init.rs
+++ b/examples/std/src/bin/init.rs
@@ -25,7 +25,7 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(registration_waiter());
-        spawner.must_spawn(registration_task());
+        spawner.spawn(registration_waiter().unwrap());
+        spawner.spawn(registration_task().unwrap());
     });
 }

--- a/examples/std/src/bin/keyboard.rs
+++ b/examples/std/src/bin/keyboard.rs
@@ -139,8 +139,8 @@ async fn run(spawner: Spawner) {
 
     keyboard::enable_broadcast_host().await;
 
-    spawner.must_spawn(host());
-    spawner.must_spawn(device());
+    spawner.spawn(host().unwrap());
+    spawner.spawn(device().unwrap());
 }
 
 fn main() {
@@ -149,6 +149,6 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(run(spawner));
+        spawner.spawn(run(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/power_policy.rs
+++ b/examples/std/src/bin/power_policy.rs
@@ -88,14 +88,14 @@ async fn run(spawner: Spawner) {
     static DEVICE0: OnceLock<ExampleDevice> = OnceLock::new();
     let device0_mock = DEVICE0.get_or_init(|| ExampleDevice::new(policy::DeviceId(0)));
     policy::register_device(device0_mock).unwrap();
-    spawner.must_spawn(device_task0(device0_mock));
+    spawner.spawn(device_task0(device0_mock).unwrap());
     let device0 = device0_mock.device.try_device_action().await.unwrap();
 
     info!("Creating device 1");
     static DEVICE1: OnceLock<ExampleDevice> = OnceLock::new();
     let device1_mock = DEVICE1.get_or_init(|| ExampleDevice::new(policy::DeviceId(1)));
     policy::register_device(device1_mock).unwrap();
-    spawner.must_spawn(device_task1(device1_mock));
+    spawner.spawn(device_task1(device1_mock).unwrap());
     let device1 = device1_mock.device.try_device_action().await.unwrap();
 
     // Plug in device 0, should become current consumer
@@ -247,8 +247,8 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(power_policy_task(power_policy_service::config::Config::default()));
-        spawner.must_spawn(run(spawner));
-        spawner.must_spawn(receiver_task());
+        spawner.spawn(power_policy_task(power_policy_service::config::Config::default()).unwrap());
+        spawner.spawn(run(spawner).unwrap());
+        spawner.spawn(receiver_task().unwrap());
     });
 }

--- a/examples/std/src/bin/thermal.rs
+++ b/examples/std/src/bin/thermal.rs
@@ -289,7 +289,7 @@ async fn init_sensor(spawner: Spawner) {
     let sensor = SENSOR.get_or_init(|| ts::sensor::Sensor::new(ts::sensor::DeviceId(0), mock_sensor, profile));
 
     ts::register_sensor(sensor.device()).await.unwrap();
-    spawner.must_spawn(mock_sensor_task(sensor));
+    spawner.spawn(mock_sensor_task(sensor).unwrap());
 }
 
 async fn init_fan(spawner: Spawner) {
@@ -299,7 +299,7 @@ async fn init_fan(spawner: Spawner) {
     let fan = FAN.get_or_init(|| ts::fan::Fan::new(ts::fan::DeviceId(0), mock_fan, ts::fan::Profile::default()));
 
     ts::register_fan(fan.device()).await.unwrap();
-    spawner.must_spawn(mock_fan_task(fan));
+    spawner.spawn(mock_fan_task(fan).unwrap());
 }
 
 async fn init_thermal(spawner: Spawner) {
@@ -353,9 +353,9 @@ async fn handle_requests() -> ! {
 async fn run(spawner: Spawner) {
     embedded_services::init().await;
     init_thermal(spawner).await;
-    spawner.must_spawn(host());
-    spawner.must_spawn(handle_alerts());
-    spawner.must_spawn(handle_requests());
+    spawner.spawn(host().unwrap());
+    spawner.spawn(handle_alerts().unwrap());
+    spawner.spawn(handle_requests().unwrap());
 }
 
 fn main() {
@@ -364,7 +364,7 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(run(spawner));
+        spawner.spawn(run(spawner).unwrap());
     });
 }
 

--- a/examples/std/src/bin/type_c/basic.rs
+++ b/examples/std/src/bin/type_c/basic.rs
@@ -144,7 +144,7 @@ async fn task(spawner: Spawner) {
     controller::init();
 
     info!("Starting controller task");
-    spawner.must_spawn(controller_task());
+    spawner.spawn(controller_task().unwrap());
     // Wait for controller to be registered
     Timer::after_secs(1).await;
 
@@ -168,6 +168,6 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(task(spawner)).unwrap();
+        spawner.spawn(task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/type_c/external.rs
+++ b/examples/std/src/bin/type_c/external.rs
@@ -109,8 +109,8 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(type_c_service_task());
-        spawner.must_spawn(task(spawner));
-        spawner.must_spawn(controller_task());
+        spawner.spawn(type_c_service_task().unwrap());
+        spawner.spawn(task(spawner).unwrap());
+        spawner.spawn(controller_task().unwrap());
     });
 }

--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -123,7 +123,7 @@ async fn task(spawner: Spawner) {
     let state = STATE.get_or_init(mock_controller::ControllerState::new);
 
     info!("Starting controller task");
-    spawner.must_spawn(controller_task(state));
+    spawner.spawn(controller_task(state).unwrap());
     // Wait for controller to be registered
     Timer::after_secs(1).await;
 
@@ -167,8 +167,8 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(power_policy_service_task());
-        spawner.must_spawn(type_c_service_task());
-        spawner.must_spawn(task(spawner));
+        spawner.spawn(power_policy_service_task().unwrap());
+        spawner.spawn(type_c_service_task().unwrap());
+        spawner.spawn(task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/type_c/ucsi.rs
+++ b/examples/std/src/bin/type_c/ucsi.rs
@@ -45,7 +45,7 @@ async fn opm_task(spawner: Spawner) {
         mock_controller::Wrapper::try_new(controller0, Default::default(), referenced0, mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
-    spawner.must_spawn(wrapper_task(wrapper0));
+    spawner.spawn(wrapper_task(wrapper0).unwrap());
 
     static STORAGE1: StaticCell<Storage<1, GlobalRawMutex>> = StaticCell::new();
     let storage1 = STORAGE1.init(Storage::new(CONTROLLER1_ID, CFU1_ID, [(PORT1_ID, POWER1_ID)]));
@@ -65,7 +65,7 @@ async fn opm_task(spawner: Spawner) {
         mock_controller::Wrapper::try_new(controller1, Default::default(), referenced1, mock_controller::Validator)
             .expect("Failed to create wrapper"),
     );
-    spawner.must_spawn(wrapper_task(wrapper1));
+    spawner.spawn(wrapper_task(wrapper1).unwrap());
 
     const CAPABILITY: PowerCapability = PowerCapability {
         voltage_mv: 20000,
@@ -245,9 +245,9 @@ async fn task(spawner: Spawner) {
 
     embedded_services::init().await;
 
-    spawner.must_spawn(power_policy_service_task());
-    spawner.must_spawn(type_c_service_task());
-    spawner.must_spawn(opm_task(spawner));
+    spawner.spawn(power_policy_service_task().unwrap());
+    spawner.spawn(type_c_service_task().unwrap());
+    spawner.spawn(opm_task(spawner).unwrap());
 }
 
 fn main() {
@@ -256,6 +256,6 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(task(spawner));
+        spawner.spawn(task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/type_c/unconstrained.rs
+++ b/examples/std/src/bin/type_c/unconstrained.rs
@@ -118,9 +118,9 @@ async fn task(spawner: Spawner) {
     );
 
     info!("Starting controller tasks");
-    spawner.must_spawn(controller_task(wrapper0));
-    spawner.must_spawn(controller_task(wrapper1));
-    spawner.must_spawn(controller_task(wrapper2));
+    spawner.spawn(controller_task(wrapper0).unwrap());
+    spawner.spawn(controller_task(wrapper1).unwrap());
+    spawner.spawn(controller_task(wrapper2).unwrap());
 
     const CAPABILITY: PowerCapability = PowerCapability {
         voltage_mv: 20000,
@@ -190,8 +190,8 @@ fn main() {
     static EXECUTOR: StaticCell<Executor> = StaticCell::new();
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.must_spawn(power_policy_service_task());
-        spawner.must_spawn(type_c_service_task());
-        spawner.must_spawn(task(spawner));
+        spawner.spawn(power_policy_service_task().unwrap());
+        spawner.spawn(type_c_service_task().unwrap());
+        spawner.spawn(task(spawner).unwrap());
     });
 }

--- a/hid-service/Cargo.toml
+++ b/hid-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "HID embedded service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [package.metadata.cargo-machete]

--- a/keyboard-service/Cargo.toml
+++ b/keyboard-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Keyboard service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [package.metadata.cargo-machete]

--- a/partition-manager/partition-manager/src/ext/bdd.rs
+++ b/partition-manager/partition-manager/src/ext/bdd.rs
@@ -11,7 +11,7 @@ impl<F, MARKER, M: RawMutex> Partition<'_, F, MARKER, M> {
     ///
     /// Will not be able to return a value of the partition is not aligned to a single block.
     const fn start_block(&self, block_size: u32) -> Option<u32> {
-        if self.offset % block_size != 0 {
+        if !self.offset.is_multiple_of(block_size) {
             None
         } else {
             Some(self.offset / block_size)

--- a/partition-manager/partition-manager/src/test/mock.rs
+++ b/partition-manager/partition-manager/src/test/mock.rs
@@ -155,7 +155,7 @@ pub mod esa {
         const READ_SIZE: usize = 4;
 
         async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
-            if (offset as usize) % Self::READ_SIZE != 0 || bytes.len() % Self::READ_SIZE != 0 {
+            if !(offset as usize).is_multiple_of(Self::READ_SIZE) || !bytes.len().is_multiple_of(Self::READ_SIZE) {
                 return Err(Error::NotAligned);
             }
 
@@ -175,7 +175,7 @@ pub mod esa {
         async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
             let len = to.checked_sub(from).unwrap();
 
-            if (from as usize) % Self::ERASE_SIZE != 0 || len as usize % Self::ERASE_SIZE != 0 {
+            if !(from as usize).is_multiple_of(Self::ERASE_SIZE) || !(len as usize).is_multiple_of(Self::ERASE_SIZE) {
                 return Err(Error::NotAligned);
             }
 
@@ -184,7 +184,7 @@ pub mod esa {
         }
 
         async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
-            if (offset as usize) % Self::WRITE_SIZE != 0 || bytes.len() % Self::WRITE_SIZE != 0 {
+            if !(offset as usize).is_multiple_of(Self::WRITE_SIZE) || !bytes.len().is_multiple_of(Self::WRITE_SIZE) {
                 return Err(Error::NotAligned);
             }
 

--- a/power-button-service/Cargo.toml
+++ b/power-button-service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 description = "Power button service built upon embedded service"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["defmt", "log"]

--- a/power-policy-service/Cargo.toml
+++ b/power-policy-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "HID embedded service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [lints]

--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -93,11 +93,10 @@ impl PowerPolicy {
         let mut unconstrained_new = UnconstrainedState::default();
         for node in self.context.devices() {
             let device = node.data::<Device>().ok_or(Error::InvalidDevice)?;
-            if let Some(capability) = device.consumer_capability().await {
-                if capability.flags.unconstrained_power() {
+            if let Some(capability) = device.consumer_capability().await
+                && capability.flags.unconstrained_power() {
                     unconstrained_new.available += 1;
                 }
-            }
         }
 
         // The overall unconstrained state is true if an unconstrained consumer is currently connected

--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -94,9 +94,10 @@ impl PowerPolicy {
         for node in self.context.devices() {
             let device = node.data::<Device>().ok_or(Error::InvalidDevice)?;
             if let Some(capability) = device.consumer_capability().await
-                && capability.flags.unconstrained_power() {
-                    unconstrained_new.available += 1;
-                }
+                && capability.flags.unconstrained_power()
+            {
+                unconstrained_new.available += 1;
+            }
         }
 
         // The overall unconstrained state is true if an unconstrained consumer is currently connected

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.90"
 targets = ["thumbv8m.main-none-eabihf"]
 components = ["rust-src", "rustfmt", "llvm-tools-preview", "clippy"]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -72,6 +72,30 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "1.0.0"
 
+[[audits.embassy-embedded-hal]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.6.0"
+notes = "No unsafe code, no build script, no powerful imports. Added Clone for I2C devices. Updated embassy dependencies (embassy-sync 0.7→0.8, embassy-hal-internal 0.3→0.4, embassy-time 0.5→0.5.1). All changes safe."
+
+[[audits.embassy-hal-internal]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "Rust 2024 edition update with new ring buffer methods (available, is_half_full). All unsafe code is sound HAL pattern usage. Build script unchanged (cfg flags only). No powerful imports."
+
+[[audits.embassy-time]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.5.1"
+notes = "Rust 2024 edition update with import reordering. Unsafe pin projection patterns unchanged and sound. No build script. No new security concerns."
+
+[[audits.embassy-time-driver]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "Rust 2024 edition update with 375kHz tick rate feature. Empty build.rs, no unsafe code, no powerful imports."
+
 [[audits.embedded-batteries]]
 who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -164,6 +188,12 @@ who = "Kurtis Dinelle <kdinelle@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.2.0"
 notes = "ODP crates are always trusted."
+
+[[audits.embedded-mcu-hal]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "Trait-based MCU HAL with zero unsafe code. No build script or powerful imports. Pure trait design with optional chrono/defmt features. Ideal for embedded controllers."
 
 [[audits.embedded-sensors-hal]]
 who = "Kurtis Dinelle <kdinelle@microsoft.com>"
@@ -325,6 +355,12 @@ criteria = "safe-to-deploy"
 delta = "0.7.4 -> 0.7.5"
 notes = "Looks like this is just uptaking a new version of num_enum_derive"
 
+[[audits.num_enum]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.7.6"
+notes = "Version bump with test infrastructure updates. No unsafe code, no build script, no powerful imports. Purely additive test changes."
+
 [[audits.num_enum_derive]]
 who = "Matteo Tullo <matteotullo@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -335,6 +371,12 @@ who = "Billy Price <williamp@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "0.7.4 -> 0.7.5"
 notes = "Looks like mostly improvements to error messaging"
+
+[[audits.num_enum_derive]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.7.6"
+notes = "Minor update adding byte literal support for enum discriminants. No unsafe code, no build script, no powerful imports."
 
 [[audits.object]]
 who = "Robert Zieba <robertzieba@microsoft.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -32,24 +32,8 @@ audit-as-crates-io = false
 version = "0.8.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.askama]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.askama_derive]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.askama_parser]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.az]]
 version = "1.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bare-metal]]
-version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.bbq2]]
@@ -62,10 +46,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bincode_derive]]
 version = "2.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitfield]]
-version = "0.13.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitfield]]
@@ -100,28 +80,12 @@ criteria = "safe-to-deploy"
 version = "1.0.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.chrono]]
-version = "0.4.40"
-criteria = "safe-to-deploy"
-
 [[exemptions.convert_case]]
 version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cordyceps]]
 version = "0.3.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.cortex-m]]
-version = "0.7.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.cortex-m-rt]]
-version = "0.7.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.cortex-m-rt-macros]]
-version = "0.7.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.crc]]
@@ -132,40 +96,12 @@ criteria = "safe-to-deploy"
 version = "2.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.critical-section]]
-version = "1.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.darling]]
-version = "0.20.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.darling_core]]
-version = "0.20.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.darling_macro]]
-version = "0.20.11"
-criteria = "safe-to-deploy"
-
 [[exemptions.dd-manifest-tree]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.defmt]]
 version = "0.3.100"
-criteria = "safe-to-deploy"
-
-[[exemptions.defmt]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.defmt-macros]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.defmt-parser]]
-version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.device-driver]]
@@ -184,18 +120,6 @@ criteria = "safe-to-deploy"
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.embassy-executor]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor-macros]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor-timer-queue]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.embassy-futures]]
 version = "0.1.2"
 criteria = "safe-to-deploy"
@@ -205,27 +129,11 @@ version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.embassy-sync]]
-version = "0.7.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-sync]]
 version = "0.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time]]
-version = "0.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.embassy-time-driver]]
 version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time-queue-utils]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embedded-hal]]
-version = "0.2.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.embedded-hal]]
@@ -360,36 +268,8 @@ criteria = "safe-to-deploy"
 version = "1.1.10"
 criteria = "safe-to-deploy"
 
-[[exemptions.proc-macro-error-attr2]]
-version = "2.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.proc-macro-error2]]
-version = "2.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.radium]]
 version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustc-demangle]]
-version = "0.1.26"
-criteria = "safe-to-run"
-
-[[exemptions.rustc_version]]
-version = "0.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.semver]]
-version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.semver-parser]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_spanned]]
-version = "0.6.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.slab]]
@@ -420,20 +300,12 @@ criteria = "safe-to-deploy"
 version = "0.0.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.vcell]]
-version = "0.1.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.version_check]]
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.virtue]]
 version = "0.0.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.volatile-register]]
-version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -314,7 +314,125 @@ user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
-[audits.OpenDevicePartnership.audits]
+[[audits.OpenDevicePartnership.audits.bare-metal]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.5"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.bitfield]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.13.2"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.cortex-m]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.7"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.cortex-m-rt]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.cortex-m-rt-macros]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.critical-section]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.defmt]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.defmt-macros]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.defmt-parser]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embassy-executor-timer-queue]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embassy-time]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.5.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/tps6699x/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embassy-time-queue-utils]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-hal]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.7"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.proc-macro-error-attr2]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.proc-macro-error2]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "2.0.1"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.rustc_version]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.semver]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.semver-parser]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.vcell]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.volatile-register]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.bytecode-alliance.audits.adler2]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -480,6 +598,17 @@ a few `unsafe` blocks related to utf-8 validation which are locally verifiable
 as correct and otherwise this crate is good to go.
 """
 
+[[audits.bytecode-alliance.audits.rustc-demangle]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.21"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.rustc-demangle]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.21 -> 0.1.24"
+
 [[audits.bytecode-alliance.audits.semver]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -523,12 +652,6 @@ ecosystem. There's one `unsafe` block in this crate and it's well-scoped.
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.17"
-
-[[audits.embark-studios.audits.ident_case]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "1.0.1"
-notes = "No unsafe usage or ambient capabilities"
 
 [[audits.embark-studios.audits.tap]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -597,7 +720,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.0"
-notes = "The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = \"std\")]`."
+notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.equivalent]]
@@ -759,8 +882,8 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.35"
 notes = """
-Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
-(except for benign \"net\" hit in tests and \"fs\" hit in README.md)
+Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
+(except for benign "net" hit in tests and "fs" hit in README.md)
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -1026,7 +1149,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.197"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -1045,7 +1168,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.202 -> 1.0.203"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -1134,17 +1257,6 @@ who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
 version = "1.2.0"
 notes = "Purely a trait, crates using this should be carefully vetted since self-referential stuff can be super tricky around various unsafe rust edges."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.strsim]]
-who = "danakj@chromium.org"
-criteria = "safe-to-deploy"
-version = "0.10.0"
-notes = """
-Reviewed in https://crrev.com/c/5171063
-
-Previously reviewed during security review and the audit is grandparented in.
-"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.unicode-ident]]
@@ -1236,6 +1348,67 @@ criteria = "safe-to-deploy"
 version = "0.5.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.askama]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = """
+Template crate.  This is only used to generate the Rust/JS code for UniFFI.
+
+We used to use askama, then we switched to rinja which was a fork.  Now rinja and
+askama have merged again.
+
+The differences from askama 0.12, are pretty straightforward and don't seem risky to me.  There's
+some unsafe code and macros, but nothing that complicated.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.14.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_derive]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = """
+Template crate.  This is only used to generate the Rust/JS code for UniFFI.
+
+We used to use askama, then we switched to rinja which was a fork.  Now rinja and
+askama have merged again.
+
+I did a quick scan of the current code and couldn't find any issues.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_derive]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.14.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_parser]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.13.0"
+notes = """
+Template crate.  This is only used to generate the Rust/JS code for UniFFI.
+
+We used to use askama, then we switched to rinja which was a fork.  Now rinja and
+askama have merged again.
+
+I did a quick scan of the current code and couldn't find any issues.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_parser]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.0 -> 0.14.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.bitflags]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1277,12 +1450,6 @@ criteria = "safe-to-deploy"
 delta = "2.6.0 -> 2.7.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.chrono]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.40 -> 0.4.41"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.crunchy]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1311,13 +1478,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.10 -> 0.2.11"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.fnv]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "1.0.7"
-notes = "Simple hasher implementation with no unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.futures-core]]
@@ -1427,12 +1587,6 @@ criteria = "safe-to-deploy"
 delta = "1.1.0 -> 1.3.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.strsim]]
-who = "Ben Dean-Kawamura <bdk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.10.0 -> 0.11.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.tracing]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1514,6 +1668,25 @@ Build script change is to fix a bug where a path separator for an included file
 was being selected by the target OS instead of the host OS.
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc-demangle]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.24 -> 0.1.25"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc-demangle]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.25 -> 0.1.26"
+notes = "Parser changes use existing parsing machinery in an obvious way."
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.serde_spanned]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.6.8 -> 0.6.9"
+aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.thread_local]]
 who = "Jack Grigg <jack@z.cash>"

--- a/thermal-service/Cargo.toml
+++ b/thermal-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Thermal service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [package.metadata.cargo-machete]

--- a/type-c-service/Cargo.toml
+++ b/type-c-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "HID embedded service implementation"
 repository = "https://github.com/OpenDevicePartnership/embedded-services"
-rust-version = "1.88"
+rust-version.workspace = true
 license = "MIT"
 
 [package.metadata.cargo-machete]

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -53,15 +53,14 @@ where
         });
 
         // Recover if we're not in the correct state
-        if status.is_connected() {
-            if let action::device::AnyState::Detached(state) = power.device_action().await {
+        if status.is_connected()
+            && let action::device::AnyState::Detached(state) = power.device_action().await {
                 warn!("Power device is detached, attempting to attach");
                 if let Err(e) = state.attach().await {
                     error!("Error attaching power device: {:?}", e);
                     return PdError::Failed.into();
                 }
             }
-        }
 
         if let Ok(state) = power.try_device_action::<action::Idle>().await {
             if let Err(e) = state.notify_consumer_power_capability(available_sink_contract).await {
@@ -125,23 +124,21 @@ where
         }
 
         // Recover if we're not in the correct state
-        if status.is_connected() {
-            if let action::device::AnyState::Detached(state) = power.device_action().await {
+        if status.is_connected()
+            && let action::device::AnyState::Detached(state) = power.device_action().await {
                 warn!("Power device is detached, attempting to attach");
                 if let Err(e) = state.attach().await {
                     error!("Error attaching power device: {:?}", e);
                     return PdError::Failed.into();
                 }
             }
-        }
 
         if let Ok(state) = power.try_device_action::<action::Idle>().await {
-            if let Some(contract) = contract {
-                if let Err(e) = state.request_provider_power_capability(contract).await {
+            if let Some(contract) = contract
+                && let Err(e) = state.request_provider_power_capability(contract).await {
                     error!("Error setting power contract: {:?}", e);
                     return PdError::Failed.into();
                 }
-            }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
             if let Some(contract) = contract {
                 // Staying a provider, but we have updated capabilities
@@ -165,12 +162,11 @@ where
             };
 
             // If contract is none, we're no longer requesting power on this port
-            if let Some(contract) = contract {
-                if let Err(e) = state.request_provider_power_capability(contract).await {
+            if let Some(contract) = contract
+                && let Err(e) = state.request_provider_power_capability(contract).await {
                     error!("Error setting power contract: {:?}", e);
                     return PdError::Failed.into();
                 }
-            }
         } else {
             error!("Invalid mode");
             return PdError::InvalidMode.into();

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -54,13 +54,14 @@ where
 
         // Recover if we're not in the correct state
         if status.is_connected()
-            && let action::device::AnyState::Detached(state) = power.device_action().await {
-                warn!("Power device is detached, attempting to attach");
-                if let Err(e) = state.attach().await {
-                    error!("Error attaching power device: {:?}", e);
-                    return PdError::Failed.into();
-                }
+            && let action::device::AnyState::Detached(state) = power.device_action().await
+        {
+            warn!("Power device is detached, attempting to attach");
+            if let Err(e) = state.attach().await {
+                error!("Error attaching power device: {:?}", e);
+                return PdError::Failed.into();
             }
+        }
 
         if let Ok(state) = power.try_device_action::<action::Idle>().await {
             if let Err(e) = state.notify_consumer_power_capability(available_sink_contract).await {
@@ -125,20 +126,22 @@ where
 
         // Recover if we're not in the correct state
         if status.is_connected()
-            && let action::device::AnyState::Detached(state) = power.device_action().await {
-                warn!("Power device is detached, attempting to attach");
-                if let Err(e) = state.attach().await {
-                    error!("Error attaching power device: {:?}", e);
-                    return PdError::Failed.into();
-                }
+            && let action::device::AnyState::Detached(state) = power.device_action().await
+        {
+            warn!("Power device is detached, attempting to attach");
+            if let Err(e) = state.attach().await {
+                error!("Error attaching power device: {:?}", e);
+                return PdError::Failed.into();
             }
+        }
 
         if let Ok(state) = power.try_device_action::<action::Idle>().await {
             if let Some(contract) = contract
-                && let Err(e) = state.request_provider_power_capability(contract).await {
-                    error!("Error setting power contract: {:?}", e);
-                    return PdError::Failed.into();
-                }
+                && let Err(e) = state.request_provider_power_capability(contract).await
+            {
+                error!("Error setting power contract: {:?}", e);
+                return PdError::Failed.into();
+            }
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
             if let Some(contract) = contract {
                 // Staying a provider, but we have updated capabilities
@@ -163,10 +166,11 @@ where
 
             // If contract is none, we're no longer requesting power on this port
             if let Some(contract) = contract
-                && let Err(e) = state.request_provider_power_capability(contract).await {
-                    error!("Error setting power contract: {:?}", e);
-                    return PdError::Failed.into();
-                }
+                && let Err(e) = state.request_provider_power_capability(contract).await
+            {
+                error!("Error setting power contract: {:?}", e);
+                return PdError::Failed.into();
+            }
         } else {
             error!("Invalid mode");
             return PdError::InvalidMode.into();


### PR DESCRIPTION
Update all three example workspaces (std, rt685s-evk, rt633) to work with embassy-executor 0.10.0, and update related workspace dependencies:

- Bump rust-toolchain and MSRV from 1.88 to 1.90
- Bump num_enum from 0.7.4 to 0.7.5 in workspace Cargo.toml
- Update embassy-imxrt git revision in workspace Cargo.lock
- Rename executor feature flags: arch-std -> platform-std, arch-cortex-m -> platform-cortex-m in each example Cargo.toml
- Update example Cargo.lock files to resolve embassy-executor 0.10.0
- Replace removed spawner.must_spawn(X) with spawner.spawn(X.unwrap()) across all example binaries (task functions now return Result<SpawnToken, SpawnError> and spawn() takes SpawnToken directly)
- Replace spawner.spawn(X).unwrap() with spawner.spawn(X.unwrap()) to match the new spawn() -> () return type
- Add Windows-only __DEFMT_MARKER_* linker stubs in std/debug.rs to work around the MSVC linker not processing defmt's ELF linker script