### PR TITLE
Update LICENSE copyright and add AI attribution instructions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Open Device Partnership
+Copyright (c) Open Device Partnership and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR applies two org-wide standardisation changes
(ref: OpenDevicePartnership/embedded-rust-template#20):

1. **LICENSE** – normalise the copyright line to:
   `Copyright (c) Open Device Partnership and Contributors`