### PR TITLE
cfu-service: Create basic updater struct

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 name: check
+env:
+  # Crates that require std and won't build on embedded-targets
+  STD_CRATES: "fw-update-interface-mocks"
 jobs:
 
   fmt:
@@ -93,6 +96,8 @@ jobs:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
         target: [x86_64-unknown-linux-gnu, thumbv8m.main-none-eabihf]
+    env:
+      COMMON_HACK_ARGS: "--feature-powerset --mutually-exclusive-features=log,defmt,defmt-timestamp-uptime"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,7 +117,11 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # --feature-powerset runs for every combination of features
       - name: cargo hack
-        run: cargo hack --feature-powerset --mutually-exclusive-features=log,defmt,defmt-timestamp-uptime clippy --locked --target ${{ matrix.target }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: cargo hack $COMMON_HACK_ARGS clippy --locked --target ${{ matrix.target }}
+      - name: cargo hack
+        if: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
+        run: cargo hack $COMMON_HACK_ARGS clippy --exclude $STD_CRATES --locked --target ${{ matrix.target }}
 
   deny:
     # cargo-deny checks licenses, advisories, sources, and bans for
@@ -203,9 +212,15 @@ jobs:
         with:
           name: updated-lock-files
       - name: cargo +${{ matrix.msrv }} check
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
           cargo check -F log --locked --target ${{ matrix.target }}
           cargo check -F defmt --locked --target ${{ matrix.target }}
+      - name: cargo +${{ matrix.msrv }} check
+        if: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
+        run: |
+          cargo check -F log --locked --workspace --exclude $STD_CRATES --target ${{ matrix.target }}
+          cargo check -F defmt --locked --workspace --exclude $STD_CRATES --target ${{ matrix.target }}
 
   check-arm-examples:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,14 +331,20 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 name = "cfu-service"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "defmt 0.3.100",
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
+ "env_logger",
+ "fw-update-interface",
+ "fw-update-interface-mocks",
  "heapless 0.8.0",
  "log",
+ "static_cell",
+ "tokio",
 ]
 
 [[package]]
@@ -940,6 +946,25 @@ name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "fw-update-interface"
+version = "0.1.0"
+dependencies = [
+ "defmt 0.3.100",
+ "embedded-services",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "fw-update-interface-mocks"
+version = "0.1.0"
+dependencies = [
+ "embedded-services",
+ "fw-update-interface",
+ "tokio",
+]
 
 [[package]]
 name = "generator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ members = [
     "power-policy-interface",
     "odp-service-common",
     "type-c-interface",
+    "fw-update-interface",
+    "fw-update-interface-mocks",
 ]
 exclude = ["examples/*"]
 
@@ -91,6 +93,8 @@ embedded-hal-async = "1.0"
 embedded-services = { path = "./embedded-service" }
 embedded-storage-async = "0.4.1"
 embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false }
+fw-update-interface = { path = "./fw-update-interface" }
+fw-update-interface-mocks = { path = "./fw-update-interface-mocks" }
 mctp-rs = { git = "https://github.com/dymk/mctp-rs" }
 num_enum = { version = "0.7.5", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }

--- a/cfu-service/Cargo.toml
+++ b/cfu-service/Cargo.toml
@@ -17,8 +17,18 @@ embassy-sync.workspace = true
 embassy-time.workspace = true
 embedded-cfu-protocol.workspace = true
 embedded-services.workspace = true
+fw-update-interface.workspace = true
 heapless.workspace = true
 log = { workspace = true, optional = true }
