### PR TITLE
Add address-review and code-review skills

### DIFF
--- a/.github/skills/address-review/SKILL.md
+++ b/.github/skills/address-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: address-review
+description: Evaluate PR review comments for validity and address confirmed ones
+---
+
+You are helping a developer respond to review comments on a pull request in the embedded-services repository.
+
+## Important
+
+Do NOT assume review comments are correct. Reviewers (both human and AI) can be wrong. Independently evaluate each comment against the actual code and context before proposing changes.
+
+## Step 1: Evaluate all comments
+
+Read every review comment and the surrounding code. Present your analysis in a table:
+
+| # | Comment | Location | Valid? | Reasoning | Proposed Fix |
+|---|---------|----------|--------|-----------|--------------|
+| 1 | Reviewer's comment (summarized) | `src/file.rs:42` ([link]) | ✅ Yes / ❌ No / ⚠️ Partial | Why you agree or disagree, with code snippet | What you would change (or "No change needed") |
+
+Include a short code snippet in the Reasoning or Proposed Fix column to show the relevant context:
+```
+// current code
+let val = buf[i];
+// proposed fix
+let val = buf.get(i).ok_or(MyError::InvalidParams)?;
+```
+
+## Step 2: Ask for confirmation
+
+After presenting the table, ask the developer which comments to address by number. Do not make any changes until confirmed.
+
+## Step 3: Apply confirmed fixes
+
+Implement only the confirmed fixes. For comments marked invalid that the developer still wants addressed, discuss the tradeoff before proceeding.
+
+## Guidelines
+
+- When disagreeing with a comment, explain clearly why — reference specific code, types, traits, or constraints.
+- Consider the crate's `no_std` context, strict clippy policy, and feature-gated code when evaluating suggestions.
+- If a reviewer suggests using `unwrap()`, `panic!()`, or direct indexing, flag it as invalid — these are denied by clippy config.
+- If a comment is about style or formatting, mark it as invalid — CI enforces these automatically.
+- Create new fixup commits for each change — do NOT amend existing commits. The author will squash them before merge.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: code-review
+description: AI-assisted code review that produces a structured summary for human reviewers
+---
+
+You are reviewing a pull request in the embedded-services repository. Produce a review designed to help a human reviewer understand and evaluate the changes efficiently.
+
+## Output format
+
+### 1. Summary of changes
+
+Write a concise summary (3–5 sentences) of what the PR does and why.
+
+### 2. Step-by-step review guide
+
+Walk the human reviewer through the changes in logical order — not file-by-file, but grouped by concept. For each step:
+- Explain what changed and why it matters
+- Call out anything non-obvious or that requires domain knowledge
+
+### 3. Potential issues
+
+Present issues in a table:
+
+| # | Severity | File | Description | Code |
+|---|----------|------|-------------|------|
+| 1 | 🔴 High | `src/example.rs:42` | Description of the issue | `snippet` |
+| 2 | 🟡 Medium | `src/other.rs:10` | Description of the issue | `snippet` |
+| 3 | 🟢 Low | `src/lib.rs:5` | Description of the issue | `snippet` |
+
+Severity levels:
+- 🔴 **High** — Design flaws, incorrect abstractions, safety violations, data loss risks
+- 🟡 **Medium** — Missing error handling, incorrect edge cases, concurrency issues, API misuse
+- 🟢 **Low** — Suboptimal patterns, missing docs on public APIs, minor improvements
+
+If there are no issues, say so explicitly.
+
+## Review rules
+
+- Do NOT flag formatting, style, or compilation errors — `cargo fmt`, `cargo clippy`, and CI handle those.
+- DO focus on **design**: Is the abstraction correct? Does the change fit the existing architecture? Are there better patterns?
+- DO evaluate **concurrency correctness** — especially around Embassy async patterns, `Signal`/`Channel` usage, and mutex interactions.
+- DO check that `#[cfg(feature = "...")]` gating is correct when code uses embassy, defmt, or log dependencies.
+- DO assess **error handling design** — are errors propagated at the right level? Is the error type appropriate?
+- DO consider **no_std constraints** — no heap allocation without `heapless`, no `std` types in non-test code.


### PR DESCRIPTION
Add two Copilot skills for PR workflows:

- address-review: evaluates review comments for validity before applying fixes, with a table-based workflow for developer confirmation
- code-review: produces structured PR reviews with summary, step-by-step guide, and potential issues table for human reviewers

Both skills are adapted for the embedded-services repository with no_std constraints, Embassy async patterns, and the Service trait.