### PR TITLE
Fix mux reconfig (MUXR) cmd

### DIFF
--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -465,7 +465,7 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
     async fn reconfigure_retimer(&mut self, port: LocalPortId) -> Result<(), Error<Self::BusError>> {
         let input = {
             let mut input = tps6699x::command::muxr::Input(0);
-            input.set_en_retry_on_target_addr_1(true);
+            input.set_en_retry_on_target_addr_tbt(true);
             input
         };
 
@@ -755,7 +755,7 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
         match self.tps6699x.execute_drst(port).await? {
             ReturnValue::Success => Ok(()),
             r => {
-                debug!("Error executing DRST on port {}: {:#?}", port.0, r);
+                error!("Error executing DRST on port {}: {:#?}", port.0, r);
                 Err(Error::Pd(PdError::InvalidResponse))
             }
         }

--- a/type-c-service/src/service/port.rs
+++ b/type-c-service/src/service/port.rs
@@ -205,11 +205,11 @@ impl<'a> Service<'a> {
         external::Response::Port(status.map(|_| external::PortResponseData::Complete))
     }
 
-    /// Process execute DisplayPort reset commands
+    /// Process execute PD data reset commands
     async fn process_execute_drst(&self, port_id: GlobalPortId) -> external::Response<'static> {
         let status = self.context.execute_drst(port_id).await;
         if let Err(e) = status {
-            error!("Error executing Data reset: {:#?}", e);
+            error!("Error executing PD data reset: {:#?}", e);
         }
 
         external::Response::Port(status.map(|_| external::PortResponseData::Complete))

--- a/type-c-service/src/service/port.rs
+++ b/type-c-service/src/service/port.rs
@@ -209,7 +209,7 @@ impl<'a> Service<'a> {
     async fn process_execute_drst(&self, port_id: GlobalPortId) -> external::Response<'static> {
         let status = self.context.execute_drst(port_id).await;
         if let Err(e) = status {
-            error!("Error executing DP reset: {:#?}", e);
+            error!("Error executing Data reset: {:#?}", e);
         }
 
         external::Response::Port(status.map(|_| external::PortResponseData::Complete))


### PR DESCRIPTION
I2c3 is used to communication with Retimer to config Muxes. PD FW configures the Retimer I2c address in TargetAddrTbt