+
+[dev-dependencies]
+static_cell.workspace = true
+critical-section = { workspace = true, features = ["std"] }
+embassy-time = { workspace = true, features = ["std", "generic-queue-8"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
+env_logger = "0.11.8"
+log = { workspace = true }
+fw-update-interface-mocks = { workspace = true }
 
 [features]
 default = []
@@ -28,6 +38,7 @@ defmt = [
     "embassy-time/defmt",
     "embassy-sync/defmt",
     "embedded-cfu-protocol/defmt",
+    "fw-update-interface/defmt",
 ]
 log = [
     "dep:log",
@@ -35,4 +46,5 @@ log = [
     "embassy-time/log",
     "embassy-sync/log",
     "embedded-cfu-protocol/log",
+    "fw-update-interface/log",
 ]

--- a/cfu-service/src/basic/config.rs
+++ b/cfu-service/src/basic/config.rs
@@ -1,0 +1,47 @@
+//! Configuration structs
+
+use embassy_time::Duration;
+
+/// Base interval for checking for FW update timeouts and recovery attempts
+pub const DEFAULT_FW_UPDATE_TICK_INTERVAL: Duration = Duration::from_millis(5000);
+/// Default number of ticks before we consider a firmware update to have timed out
+/// 300 seconds at 5 seconds per tick
+pub const DEFAULT_FW_UPDATE_TIMEOUT_TICKS: u32 = 60;
+
+/// Config values for FW update recovery
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct Recovery {
+    /// Interval between recovery ticks
+    pub tick_interval: Duration,
+    /// Timeout (in recovery ticks) before we assume the update has failed.
+    pub update_timeout_ticks: u32,
+}
+
+impl Default for Recovery {
+    fn default() -> Self {
+        Self {
+            tick_interval: DEFAULT_FW_UPDATE_TICK_INTERVAL,
+            update_timeout_ticks: DEFAULT_FW_UPDATE_TIMEOUT_TICKS,
+        }
+    }
+}
+
+/// Configuration for [`crate::basic::Updater`]
+#[derive(Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct Updater {
+    /// Recovery configuration for the updater
+    pub recovery: Recovery,
+}
+
+/// Configuration for [`crate::basic::event_receiver::EventReceiver`]
+#[derive(Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct EventReceiver {
+    /// Recovery configuration for the event receiver
+    pub recovery: Recovery,
+}

--- a/cfu-service/src/basic/config.rs
+++ b/cfu-service/src/basic/config.rs
@@ -3,7 +3,7 @@
 use embassy_time::Duration;
 
 /// Base interval for checking for FW update timeouts and recovery attempts
-pub const DEFAULT_FW_UPDATE_TICK_INTERVAL: Duration = Duration::from_millis(5000);
+pub const DEFAULT_FW_UPDATE_TICK_INTERVAL: Duration = Duration::from_secs(5);
 /// Default number of ticks before we consider a firmware update to have timed out
 /// 300 seconds at 5 seconds per tick
 pub const DEFAULT_FW_UPDATE_TIMEOUT_TICKS: u32 = 60;

--- a/cfu-service/src/basic/event_receiver.rs
+++ b/cfu-service/src/basic/event_receiver.rs
@@ -1,0 +1,197 @@
+use embassy_futures::select::{Either, select};
+use embassy_time::{Instant, Timer};
+use embedded_services::{debug, error, sync::Lockable};
+
+use crate::basic::{
+    Output,
+    config::EventReceiver as Config,
+    state::{FwUpdateState, SharedState},
+};
+
+/// CFU events
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Event {
+    /// CFU request
+    Request(crate::component::RequestData),
+    /// Recovery tick
+    ///
+    /// Occurs when the FW update has timed out to abort the update and return hardware to its normal state
+    RecoveryTick,
+}
+
+/// Struct to receive CFU events.
+pub struct EventReceiver<'a, Shared: Lockable<Inner = SharedState>> {
+    /// Config
+    config: Config,
+    /// CFU device used for firmware updates
+    cfu_device: &'static crate::component::CfuDevice,
+    /// State shared with [`crate::basic::Updater`]
+    shared_state: &'a Shared,
+}
+
+impl<'a, Shared: Lockable<Inner = SharedState>> EventReceiver<'a, Shared> {
+    /// Create a new CFU event receiver
+    pub fn new(cfu_device: &'static crate::component::CfuDevice, shared_state: &'a Shared, config: Config) -> Self {
+        Self {
+            cfu_device,
+            shared_state,
+            config,
+        }
+    }
+
+    /// Wait for the next CFU event
+    pub async fn wait_next(&mut self) -> Event {
+        loop {
+            let (fw_update_state, next_recovery_tick) = {
+                let state = self.shared_state.lock().await;
+                (state.fw_update_state, state.next_recovery_tick)
+            };
+            match fw_update_state {
+                FwUpdateState::Idle => {
+                    // No FW update in progress, just wait for a command
+                    return Event::Request(self.cfu_device.wait_request().await);
+                }
+                FwUpdateState::InProgress(ticks) => {
+                    match select(self.cfu_device.wait_request(), Timer::at(next_recovery_tick)).await {
+                        Either::First(command) => return Event::Request(command),
+                        Either::Second(_) => {
+                            debug!("CFU tick: {}", ticks);
+
+                            let mut shared_state = self.shared_state.lock().await;
+                            shared_state.next_recovery_tick = Instant::now() + self.config.recovery.tick_interval;
+
+                            if ticks + 1 < self.config.recovery.update_timeout_ticks {
+                                shared_state.fw_update_state = FwUpdateState::InProgress(ticks + 1);
+                                continue;
+                            } else {
+                                error!(
+                                    "FW update timed out after {} ticks",
+                                    self.config.recovery.update_timeout_ticks
+                                );
+                                shared_state.fw_update_state = FwUpdateState::Recovery;
+                                return Event::RecoveryTick;
+                            }
+                        }
+                    }
+                }
+                FwUpdateState::Recovery => {
+                    // Recovery state, wait for the next attempt to recover the device
+                    let next_recovery_tick = self.shared_state.lock().await.next_recovery_tick;
+                    Timer::at(next_recovery_tick).await;
+                    self.shared_state.lock().await.next_recovery_tick =
+                        Instant::now() + self.config.recovery.tick_interval;
+                    debug!("FW update ticker ticked");
+                    return Event::RecoveryTick;
+                }
+            }
+        }
+    }
+
+    /// Finalize the processing of an output
+    // TODO: remove this when we refactor CFU
+    pub async fn finalize(&mut self, output: Output) {
+        if let Output::CfuResponse(response) = output {
+            self.cfu_device.send_response(response).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{basic::config::Recovery, component::CfuDevice};
+
+    use super::*;
+    use embassy_sync::mutex::Mutex;
+    use embassy_time::{Duration, Instant, TimeoutError, with_timeout};
+    use embedded_services::GlobalRawMutex;
+    use static_cell::StaticCell;
+
+    /// Test that we get recovery ticks as expected
+    #[tokio::test]
+    async fn test_recovery_timeout() {
+        static CFU_DEVICE: StaticCell<CfuDevice> = StaticCell::new();
+
+        // Maximum timeout for the recovery entry, actual time should be 1000, but gives us some margin
+        const RECOVERY_ENTRY_MAX_TIMEOUT: Duration = Duration::from_millis(1100);
+        // Maximum timeout for an individual recovery tick, actual time should be 100, but gives us some margin
+        const RECOVERY_TICK_MAX_TIMEOUT: Duration = Duration::from_millis(110);
+        // Expected measured interval between recovery ticks, actual time should be 100, but undershoot slightly for some margin
+        const EXPECTED_RECOVERY_TICK_INTERVAL: Duration = Duration::from_millis(90);
+
+        let shared_state: Mutex<GlobalRawMutex, _> = Mutex::new(SharedState::default());
+        let cfu_device = CFU_DEVICE.init(CfuDevice::new(0));
+        let recovery_config = Recovery {
+            tick_interval: Duration::from_millis(100),
+            update_timeout_ticks: 10,
+        };
+
+        let mut event_receiver = EventReceiver::new(
+            cfu_device,
+            &shared_state,
+            Config {
+                recovery: recovery_config,
+            },
+        );
+
+        // First test the recovery timer isn't active in the idle state
+        assert_eq!(
+            with_timeout(RECOVERY_ENTRY_MAX_TIMEOUT, event_receiver.wait_next()).await,
+            Err(TimeoutError),
+        );
+        assert_eq!(
+            event_receiver.shared_state.lock().await.fw_update_state,
+            FwUpdateState::Idle
+        );
+
+        // Start the recovery ticker, normally the update struct handles this.
+        shared_state
+            .lock()
+            .await
+            .enter_in_progress(recovery_config.tick_interval);
+
+        let start = Instant::now();
+        assert_eq!(
+            with_timeout(RECOVERY_ENTRY_MAX_TIMEOUT, event_receiver.wait_next()).await,
+            Ok(Event::RecoveryTick),
+        );
+        let duration = Instant::now() - start;
+
+        // Check that we waited approximately the correct amount of time
+        assert!(duration.as_millis() >= 1000);
+        assert_eq!(
+            event_receiver.shared_state.lock().await.fw_update_state,
+            FwUpdateState::Recovery
+        );
+
+        // Check the first recovery tick after the state transition
+        let start = Instant::now();
+        assert_eq!(
+            with_timeout(RECOVERY_TICK_MAX_TIMEOUT, event_receiver.wait_next()).await,
+            Ok(Event::RecoveryTick),
+        );
+        let duration = Instant::now() - start;
+
+        // Check that we waited approximately the correct amount of time
+        assert!(duration >= EXPECTED_RECOVERY_TICK_INTERVAL);
+        assert_eq!(
+            event_receiver.shared_state.lock().await.fw_update_state,
+            FwUpdateState::Recovery
+        );
+
+        // Check subsequent recovery ticks
+        let start = Instant::now();
+        assert_eq!(
+            with_timeout(RECOVERY_TICK_MAX_TIMEOUT, event_receiver.wait_next()).await,
+            Ok(Event::RecoveryTick),
+        );
+        let duration = Instant::now() - start;
+
+        // Check that we waited approximately the correct amount of time
+        assert!(duration >= EXPECTED_RECOVERY_TICK_INTERVAL);
+        assert_eq!(
+            event_receiver.shared_state.lock().await.fw_update_state,
+            FwUpdateState::Recovery
+        );
+    }
+}

--- a/cfu-service/src/basic/mod.rs
+++ b/cfu-service/src/basic/mod.rs
@@ -1,0 +1,293 @@
+//! Basic CFU implementation over the basic [`FwUpdate`] trait.
+use crate::{
+    basic::{
+        config::Updater as Config,
+        event_receiver::Event,
+        state::{FwUpdateState, SharedState},
+    },
+    component::{InternalResponseData, RequestData},
+    customization::Customization,
+};
+use embedded_cfu_protocol::protocol_definitions::*;
+use embedded_services::{debug, error, sync::Lockable};
+use fw_update_interface::basic::FwUpdate;
+
+pub mod config;
+pub mod event_receiver;
+pub mod state;
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Output {
+    CfuResponse(InternalResponseData),
+    CfuRecovery,
+}
+
+/// Basic CFU handler that bridges CFU protocol commands with the [`FwUpdate`] trait.
+///
+/// This struct is generic over a firmware offer validator and processes CFU commands
+/// by delegating firmware operations to any [`FwUpdate`] implementor passed to each method.
+pub struct Updater<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState>, Cust: Customization> {
+    device: &'a Device,
+    component_id: ComponentId,
+    customization: Cust,
+    shared_state: &'a Shared,
+    config: Config,
+}
+
+impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState>, Cust: Customization>
+    Updater<'a, Device, Shared, Cust>
+{
+    /// Create a new CfuBasic instance
+    pub fn new(
+        device: &'a Device,
+        shared_state: &'a Shared,
+        config: Config,
+        component_id: ComponentId,
+        customization: Cust,
+    ) -> Self {
+        Self {
+            device,
+            shared_state,
+            component_id,
+            customization,
+            config,
+        }
+    }
+
+    /// Create a response with an invalid firmware version
+    fn create_invalid_fw_version_response(&self) -> InternalResponseData {
+        let dev_inf = FwVerComponentInfo::new(FwVersion::new(0xffffffff), self.component_id);
+        let comp_info: [FwVerComponentInfo; MAX_CMPT_COUNT] = [dev_inf; MAX_CMPT_COUNT];
+        InternalResponseData::FwVersionResponse(GetFwVersionResponse {
+            header: GetFwVersionResponseHeader::new(1, GetFwVerRespHeaderByte3::NoSpecialFlags),
+            component_info: comp_info,
+        })
+    }
+
+    /// Create an offer rejection response
+    fn create_offer_rejection() -> InternalResponseData {
+        InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_with_failure(
+            HostToken::Driver,
+            OfferRejectReason::InvalidComponent,
+            OfferStatus::Reject,
+        ))
+    }
+
+    /// Returns a copy of the current update state
+    pub async fn update_state(&self) -> FwUpdateState {
+        self.shared_state.lock().await.fw_update_state
+    }
+
+    /// Gives immutable access to the customization object
+    pub fn customization(&self) -> &Cust {
+        &self.customization
+    }
+
+    /// Gives mutable access to the customization object
+    pub fn customization_mut(&mut self) -> &mut Cust {
+        &mut self.customization
+    }
+
+    /// Process a CFU event
+    pub async fn process_event(&mut self, event: Event) -> Output {
+        match event {
+            Event::Request(request) => {
+                let response = self.process_cfu_command(&request).await;
+                Output::CfuResponse(response)
+            }
+            Event::RecoveryTick => {
+                // FW Update recovery tick, process recovery attempts
+                self.process_recovery_tick().await;
+                Output::CfuRecovery
+            }
+        }
+    }
+
+    /// Process a GetFwVersion command
+    pub async fn process_get_fw_version(&mut self) -> InternalResponseData {
+        let version = match self.device.lock().await.get_active_fw_version().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Failed to get active firmware version: {:?}", e);
+                return self.create_invalid_fw_version_response();
+            }
+        };
+
+        let dev_inf = FwVerComponentInfo::new(FwVersion::new(version), self.component_id);
+        let comp_info: [FwVerComponentInfo; MAX_CMPT_COUNT] = [dev_inf; MAX_CMPT_COUNT];
+        InternalResponseData::FwVersionResponse(GetFwVersionResponse {
+            header: GetFwVersionResponseHeader::new(1, GetFwVerRespHeaderByte3::NoSpecialFlags),
+            component_info: comp_info,
+        })
+    }
+
+    /// Process a GiveOffer command
+    pub async fn process_give_offer(&mut self, offer: &FwUpdateOffer) -> InternalResponseData {
+        if offer.component_info.component_id != self.component_id {
+            return Self::create_offer_rejection();
+        }
+
+        let version = match self.device.lock().await.get_active_fw_version().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Failed to get active firmware version: {:?}", e);
+                return Self::create_offer_rejection();
+            }
+        };
+
+        InternalResponseData::OfferResponse(self.customization.validate(FwVersion::new(version), offer))
+    }
+
+    /// Process an AbortUpdate command
+    pub async fn process_abort_update(&mut self) -> InternalResponseData {
+        let result = self.device.lock().await.abort_fw_update().await;
+        match result {
+            Ok(_) => {
+                debug!("FW update aborted successfully");
+                self.shared_state.lock().await.enter_idle();
+            }
+            Err(e) => {
+                error!("Failed to abort FW update: {:?}", e);
+                self.shared_state.lock().await.enter_recovery();
+            }
+        }
+
+        InternalResponseData::ComponentPrepared
+    }
+
+    /// Process a GiveContent command
+    pub async fn process_give_content(&mut self, content: &FwUpdateContentCommand) -> InternalResponseData {
+        let data = if let Some(data) = content.data.get(0..content.header.data_length as usize) {
+            data
+        } else {
+            return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                content.header.sequence_num,
+                CfuUpdateContentResponseStatus::ErrorPrepare,
+            ));
+        };
+
+        debug!("Got content {:#?}", content);
+        let mut locked_device = self.device.lock().await;
+        if content.header.flags & FW_UPDATE_FLAG_FIRST_BLOCK != 0 {
+            debug!("Got first block");
+
+            let result = locked_device.start_fw_update().await;
+            match result {
+                Ok(_) => {
+                    debug!("FW update started successfully");
+                }
+                Err(e) => {
+                    error!("Failed to start FW update: {:?}", e);
+                    self.shared_state.lock().await.enter_recovery();
+                    return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                        content.header.sequence_num,
+                        CfuUpdateContentResponseStatus::ErrorPrepare,
+                    ));
+                }
+            }
+
+            let mut shared_state = self.shared_state.lock().await;
+            shared_state.enter_in_progress(self.config.recovery.tick_interval);
+        }
+
+        match locked_device
+            .write_fw_contents(content.header.firmware_address as usize, data)
+            .await
+        {
+            Ok(_) => {
+                debug!("Block written successfully");
+            }
+            Err(e) => {
+                error!("Failed to write block: {:?}", e);
+                return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    content.header.sequence_num,
+                    CfuUpdateContentResponseStatus::ErrorWrite,
+                ));
+            }
+        }
+
+        if content.header.flags & FW_UPDATE_FLAG_LAST_BLOCK != 0 {
+            match locked_device.finalize_fw_update().await {
+                Ok(_) => {
+                    debug!("FW update finalized successfully");
+                    self.shared_state.lock().await.enter_idle();
+                }
+                Err(e) => {
+                    error!("Failed to finalize FW update: {:?}", e);
+                    self.shared_state.lock().await.enter_recovery();
+                    return InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                        content.header.sequence_num,
+                        CfuUpdateContentResponseStatus::ErrorWrite,
+                    ));
+                }
+            }
+        }
+
+        InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+            content.header.sequence_num,
+            CfuUpdateContentResponseStatus::Success,
+        ))
+    }
+
+    /// Process a CFU recovery tick.
+    pub async fn process_recovery_tick(&mut self) {
+        // Update timed out, attempt to abort
+        self.shared_state.lock().await.enter_recovery();
+        match self.device.lock().await.abort_fw_update().await {
+            Ok(_) => {
+                debug!("FW update aborted successfully");
+                self.shared_state.lock().await.enter_idle();
+            }
+            Err(e) => {
+                error!("Failed to abort FW update: {:?}", e);
+            }
+        }
+    }
+
+    /// Process a CFU command, dispatching to the appropriate handler
+    pub async fn process_cfu_command(&mut self, command: &RequestData) -> InternalResponseData {
+        if self.shared_state.lock().await.fw_update_state == FwUpdateState::Recovery {
+            debug!("FW update in recovery state, rejecting command");
+            return InternalResponseData::ComponentBusy;
+        }
+
+        match command {
+            RequestData::FwVersionRequest => {
+                debug!("Got FwVersionRequest");
+                self.process_get_fw_version().await
+            }
+            RequestData::GiveOffer(offer) => {
+                debug!("Got GiveOffer");
+                self.process_give_offer(offer).await
+            }
+            RequestData::GiveContent(content) => {
+                debug!("Got GiveContent");
+                self.process_give_content(content).await
+            }
+            RequestData::AbortUpdate => {
+                debug!("Got AbortUpdate");
+                self.process_abort_update().await
+            }
+            RequestData::FinalizeUpdate => {
+                debug!("Got FinalizeUpdate");
+                InternalResponseData::ComponentPrepared
+            }
+            RequestData::PrepareComponentForUpdate => {
+                debug!("Got PrepareComponentForUpdate");
+                InternalResponseData::ComponentPrepared
+            }
+            RequestData::GiveOfferExtended(_) => {
+                debug!("Got GiveExtendedOffer, rejecting");
+                Self::create_offer_rejection()
+            }
+            RequestData::GiveOfferInformation(_) => {
+                debug!("Got GiveOfferInformation, rejecting");
+                Self::create_offer_rejection()
+            }
+        }
+    }
+}

