### PR TITLE
Add AI attribution requirements to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,3 +176,23 @@ Follow the [standard Git commit message conventions](https://tbaggery.com/2008/0
 - Separate subject from body with a blank line
 - Wrap body text at 72 characters
 - Use the body to explain *what* and *why*, not *how*
+
+### AI Attribution
+
+Every commit that includes AI-generated or AI-assisted work **must** contain an `Assisted-by` trailer in the commit message:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+Where:
+
+- `AGENT_NAME` is the name of the AI tool or framework (e.g., `GitHub Copilot`)
+- `MODEL_VERSION` is the specific model version used (e.g., `claude-opus-4.6`)
+- `[TOOL1] [TOOL2]` are optional specialized analysis tools used (e.g., `coccinelle`, `sparse`, `smatch`, `clang-tidy`)
+
+Basic development tools (git, cargo, editors) should not be listed.
+
+AI agents **must** verify their own identity (agent name and model version) before composing the `Assisted-by` trailer — do not assume or hard-code a model name from a previous session.
+
+AI agents **MUST NOT** add `Signed-off-by` tags. Only humans can certify the Developer Certificate of Origin.


### PR DESCRIPTION
Every commit with AI-assisted work must include an Assisted-by trailer. AI agents must verify their own identity before composing the trailer and must not add Signed-off-by tags.

Assisted-by: GitHub Copilot:claude-opus-4.6