### PR TITLE
Add guardrails and update audit sources for cargo-vet workflow

### DIFF
--- a/.github/agents/cargo-vet-auditor.agent.md
+++ b/.github/agents/cargo-vet-auditor.agent.md
@@ -86,6 +86,21 @@ For every crate you review, systematically check ALL of the following:
 
 ## How to Review
 
+## Duplicate-Audit Guardrail
+
+Before recommending or running certification, check whether an identical
+`[[audits.<crate>]]` entry (same who/criteria/version-or-delta/notes) already
+exists in `supply-chain/audits.toml`.
+
+If an identical entry already exists:
+
+- Do not recommend re-certifying with the same data
+- Report that the crate is already certified with identical audit content
+- If duplicates already exist, explicitly recommend deduplicating by keeping one
+  copy and removing the rest
+
+Rationale: retried `cargo vet certify` commands can append duplicate blocks.
+
 ### For Delta Audits
 
 Use `PAGER=cat cargo vet diff CRATE FROM TO` (POSIX) or

--- a/.github/agents/cargo-vet-auditor.agent.md
+++ b/.github/agents/cargo-vet-auditor.agent.md
@@ -86,6 +86,30 @@ For every crate you review, systematically check ALL of the following:
 
 ## How to Review
 
+### Non-Interactive Execution
+
+**CRITICAL:** All `cargo vet` commands must run non-interactively:
+
+- **`diff` / `inspect`:** Always set the pager to `cat` to prevent the pager
+  from waiting for input. Use `$env:PAGER='cat';` (PowerShell) or `PAGER=cat`
+  (POSIX) before the command.
+- **`certify`:** Always pass `--accept-all` along with `--criteria`, `--who`,
+  and `--notes` to skip all interactive prompts.
+
+Never run a `cargo vet` command that could block waiting for terminal input.
+
+## Exemptions Are a Last Resort
+
+Do **not** recommend adding `[[exemptions]]` entries without good reason.
+Each exemption bypasses the audit process entirely and requires explicit manual
+confirmation from the user. Always prefer performing a full or delta audit over
+exempting a crate. If an exemption is truly necessary (e.g., the crate is only
+needed at `safe-to-run` level for dev tooling, or an import source removal
+requires temporary coverage), flag it clearly and let the user decide.
+
+Every exemption **must** include a `notes` field explaining why the exemption
+exists and under what conditions it can be removed.
+
 ## Duplicate-Audit Guardrail
 
 Before recommending or running certification, check whether an identical

--- a/.github/agents/cargo-vet-auditor.agent.md
+++ b/.github/agents/cargo-vet-auditor.agent.md
@@ -90,15 +90,15 @@ For every crate you review, systematically check ALL of the following:
 
 **CRITICAL:** All `cargo vet` commands must run non-interactively:
 
-- **`diff` / `inspect`:** Always set the pager to `cat` to prevent the pager
-  from waiting for input. Use `$env:PAGER='cat';` (PowerShell) or `PAGER=cat`
-  (POSIX) before the command.
+- **`diff` / `inspect`:** Always set the pager to a non-interactive command to
+  prevent the pager from waiting for input. Use `$env:PAGER='more.com';`
+  (PowerShell) or `PAGER=cat` (POSIX) before the command.
 - **`certify`:** Always pass `--accept-all` along with `--criteria`, `--who`,
   and `--notes` to skip all interactive prompts.
 
 Never run a `cargo vet` command that could block waiting for terminal input.
 
-## Exemptions Are a Last Resort
+### Exemptions Are a Last Resort
 
 Do **not** recommend adding `[[exemptions]]` entries without good reason.
 Each exemption bypasses the audit process entirely and requires explicit manual
@@ -110,7 +110,7 @@ requires temporary coverage), flag it clearly and let the user decide.
 Every exemption **must** include a `notes` field explaining why the exemption
 exists and under what conditions it can be removed.
 
-## Duplicate-Audit Guardrail
+### Duplicate-Audit Guardrail
 
 Before recommending or running certification, check whether an identical
 `[[audits.<crate>]]` entry (same who/criteria/version-or-delta/notes) already
@@ -128,7 +128,7 @@ Rationale: retried `cargo vet certify` commands can append duplicate blocks.
 ### For Delta Audits
 
 Use `PAGER=cat cargo vet diff CRATE FROM TO` (POSIX) or