--- a/cfu-service/src/basic/mod.rs
+++ b/cfu-service/src/basic/mod.rs
@@ -109,7 +109,8 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
 
     /// Process a GetFwVersion command
     pub async fn process_get_fw_version(&mut self) -> InternalResponseData {
-        let version = match self.device.lock().await.get_active_fw_version().await {
+        let result = self.device.lock().await.get_active_fw_version().await;
+        let version = match result {
             Ok(v) => v,
             Err(e) => {
                 error!("Failed to get active firmware version: {:?}", e);
@@ -131,7 +132,8 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
             return Self::create_offer_rejection();
         }
 
-        let version = match self.device.lock().await.get_active_fw_version().await {
+        let result = self.device.lock().await.get_active_fw_version().await;
+        let version = match result {
             Ok(v) => v,
             Err(e) => {
                 error!("Failed to get active firmware version: {:?}", e);
@@ -171,11 +173,10 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
         };
 
         debug!("Got content {:#?}", content);
-        let mut locked_device = self.device.lock().await;
         if content.header.flags & FW_UPDATE_FLAG_FIRST_BLOCK != 0 {
             debug!("Got first block");
 
-            let result = locked_device.start_fw_update().await;
+            let result = self.device.lock().await.start_fw_update().await;
             match result {
                 Ok(_) => {
                     debug!("FW update started successfully");
@@ -190,14 +191,19 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
                 }
             }
 
-            let mut shared_state = self.shared_state.lock().await;
-            shared_state.enter_in_progress(self.config.recovery.tick_interval);
+            self.shared_state
+                .lock()
+                .await
+                .enter_in_progress(self.config.recovery.tick_interval);
         }
 
-        match locked_device
-            .write_fw_contents(content.header.firmware_address as usize, data)
+        let result = self
+            .device
+            .lock()
             .await
-        {
+            .write_fw_contents(content.header.firmware_address as usize, data)
+            .await;
+        match result {
             Ok(_) => {
                 debug!("Block written successfully");
             }
@@ -211,7 +217,8 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
         }
 
         if content.header.flags & FW_UPDATE_FLAG_LAST_BLOCK != 0 {
-            match locked_device.finalize_fw_update().await {
+            let result = self.device.lock().await.finalize_fw_update().await;
+            match result {
                 Ok(_) => {
                     debug!("FW update finalized successfully");
                     self.shared_state.lock().await.enter_idle();
@@ -237,7 +244,8 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
     pub async fn process_recovery_tick(&mut self) {
         // Update timed out, attempt to abort
         self.shared_state.lock().await.enter_recovery();
-        match self.device.lock().await.abort_fw_update().await {
+        let result = self.device.lock().await.abort_fw_update().await;
+        match result {
             Ok(_) => {
                 debug!("FW update aborted successfully");
                 self.shared_state.lock().await.enter_idle();
@@ -250,7 +258,8 @@ impl<'a, Device: Lockable<Inner: FwUpdate>, Shared: Lockable<Inner = SharedState
 
     /// Process a CFU command, dispatching to the appropriate handler
     pub async fn process_cfu_command(&mut self, command: &RequestData) -> InternalResponseData {
-        if self.shared_state.lock().await.fw_update_state == FwUpdateState::Recovery {
+        let fw_update_state = self.shared_state.lock().await.fw_update_state;
+        if fw_update_state == FwUpdateState::Recovery {
             debug!("FW update in recovery state, rejecting command");
             return InternalResponseData::ComponentBusy;
         }

--- a/cfu-service/src/basic/state.rs
+++ b/cfu-service/src/basic/state.rs
@@ -1,0 +1,56 @@
+use embassy_time::{Duration, Instant};
+
+/// Current state of the firmware update process
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FwUpdateState {
+    /// None in progress
+    #[default]
+    Idle,
+    /// Firmware update in progress.
+    /// Integer is number of recovery ticks that have occurred since the start of the update.
+    InProgress(u32),
+    /// Firmware update has failed and the device is in an unknown state
+    Recovery,
+}
+
+/// State shared between [`crate::basic::event_receiver::EventReceiver`] and [`crate::basic::Updater`]
+#[derive(Clone, Copy)]
+pub struct SharedState {
+    /// Current update state
+    pub(super) fw_update_state: FwUpdateState,
+    /// Next recovery tick
+    pub(super) next_recovery_tick: Instant,
+}
+
+impl SharedState {
+    pub fn new() -> Self {
+        Self {
+            fw_update_state: FwUpdateState::Idle,
+            next_recovery_tick: Instant::MAX,
+        }
+    }
+
+    pub(super) fn enter_idle(&mut self) {
+        self.fw_update_state = FwUpdateState::Idle;
+        self.next_recovery_tick = Instant::MAX;
+    }
+
+    pub(super) fn enter_in_progress(&mut self, next_recovery_tick: Duration) {
+        self.fw_update_state = FwUpdateState::InProgress(0);
+        self.next_recovery_tick = Instant::now() + next_recovery_tick;
+    }
+
+    pub(super) fn enter_recovery(&mut self) {
+        self.fw_update_state = FwUpdateState::Recovery;
+        if self.next_recovery_tick == Instant::MAX {
+            self.next_recovery_tick = Instant::now();
+        }
+    }
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/cfu-service/src/basic/test.rs
+++ b/cfu-service/src/basic/test.rs
@@ -1,0 +1,366 @@
+//! Tests for [`crate::basic::Updater`]
+#![allow(clippy::unwrap_used)]
+extern crate std;
+
+use crate::{
+    basic::{
+        Output, Updater,
+        event_receiver::Event,
+        state::{FwUpdateState, SharedState},
+    },
+    component::{InternalResponseData, RequestData},
+};
+use embassy_sync::{mutex::Mutex, once_lock::OnceLock};
+use embassy_time::{Duration, with_timeout};
+use embedded_cfu_protocol::protocol_definitions::{
+    CfuUpdateContentResponseStatus, DEFAULT_DATA_LENGTH, FW_UPDATE_FLAG_FIRST_BLOCK, FW_UPDATE_FLAG_LAST_BLOCK,
+    FwUpdateContentCommand, FwUpdateContentHeader, FwUpdateContentResponse, FwUpdateOffer, FwUpdateOfferResponse,
+    FwVerComponentInfo, FwVersion, GetFwVerRespHeaderByte3, GetFwVersionResponse, GetFwVersionResponseHeader,
+    HostToken, MAX_CMPT_COUNT,
+};
+use embedded_services::GlobalRawMutex;
+
+use crate::mocks::customization::{FnCall as CustomizationFnCall, Mock as MockCustomization};
+use fw_update_interface_mocks::basic::{FnCall as FwFnCall, Mock};
+
+use std::vec;
+
+const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
+
+const CURRENT_FW_VERSION: u32 = 0x12345678;
+const NEW_FW_VERSION: u32 = 0x89abcdef;
+
+const DEVICE0_COMPONENT_ID: u8 = 5;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
+
+type DeviceType = Mutex<GlobalRawMutex, Mock>;
+type SharedStateType = Mutex<GlobalRawMutex, SharedState>;
+type UpdaterType<'a> = Updater<'a, DeviceType, SharedStateType, MockCustomization>;
+
+/// Test the basic flow of the updater.
+///
+/// This will get the FW version, give an offer, then send a start, middle, and end content
+pub struct TestBasicFlow;
+
+impl Test for TestBasicFlow {
+    async fn run<'a>(&mut self, device: &'a DeviceType, cfu_basic: &'a mut UpdaterType<'a>) {
+        {
+            // Get FW version
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::FwVersionRequest)),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::FwVersionResponse(GetFwVersionResponse {
+                    header: GetFwVersionResponseHeader::new(1, GetFwVerRespHeaderByte3::NoSpecialFlags),
+                    component_info: [FwVerComponentInfo::new(FwVersion::new(CURRENT_FW_VERSION), DEVICE0_COMPONENT_ID);
+                        MAX_CMPT_COUNT],
+                }))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::Idle);
+            assert_eq!(device.lock().await.fn_calls.len(), 1);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::GetActiveFwVersion
+            );
+        }
+
+        {
+            // Give offer
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::GiveOffer(FwUpdateOffer::new(
+                    HostToken::Driver,
+                    DEVICE0_COMPONENT_ID,
+                    FwVersion::new(NEW_FW_VERSION),
+                    0,
+                    0,
+                )))),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_accept(
+                    HostToken::Driver
+                )))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::Idle);
+            assert_eq!(device.lock().await.fn_calls.len(), 1);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::GetActiveFwVersion
+            );
+
+            assert_eq!(cfu_basic.customization().fn_calls.len(), 1);
+            assert_eq!(
+                cfu_basic.customization_mut().fn_calls.pop_front(),
+                Some(CustomizationFnCall::Validate(
+                    FwVersion::new(CURRENT_FW_VERSION),
+                    FwUpdateOffer::new(
+                        HostToken::Driver,
+                        DEVICE0_COMPONENT_ID,
+                        FwVersion::new(NEW_FW_VERSION),
+                        0,
+                        0,
+                    )
+                ))
+            );
+        }
+
+        {
+            // Give first content block
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::GiveContent(FwUpdateContentCommand {
+                    header: FwUpdateContentHeader {
+                        flags: FW_UPDATE_FLAG_FIRST_BLOCK,
+                        data_length: DEFAULT_DATA_LENGTH as u8,
+                        sequence_num: 0,
+                        firmware_address: 0x0,
+                    },
+                    data: [1; DEFAULT_DATA_LENGTH],
+                }))),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    0,
+                    CfuUpdateContentResponseStatus::Success
+                )))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::InProgress(0));
+            assert_eq!(device.lock().await.fn_calls.len(), 2);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::StartFwUpdate
+            );
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::WriteFwContents(0, vec![1; DEFAULT_DATA_LENGTH])
+            );
+        }
+
+        {
+            // Give middle content block
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::GiveContent(FwUpdateContentCommand {
+                    header: FwUpdateContentHeader {
+                        flags: 0,
+                        data_length: DEFAULT_DATA_LENGTH as u8,
+                        sequence_num: 1,
+                        firmware_address: 0x0,
+                    },
+                    data: [2; DEFAULT_DATA_LENGTH],
+                }))),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    1,
+                    CfuUpdateContentResponseStatus::Success
+                )))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::InProgress(0));
+            assert_eq!(device.lock().await.fn_calls.len(), 1);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::WriteFwContents(0, vec![2; DEFAULT_DATA_LENGTH])
+            );
+        }
+
+        {
+            // Give final content block
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::GiveContent(FwUpdateContentCommand {
+                    header: FwUpdateContentHeader {
+                        flags: FW_UPDATE_FLAG_LAST_BLOCK,
+                        data_length: DEFAULT_DATA_LENGTH as u8,
+                        sequence_num: 2,
+                        firmware_address: 0x0,
+                    },
+                    data: [3; DEFAULT_DATA_LENGTH],
+                }))),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    2,
+                    CfuUpdateContentResponseStatus::Success
+                )))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::Idle);
+            assert_eq!(device.lock().await.fn_calls.len(), 2);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::WriteFwContents(0, vec![3; DEFAULT_DATA_LENGTH])
+            );
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::FinalizeFwUpdate
+            );
+        }
+    }
+}
+
+/// Test that the recovery flow works immediately after sending the first content block.
+struct TestStartRecoveryFlow;
+
+impl Test for TestStartRecoveryFlow {
+    async fn run<'a>(&mut self, device: &'a DeviceType, cfu_basic: &'a mut UpdaterType<'a>) {
+        {
+            // Give offer
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::GiveOffer(FwUpdateOffer::new(
+                    HostToken::Driver,
+                    DEVICE0_COMPONENT_ID,
+                    FwVersion::new(NEW_FW_VERSION),
+                    0,
+                    0,
+                )))),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::OfferResponse(FwUpdateOfferResponse::new_accept(
+                    HostToken::Driver
+                )))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::Idle);
+            assert_eq!(device.lock().await.fn_calls.len(), 1);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::GetActiveFwVersion
+            );
+
+            assert_eq!(cfu_basic.customization().fn_calls.len(), 1);
+            assert_eq!(
+                cfu_basic.customization_mut().fn_calls.pop_front(),
+                Some(CustomizationFnCall::Validate(
+                    FwVersion::new(CURRENT_FW_VERSION),
+                    FwUpdateOffer::new(
+                        HostToken::Driver,
+                        DEVICE0_COMPONENT_ID,
+                        FwVersion::new(NEW_FW_VERSION),
+                        0,
+                        0,
+                    )
+                ))
+            );
+        }
+
+        {
+            // Give first content block
+            let output = with_timeout(
+                PER_CALL_TIMEOUT,
+                cfu_basic.process_event(Event::Request(RequestData::GiveContent(FwUpdateContentCommand {
+                    header: FwUpdateContentHeader {
+                        flags: FW_UPDATE_FLAG_FIRST_BLOCK,
+                        data_length: DEFAULT_DATA_LENGTH as u8,
+                        sequence_num: 0,
+                        firmware_address: 0x0,
+                    },
+                    data: [1; DEFAULT_DATA_LENGTH],
+                }))),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                output,
+                Output::CfuResponse(InternalResponseData::ContentResponse(FwUpdateContentResponse::new(
+                    0,
+                    CfuUpdateContentResponseStatus::Success
+                )))
+            );
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::InProgress(0));
+            assert_eq!(device.lock().await.fn_calls.len(), 2);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::StartFwUpdate
+            );
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::WriteFwContents(0, vec![1; DEFAULT_DATA_LENGTH])
+            );
+        }
+
+        {
+            // Trigger recovery
+            let output = with_timeout(PER_CALL_TIMEOUT, cfu_basic.process_event(Event::RecoveryTick))
+                .await
+                .unwrap();
+
+            assert_eq!(output, Output::CfuRecovery);
+            // Idle since we should have successfully recovered
+            assert_eq!(cfu_basic.update_state().await, FwUpdateState::Idle);
+            assert_eq!(device.lock().await.fn_calls.len(), 1);
+            assert_eq!(
+                device.lock().await.fn_calls.pop_front().unwrap(),
+                FwFnCall::AbortFwUpdate
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn run_test_basic_flow() {
+    run_test(DEFAULT_TIMEOUT, TestBasicFlow).await;
+}
+
+#[tokio::test]
+async fn run_test_start_recovery_flow() {
+    run_test(DEFAULT_TIMEOUT, TestStartRecoveryFlow).await;
+}
+
+/// Trait for runnable tests.
+///
+/// This exists because there are lifetime issues with being generic over FnOnce or FnMut.
+/// Those can be resolved, but having a dedicated trait is simpler.
+pub trait Test {
+    fn run<'a>(&mut self, device: &'a DeviceType, cfu_basic: &'a mut UpdaterType<'a>) -> impl Future<Output = ()>;
+}
+
+/// Test running function
+async fn run_test(timeout: Duration, mut test: impl Test) {
+    // Tokio runs tests in parallel, but logging is global so we need to run tests sequentially to avoid interleaved logs.
+    static TEST_MUTEX: OnceLock<Mutex<GlobalRawMutex, ()>> = OnceLock::new();
+    let test_mutex = TEST_MUTEX.get_or_init(|| Mutex::new(()));
+    let _lock = test_mutex.lock().await;
+
+    // Initialize logging, ignore the error if the logger was already initialized by another test.
+    let _ = env_logger::builder().filter_level(log::LevelFilter::Debug).try_init();
+    embedded_services::init().await;
+
+    let shared_state: Mutex<GlobalRawMutex, _> = Mutex::new(SharedState::default());
+    let device = Mutex::new(Mock::new("PSU0", CURRENT_FW_VERSION));
+    let mut cfu_basic = Updater::new(
+        &device,
+        &shared_state,
+        Default::default(),
+        DEVICE0_COMPONENT_ID,
+        MockCustomization::new(FwVersion::new(NEW_FW_VERSION)),
+    );
+
+    with_timeout(timeout, test.run(&device, &mut cfu_basic)).await.unwrap();
+}

--- a/cfu-service/src/customization.rs
+++ b/cfu-service/src/customization.rs
@@ -1,0 +1,8 @@
+//! Common CFU customization trait
+use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferResponse, FwVersion};
+
+/// Common CFU customization trait
+pub trait Customization {
+    /// Determine if we are accepting the firmware update offer, returns a CFU offer response
+    fn validate(&mut self, current: FwVersion, offer: &FwUpdateOffer) -> FwUpdateOfferResponse;
+}

