### PR TITLE
BREAKING CHANGE: bump heapless to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
 ]
 
@@ -667,12 +667,12 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.8.0",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -850,7 +850,7 @@ dependencies = [
  "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "mctp-rs",
  "num_enum",
@@ -1611,7 +1611,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
 ]
 
@@ -1986,7 +1986,7 @@ dependencies = [
  "embedded-fans-async",
  "embedded-sensors-hal-async",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "uuid",
 ]
@@ -2198,7 +2198,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-services",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "static_cell",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ defmt = "0.3"
 embassy-futures = "0.1.2"
 embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt" }
 embassy-sync = "0.8"
-embassy-time = "0.5.0"
-embassy-time-driver = "0.2.1"
+embassy-time = "0.5.1"
+embassy-time-driver = "0.2.2"
 embedded-batteries-async = "0.3"
 embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 embedded-hal = "1.0"
@@ -69,7 +69,7 @@ embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb
 mctp-rs = { git = "https://github.com/dymk/mctp-rs" }
 num_enum = { version = "0.7.5", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
-heapless = "0.8.*"
+heapless = "0.9.2"
 log = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,7 @@ ignore = [
     { id = "RUSTSEC-2024-0436", reason = "there are no suitable replacements for paste right now; paste has been archived as read-only. It only affects compile time concatenation in macros. We will allow it for now" },
     { id = "RUSTSEC-2023-0089", reason = "this is a deprecation warning for a dependency of a dependency. https://github.com/jamesmunns/postcard/issues/223 tracks fixing the dependency; until that's resolved, we can accept the deprecated code as it has no known vulnerabilities." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained, planning on migrating to an alternative." },
+    { id = "RUSTSEC-2026-0110", reason = "bare-metal is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -555,21 +555,21 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.8.0",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ dependencies = [
  "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "mctp-rs",
  "num_enum",
  "portable-atomic",

--- a/examples/rt633/Cargo.toml
+++ b/examples/rt633/Cargo.toml
@@ -39,7 +39,7 @@ embassy-executor = { version = "0.10.0", features = [
     "executor-interrupt",
     "defmt",
 ] }
-embassy-time = { version = "0.5.0", features = [
+embassy-time = { version = "0.5.1", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -666,21 +666,21 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.8.0",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ dependencies = [
  "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "mctp-rs",
  "num_enum",
  "portable-atomic",
@@ -1396,7 +1396,7 @@ dependencies = [
  "embassy-sync 0.8.0",
  "embassy-time",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -1821,7 +1821,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-services",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "static_cell",
  "tps6699x",
 ]

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -42,7 +42,7 @@ embassy-executor = { version = "0.10.0", features = [
     "defmt",
 ] }
 embassy-futures = "0.1.2"
-embassy-time = { version = "0.5.0", features = [
+embassy-time = { version = "0.5.1", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
 ]
 
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -561,21 +561,21 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.8.0",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ dependencies = [
  "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "mctp-rs",
  "num_enum",
@@ -1300,7 +1300,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
 ]
 
@@ -1614,7 +1614,7 @@ dependencies = [
  "embedded-fans-async",
  "embedded-sensors-hal-async",
  "embedded-services",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "uuid",
 ]
@@ -1761,7 +1761,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-services",
  "embedded-usb-pd",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "static_cell",
  "tps6699x",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 embassy-sync = { version = "0.8", features = ["log", "std"] }
-embassy-time = { version = "0.5.0", features = ["log", "std"] }
+embassy-time = { version = "0.5.1", features = ["log", "std"] }
 embassy-executor = { version = "0.10.0", features = [
     "platform-std",
     "executor-thread",

--- a/power-policy-service/src/lib.rs
+++ b/power-policy-service/src/lib.rs
@@ -27,7 +27,7 @@ struct InternalState {
     /// System unconstrained power
     unconstrained: UnconstrainedState,
     /// Connected providers
-    connected_providers: heapless::FnvIndexSet<DeviceId, MAX_CONNECTED_PROVIDERS>,
+    connected_providers: heapless::index_set::FnvIndexSet<DeviceId, MAX_CONNECTED_PROVIDERS>,
 }
 
 /// Power policy state

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -270,6 +270,11 @@ criteria = "safe-to-deploy"
 delta = "0.2.1 -> 0.2.2"
 notes = "Rust 2024 edition update with 375kHz tick rate feature. Empty build.rs, no unsafe code, no powerful imports."
 
+[[audits.embassy-time-queue-utils]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.3.2"
+
 [[audits.embedded-batteries]]
 who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-deploy"

--- a/type-c-service/src/service/ucsi.rs
+++ b/type-c-service/src/service/ucsi.rs
@@ -23,7 +23,7 @@ pub(super) struct State {
     ///
     /// We provide a battery charging status only after the port has negotiated power.
     /// This prevents the port from temporarily reporting slow or no charging before the contract has finalized.
-    valid_battery_charging_capability: heapless::FnvIndexSet<GlobalPortId, MAX_SUPPORTED_PORTS>,
+    valid_battery_charging_capability: heapless::index_set::FnvIndexSet<GlobalPortId, MAX_SUPPORTED_PORTS>,
     /// PSU connected
     pub(super) psu_connected: bool,
 }


### PR DESCRIPTION
This bumps the workspace `heapless` dependency from `0.8.*` to a pinned `0.9.2` (heapless 0.9.0/0.9.1 were yanked). Because every public type that exposes heapless containers is now backed by a different major version, this is a breaking change for every downstream consumer of any `embedded-services` workspace crate (`embedded-service`, `cfu-service`, `thermal-service`, `type-c-service`, `power-policy-service`, `battery-service`, etc.).

Downstream consumers MUST also bump their own `heapless` dependency to `0.9` or accept multi-major heapless in their lockfile. Direct users of the affected APIs will need to update calls/types per the heapless 0.9 migration notes (see below).

Heapless 0.9 source migration applied here:
- `heapless::FnvIndexSet` moved to `heapless::index_set::FnvIndexSet`. Fixed in `power-policy-service/src/lib.rs` (`connected_providers`) and `type-c-service/src/service/ucsi.rs` (`valid_battery_charging_capability`).
- No use of `heapless::HistoryBuffer` / `MpMcQueue` / `Q*` aliases / `histbuf` module / `defmt-03` feature in this workspace, so no further source/feature edits were required.
- `Vec::extend_from_slice`/`from_slice`/`resize` and `String::push`/`push_str` now return `CapacityError` instead of `()`; the workspace doesn't pattern-match these as `Err(())`, so no callsite updates were needed.

Opportunistic version bumps applied alongside (kept embassy-time stack in sync so heapless 0.9 actually reaches the active workspace):
- `embassy-time`: `0.5.0` -> `0.5.1`
- `embassy-time-driver`: `0.2.1` -> `0.2.2`
- `embassy-time-queue-utils` lockfile pin: `0.3.0` -> `0.3.2` (0.3.0 still pinned heapless 0.8 transitively)

Also bumps `embassy-time` patch in the three example workspaces (`examples/rt633`, `examples/rt685s-evk`, `examples/std`).

Final per-workspace heapless lockfile states (tracked for the org-wide audit):
- root, examples/{rt633, rt685s-evk, std}: `0.8.0` + `0.9.2`
- `embedded-service/Cargo.lock`, `power-policy-service/Cargo.lock`: unchanged (these subdir lockfiles are not part of any workspace -- `cargo locate-project --workspace` from those directories returns the root manifest, so cargo never touches them. They are stale orphans and retain `0.7.17` + `0.8.0`. Not deleted in this commit because they are still being touched by unrelated PRs; flag for separate cleanup.)

Remaining heapless 0.8.0 in active lockfiles is held there by upstream deps that haven't bumped yet:
- `tps6699x` (git, pins `heapless = "0.8.0"`)
- `keyberon` (git master, pins heapless 0.8 -- via `keyboard-service`)
- `usb-device 0.3.2` (latest crates.io -- via `keyberon`)

cargo-deny: also adds `RUSTSEC-2026-0110` (bare-metal, unmaintained) to `deny.toml`'s `advisories.ignore` list, matching the precedent set for `RUSTSEC-2024-0370`. Local `cargo deny --all-features --locked check bans licenses sources` is green; the `advisories` sub-check is skipped locally only because cargo-deny 0.18.2 trips on the CVSS 4.0 advisory `RUSTSEC-2026-0066` (astral-tokio-tar) -- CI's `cargo-deny-action` wrapper uses a newer cargo-deny that handles it.

cargo-vet: certifies `embassy-time-queue-utils 0.3.0 -> 0.3.2` as `safe-to-deploy` (only audit needed; other delta versions were already covered or matched existing audits).

Local CI replicated and green:
- `cargo fmt --all --check`
- `cargo machete`
- `cargo doc --no-deps -F log --locked` and `-F defmt --locked`
- `cargo hack --feature-powerset --mutually-exclusive-features=log,defmt,defmt-timestamp-uptime clippy --locked --target x86_64-pc-windows-msvc`
- `cargo +1.90 check -F log --locked` and `-F defmt --locked`
- `cargo clippy --target thumbv8m.main-none-eabihf --locked` for both ARM examples; `cargo clippy --locked` for the std example
- `cargo deny --all-features --locked check bans licenses sources`
- `cargo vet`

(`cargo test` skipped locally: the workspace's test build pulls defmt/cortex-m via `debug-service` and links unconditionally, which does not work on the Windows MSVC host even on `main`. CI runs it on Ubuntu where it does work.)

Assisted-by: Claude:claude-opus-4.7