-`$env:PAGER='cat'; cargo vet diff CRATE FROM TO` (PowerShell) to view the diff.
+`$env:PAGER='more.com'; cargo vet diff CRATE FROM TO` (PowerShell) to view the diff.
 
 Focus on:
 1. New `unsafe` blocks or modifications to existing ones
@@ -140,7 +140,7 @@ Focus on:
 ### For Full Version Audits
 
 Use `PAGER=cat cargo vet inspect CRATE VERSION` (POSIX) or
-`$env:PAGER='cat'; cargo vet inspect CRATE VERSION` (PowerShell) to view source.
+`$env:PAGER='more.com'; cargo vet inspect CRATE VERSION` (PowerShell) to view source.
 
 Focus on:
 1. All `unsafe` code (search for `unsafe`)

--- a/.github/skills/cargo-vet-audit/SKILL.md
+++ b/.github/skills/cargo-vet-audit/SKILL.md
@@ -136,17 +136,9 @@ Duplicate-check workflow:
 2. If duplicates exist, keep one copy (usually the first) and remove the rest
 3. Re-run `cargo vet` after deduplication to ensure state is still valid
 
-Suggested duplicate detection commands:
-
-```powershell
-# PowerShell: use any local script/command that prints duplicate blocks
-# with crate names and line numbers
-```
-
-```shell
-# POSIX: optional equivalent using awk/python if available
-# (implementation may vary by environment)
-```
+To detect duplicates, scan `supply-chain/audits.toml` for repeated blocks
+with identical crate name, who, criteria, version/delta, and notes fields.
+Remove any duplicates before proceeding.
 
 Then run the normal cleanup sequence:
 

--- a/.github/skills/cargo-vet-audit/SKILL.md
+++ b/.github/skills/cargo-vet-audit/SKILL.md
@@ -60,6 +60,29 @@ Confidence scoring rubric:
 
 ## Step 5: Certify
 