--- a/cfu-service/src/lib.rs
+++ b/cfu-service/src/lib.rs
@@ -6,12 +6,17 @@ use embedded_cfu_protocol::components::CfuComponentTraits;
 use embedded_cfu_protocol::protocol_definitions::*;
 use embedded_services::{GlobalRawMutex, comms, error, info, intrusive_list, trace};
 
+pub mod basic;
 pub mod buffer;
 pub mod component;
+pub mod customization;
 pub mod host;
 mod responses;
 pub mod splitter;
 pub mod task;
+
+#[cfg(test)]
+pub mod mocks;
 
 pub struct CfuClient {
     /// Cfu Client context

--- a/cfu-service/src/mocks/customization.rs
+++ b/cfu-service/src/mocks/customization.rs
@@ -1,0 +1,83 @@
+//! Code related to mock for [`cfu_service::customization::Customization`]
+extern crate std;
+
+use std::collections::VecDeque;
+
+use crate::customization::Customization;
+use embedded_cfu_protocol::protocol_definitions::{
+    FwUpdateOffer, FwUpdateOfferResponse, FwVersion, HostToken, OfferRejectReason, OfferStatus,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FnCall {
+    Validate(FwVersion, FwUpdateOffer),
+}
+
+/// Simple mock
+pub struct Mock {
+    /// Queue to record function calls
+    pub fn_calls: VecDeque<FnCall>,
+    /// Acceptable version
+    acceptable_version: FwVersion,
+}
+
+impl Mock {
+    /// Create a new mock
+    pub fn new(acceptable_version: FwVersion) -> Self {
+        Self {
+            fn_calls: VecDeque::new(),
+            acceptable_version,
+        }
+    }
+
+    fn record_fn_call(&mut self, fn_call: FnCall) {
+        self.fn_calls.push_back(fn_call);
+    }
+}
+
+impl Customization for Mock {
+    fn validate(&mut self, current: FwVersion, fw_update_offer: &FwUpdateOffer) -> FwUpdateOfferResponse {
+        self.record_fn_call(FnCall::Validate(current, *fw_update_offer));
+        if fw_update_offer.firmware_version == self.acceptable_version {
+            FwUpdateOfferResponse::new_accept(HostToken::Driver)
+        } else {
+            FwUpdateOfferResponse::new_with_failure(HostToken::Driver, OfferRejectReason::OldFw, OfferStatus::Reject)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_validate_accept() {
+        let acceptable_version = FwVersion::new(1);
+        let mut mock = Mock::new(acceptable_version);
+        let fw_update_offer = FwUpdateOffer::new(HostToken::Driver, 0, FwVersion::new(1), 0, 0);
+        let response = mock.validate(acceptable_version, &fw_update_offer);
+        assert_eq!(response, FwUpdateOfferResponse::new_accept(HostToken::Driver));
+        assert_eq!(mock.fn_calls.len(), 1);
+        assert_eq!(
+            mock.fn_calls.pop_front(),
+            Some(FnCall::Validate(acceptable_version, fw_update_offer))
+        );
+    }
+
+    #[test]
+    fn test_validate_reject() {
+        let acceptable_version = FwVersion::new(1);
+        let mut mock = Mock::new(acceptable_version);
+        let fw_update_offer = FwUpdateOffer::new(HostToken::Driver, 0, FwVersion::new(9), 0, 0);
+        let response = mock.validate(acceptable_version, &fw_update_offer);
+        assert_eq!(
+            response,
+            FwUpdateOfferResponse::new_with_failure(HostToken::Driver, OfferRejectReason::OldFw, OfferStatus::Reject)
+        );
+        assert_eq!(mock.fn_calls.len(), 1);
+        assert_eq!(
+            mock.fn_calls.pop_front(),
+            Some(FnCall::Validate(acceptable_version, fw_update_offer))
+        );
+    }
+}

--- a/cfu-service/src/mocks/mod.rs
+++ b/cfu-service/src/mocks/mod.rs
@@ -1,0 +1,2 @@
+//! Mocks for [`cfu_service`] testing.
+pub mod customization;

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
+ "fw-update-interface",
  "heapless 0.8.0",
 ]
 
@@ -732,6 +733,14 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "fw-update-interface"
+version = "0.1.0"
+dependencies = [
+ "defmt 0.3.100",
+ "embedded-services",
+]
 
 [[package]]
 name = "generator"

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
+ "fw-update-interface",
  "heapless 0.8.0",
  "log",
 ]
@@ -707,6 +708,14 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "fw-update-interface"
+version = "0.1.0"
+dependencies = [
+ "embedded-services",
+ "log",
+]
 
 [[package]]
 name = "generator"

--- a/fw-update-interface-mocks/Cargo.toml
+++ b/fw-update-interface-mocks/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fw-update-interface-mocks"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+embedded-services = { workspace = true }
+fw-update-interface = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
+
+[lints]
+workspace = true

--- a/fw-update-interface-mocks/src/basic.rs
+++ b/fw-update-interface-mocks/src/basic.rs
@@ -1,0 +1,151 @@
+//! Module for a mock that implements [`fw_update_interface::basic::FwUpdate`]
+use std::collections::VecDeque;
+use std::vec::Vec;
+
+use embedded_services::named::Named;
+use fw_update_interface::basic::{Error, FwUpdate};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum FnCall {
+    GetActiveFwVersion,
+    StartFwUpdate,
+    AbortFwUpdate,
+    FinalizeFwUpdate,
+    WriteFwContents(usize, Vec<u8>),
+}
+
+pub struct Mock {
+    /// Signal to record function calls
+    pub fn_calls: VecDeque<FnCall>,
+    /// The next error to return from the mock
+    next_error: Option<Error>,
+    /// Mock current FW version
+    current_fw_version: u32,
+    /// Human-readable name of the mock
+    name: &'static str,
+}
+
+impl Mock {
+    pub fn new(name: &'static str, current_fw_version: u32) -> Self {
+        Self {
+            name,
+            fn_calls: VecDeque::new(),
+            next_error: None,
+            current_fw_version,
+        }
+    }
+
+    fn record_fn_call(&mut self, fn_call: FnCall) {
+        self.fn_calls.push_back(fn_call);
+    }
+
+    /// Set an error for the next function call
+    pub fn set_next_error(&mut self, error: Option<Error>) {
+        self.next_error = error;
+    }
+}
+
+impl FwUpdate for Mock {
+    async fn get_active_fw_version(&mut self) -> Result<u32, Error> {
+        self.record_fn_call(FnCall::GetActiveFwVersion);
+        if let Some(error) = self.next_error.take() {
+            return Err(error);
+        }
+        Ok(self.current_fw_version)
+    }
+
+    async fn start_fw_update(&mut self) -> Result<(), Error> {
+        self.record_fn_call(FnCall::StartFwUpdate);
+        if let Some(error) = self.next_error.take() {
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn abort_fw_update(&mut self) -> Result<(), Error> {
+        self.record_fn_call(FnCall::AbortFwUpdate);
+        if let Some(error) = self.next_error.take() {
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn finalize_fw_update(&mut self) -> Result<(), Error> {
+        self.record_fn_call(FnCall::FinalizeFwUpdate);
+        if let Some(error) = self.next_error.take() {
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn write_fw_contents(&mut self, offset: usize, data: &[u8]) -> Result<(), Error> {
+        self.record_fn_call(FnCall::WriteFwContents(offset, Vec::from(data)));
+
+        if let Some(error) = self.next_error.take() {
+            return Err(error);
+        }
+        Ok(())
+    }
+}
+
+impl Named for Mock {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::vec;
+
+    #[tokio::test]
+    async fn test_get_active_fw_version() {
+        let mut mock = super::Mock::new("test", 1);
+        let version = mock.get_active_fw_version().await;
+        assert_eq!(version, Ok(1));
+        assert_eq!(mock.fn_calls.pop_front(), Some(FnCall::GetActiveFwVersion));
+    }
+
+    #[tokio::test]
+    async fn test_start_fw_update() {
+        let mut mock = super::Mock::new("test", 1);
+        let result = mock.start_fw_update().await;
+        assert_eq!(result, Ok(()));
+        assert_eq!(mock.fn_calls.pop_front(), Some(FnCall::StartFwUpdate));
+    }
+
+    #[tokio::test]
+    async fn test_abort_fw_update() {
+        let mut mock = super::Mock::new("test", 1);
+        let result = mock.abort_fw_update().await;
+        assert_eq!(result, Ok(()));
+        assert_eq!(mock.fn_calls.pop_front(), Some(FnCall::AbortFwUpdate));
+    }
+
+    #[tokio::test]
+    async fn test_finalize_fw_update() {
+        let mut mock = super::Mock::new("test", 1);
+        let result = mock.finalize_fw_update().await;
+        assert_eq!(result, Ok(()));
+        assert_eq!(mock.fn_calls.pop_front(), Some(FnCall::FinalizeFwUpdate));
+    }
+
+    #[tokio::test]
+    async fn test_write_fw_contents() {
+        let mut mock = super::Mock::new("test", 1);
+        let data = vec![1, 2, 3, 4];
+        let result = mock.write_fw_contents(0, &data).await;
+        assert_eq!(result, Ok(()));
+        assert_eq!(mock.fn_calls.pop_front(), Some(FnCall::WriteFwContents(0, data)));
+    }
+
+    #[tokio::test]
+    async fn test_set_next_error() {
+        let mut mock = super::Mock::new("test", 1);
+        mock.set_next_error(Some(Error::Failed));
+        let result = mock.get_active_fw_version().await;
+        assert_eq!(result, Err(Error::Failed));
+    }
+}

--- a/fw-update-interface-mocks/src/lib.rs
+++ b/fw-update-interface-mocks/src/lib.rs
@@ -1,0 +1,2 @@
+//! Mocks for [`fw_update_interface`] testing.
+pub mod basic;

--- a/fw-update-interface/Cargo.toml
+++ b/fw-update-interface/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "fw-update-interface"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+log = { workspace = true, optional = true }
+defmt = { workspace = true, optional = true }
+embedded-services = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
+
+[features]
+default = []
+defmt = ["dep:defmt", "embedded-services/defmt"]
+log = ["dep:log", "embedded-services/log"]
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-machete]
+# Not directly needed currently, but present to match the log/defmt patterns of other crates
+ignored = ["log"]

--- a/fw-update-interface/src/basic.rs
+++ b/fw-update-interface/src/basic.rs
@@ -1,0 +1,43 @@
+//! This module contains types for a very basic firmware update interface.
+
+use embedded_services::named::Named;
+
+/// Basic FW update error type
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// The operation is not valid during a FW update
+    UpdateInProgress,
+    /// This operation is only valid when a FW update is in progress
+    NeedsActiveUpdate,
+    /// Invalid address
+    InvalidAddress(usize),
+    /// The firmware content is invalid
+    InvalidContent,
+    /// The requested operation timed out
+    Timeout,
+    /// The device is busy
+    Busy,
+    /// Bus error
+    Bus,
+    /// Unspecified failure
+    Failed,
+}
+
+/// Basic FW update trait
+///
+/// This is for devices that don't need to expose multiple banks and can support
+/// a FW update done through a few operations. Write only.
+pub trait FwUpdate: Named {
+    /// Get current FW version
+    fn get_active_fw_version(&mut self) -> impl Future<Output = Result<u32, Error>>;
+    /// Start a firmware update
+    fn start_fw_update(&mut self) -> impl Future<Output = Result<(), Error>>;
+    /// Abort a firmware update
+    fn abort_fw_update(&mut self) -> impl Future<Output = Result<(), Error>>;
+    /// Finalize a firmware update
+    fn finalize_fw_update(&mut self) -> impl Future<Output = Result<(), Error>>;
+    /// Write firmware update contents
+    fn write_fw_contents(&mut self, offset: usize, data: &[u8]) -> impl Future<Output = Result<(), Error>>;
+}

--- a/fw-update-interface/src/lib.rs
+++ b/fw-update-interface/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod basic;


### PR DESCRIPTION
Use the existing CFU logic in type-c-service to create a struct that can perform CFU updates on anything that implements a basic FW update trait