+### Exemptions Are a Last Resort
+
+Do **not** add `[[exemptions]]` entries without explicit user confirmation.
+Each exemption bypasses the audit process entirely and must be justified.
+Valid reasons include:
+
+- The crate is only needed for `safe-to-run` (test/dev tooling) and a full
+  audit is disproportionate
+- An upstream import source was removed and the crate needs temporary coverage
+  while a first-party audit is scheduled
+- The user explicitly requests an exemption after reviewing the trade-offs
+
+Always prefer auditing (full or delta) over exempting. When an exemption is
+unavoidable, present it to the user for manual approval before adding it.
+
+Every exemption **must** include a `--notes` explaining why the exemption exists
+and under what conditions it can be removed:
+
+```shell
+cargo vet add-exemption CRATE VERSION --criteria CRITERIA \
+  --notes "Reason for exemption; plan for resolution"
+```
+
 For each crate that passes (confidence ≥ 70), run:
 
 ```shell

--- a/.github/skills/cargo-vet-audit/SKILL.md
+++ b/.github/skills/cargo-vet-audit/SKILL.md
@@ -104,9 +104,32 @@ the human reviewer, never the AI agent.
 
 ## Step 6: Verify and Clean Up
 
-1. Run `cargo vet` again to confirm everything passes
-2. Run `cargo vet prune` to remove stale exemptions
-3. Run `cargo vet` one final time to confirm clean state
+Before final verification, detect and remove identical duplicate `[[audits.*]]`
+entries that may have been appended by retried `cargo vet certify` commands.
+
+Duplicate-check workflow:
+
+1. Scan `supply-chain/audits.toml` for byte-for-byte identical audit blocks
+2. If duplicates exist, keep one copy (usually the first) and remove the rest
+3. Re-run `cargo vet` after deduplication to ensure state is still valid
+
+Suggested duplicate detection commands:
+
+```powershell
+# PowerShell: use any local script/command that prints duplicate blocks
+# with crate names and line numbers
+```
+
+```shell
+# POSIX: optional equivalent using awk/python if available
+# (implementation may vary by environment)
+```
+
+Then run the normal cleanup sequence:
+
+4. Run `cargo vet` again to confirm everything passes
+5. Run `cargo vet prune` to remove stale exemptions
+6. Run `cargo vet` one final time to confirm clean state
 
 ## Reviewing Import Sources
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -46,6 +46,12 @@ who = "Douglas Cheah <douglascheah@microsoft.com>"
 criteria = "safe-to-run"
 version = "1.1.0"
 
+[[audits.autocfg]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+notes = "No unsafe, no build.rs, no network access; delta adds edition-aware rustc probing and best-effort probe-file cleanup only. Assisted-by: copilot-cli:GPT-5.3-Codex cargo-vet"
+
 [[audits.backtrace]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-run"
@@ -71,6 +77,12 @@ version = "1.0.3"
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "1.0.0"
+
+[[audits.crunchy]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.3 -> 0.2.4"
+notes = "Tiny diff to use newer core/std features via build.rs env var for path separator; no safety impact. Assisted-by: copilot-cli:GPT-5.3-Codex cargo-vet"
 
 [[audits.embassy-embedded-hal]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -460,6 +472,12 @@ who = "jerrysxie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.6.8"
 
+[[audits.serde_spanned]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.8 -> 0.6.9"
+notes = "Trivial delta: metadata, lint config, and doc formatting only. No functional code changes, no unsafe, no build script, no I/O. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+
 [[audits.smbus-pec]]
 who = "Matteo Tullo <matteotullo@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -479,6 +497,18 @@ version = "2.1.1"
 who = "Matteo Tullo <matteotullo@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "1.1.2"
+
+[[audits.tap]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+notes = "No unsafe, no build.rs, no ambient I/O/process/network capabilities; behavior matches no_std tap/pipe/conv utility traits. Assisted-by: copilot-cli:GPT-5.3-Codex cargo-vet"
+
+[[audits.thread_local]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.4 -> 1.1.9"
+notes = "No build script, no FS/net/process capability expansion; unsafe refactor to lock-free insertion and nightly TLS path appears sound on review. Assisted-by: copilot-cli:GPT-5.3-Codex cargo-vet"
 
 [[audits.tokio]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
@@ -534,6 +564,12 @@ version = "0.3.2"
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "1.17.0"
+
+[[audits.valuable]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "No unsafe code; build.rs only sets target atomic cfg via env; no fs/net/process capability use observed; behavior matches value-inspection purpose. Assisted-by: copilot-cli:GPT-5.3-Codex cargo-vet"
 
 [[audits.windows-targets]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
@@ -653,6 +689,12 @@ criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)
 start = "2019-02-25"
 end = "2026-09-03"
+
+[[trusted.rustc-demangle]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2023-03-23"
+end = "2027-04-17"
 
 [[trusted.rustversion]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -10,17 +10,11 @@ url = "https://raw.githubusercontent.com/OpenDevicePartnership/rust-crate-audits
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 
-[imports.embark-studios]
-url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
-
 [imports.google]
 url = "https://raw.githubusercontent.com/google/rust-crate-audits/main/audits.toml"
 
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
-
-[imports.zcash]
-url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [policy.embassy-imxrt]
 audit-as-crates-io = false

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -69,6 +69,12 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
+[[publisher.rustc-demangle]]
+version = "0.1.26"
+when = "2025-07-27"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.rustversion]]
 version = "1.0.22"
 when = "2025-08-08"
@@ -598,17 +604,6 @@ a few `unsafe` blocks related to utf-8 validation which are locally verifiable
 as correct and otherwise this crate is good to go.
 """
 
-[[audits.bytecode-alliance.audits.rustc-demangle]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "0.1.21"
-notes = "I am the author of this crate."
-
-[[audits.bytecode-alliance.audits.rustc-demangle]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.1.21 -> 0.1.24"
-
 [[audits.bytecode-alliance.audits.semver]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -652,18 +647,6 @@ ecosystem. There's one `unsafe` block in this crate and it's well-scoped.
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.17"
-
-[[audits.embark-studios.audits.tap]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "1.0.1"
-notes = "No unsafe usage or ambient capabilities"
-
-[[audits.embark-studios.audits.valuable]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = "No unsafe usage or ambient capabilities, sane build script"
 
 [[audits.google.audits.autocfg]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -1342,6 +1325,12 @@ end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.adler2]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.arraydeque]]
 who = "Lars Eggert <lars@eggert.org>"
 criteria = "safe-to-deploy"
@@ -1645,79 +1634,3 @@ who = "Mark Hammond <mhammond@skippinet.com.au>"
 criteria = "safe-to-deploy"
 delta = "0.3.19 -> 0.3.20"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.zcash.audits.adler2]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "2.0.0 -> 2.0.1"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.autocfg]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.4.0 -> 1.5.0"
-notes = "Filesystem change is to remove the generated LLVM IR output file after probing."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.crunchy]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.2.3 -> 0.2.4"
-notes = """
-Build script change is to fix a bug where a path separator for an included file
-was being selected by the target OS instead of the host OS.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.rustc-demangle]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.1.24 -> 0.1.25"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.rustc-demangle]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.1.25 -> 0.1.26"
-notes = "Parser changes use existing parsing machinery in an obvious way."
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.serde_spanned]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.6.8 -> 0.6.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.thread_local]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "1.1.4 -> 1.1.7"
-notes = """
-New `unsafe` usage:
-- An extra `deallocate_bucket`, to replace a `Mutex::lock` with a `compare_exchange`.
-- Setting and getting a `#[thread_local] static mut Option<Thread>` on nightly.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.thread_local]]
-who = "Daira-Emma Hopwood <daira@jacaranda.org>"
-criteria = "safe-to-deploy"
-delta = "1.1.7 -> 1.1.8"
-notes = """
-Adds `unsafe` code that makes an assumption that `ptr::null_mut::<Entry<T>>()` is a valid representation
-of an `AtomicPtr<Entry<T>>`, but this is likely a correct assumption.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.thread_local]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.1.8 -> 1.1.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.valuable]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.1"
-notes = "Build script changes are for linting."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"


### PR DESCRIPTION
This pull request introduces several important improvements to the cargo-vet audit process documentation and configuration, focusing on stricter exemption policies, duplicate audit entry prevention, and the addition of new audit records. The main themes are: enhanced documentation for reviewers, stricter exemption and deduplication workflows, and updates to the audit registry.

**Documentation and Workflow Improvements:**

* Added explicit instructions to always run `cargo vet` commands non-interactively to prevent blocking on terminal input, and clarified how to set the pager and use `--accept-all` for certification. (.github/agents/cargo-vet-auditor.agent.md)
* Strengthened the policy that exemptions (`[[exemptions]]`) should only be used as a last resort, requiring explicit user confirmation and justification, and that every exemption must include a `notes` field explaining its necessity and removal conditions. (.github/agents/cargo-vet-auditor.agent.md, .github/skills/cargo-vet-audit/SKILL.md) [[1]](diffhunk://#diff-34643b14215fa0cbb482e40432146ebcf329c13cd61ef7b7fed20e112b8e19e6R89-R127) [[2]](diffhunk://#diff-c18d588b43b8f757894f63618ccb4e6f2d9a5adb55452ac09267853410462f77R63-R85)
* Introduced a duplicate-audit guardrail: before certifying, the workflow now checks for identical existing audit entries and instructs reviewers to deduplicate them, preventing redundant audit records. (.github/agents/cargo-vet-auditor.agent.md, .github/skills/cargo-vet-audit/SKILL.md) [[1]](diffhunk://#diff-34643b14215fa0cbb482e40432146ebcf329c13cd61ef7b7fed20e112b8e19e6R89-R127) [[2]](diffhunk://#diff-c18d588b43b8f757894f63618ccb4e6f2d9a5adb55452ac09267853410462f77L107-R155)

**Audit Registry Updates:**

* Added new or updated audit entries for the following crates: `autocfg`, `crunchy`, `serde_spanned`, `tap`, `thread_local`, and `valuable`, all with detailed notes and criteria. (supply-chain/audits.toml) [[1]](diffhunk://#diff-eb494298b7630e575978d77f3bdd3178163bb7f5dbbf7e24316abe77210549f6R49-R54) [[2]](diffhunk://#diff-eb494298b7630e575978d77f3bdd3178163bb7f5dbbf7e24316abe77210549f6R81-R86) [[3]](diffhunk://#diff-eb494298b7630e575978d77f3bdd3178163bb7f5dbbf7e24316abe77210549f6R475-R480) [[4]](diffhunk://#diff-eb494298b7630e575978d77f3bdd3178163bb7f5dbbf7e24316abe77210549f6R501-R512) [[5]](diffhunk://#diff-eb494298b7630e575978d77f3bdd3178163bb7f5dbbf7e24316abe77210549f6R568-R573)
* Added a new trusted entry for `rustc-demangle` with `safe-to-deploy` criteria. (supply-chain/audits.toml)

**Configuration Clean-up:**

* Removed unused or unnecessary import sources from `supply-chain/config.toml` (specifically `embark-studios` and `zcash`). (supply-chain/config.toml)