### PR TITLE
Update embedded-io-async to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,7 +2301,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-sync",
- "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "embedded-services",
  "log",
  "mctp-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ embassy-executor = "0.10.0"
 cfu-service = { path = "./cfu-service" }
 embedded-hal-nb = "1.0"
 embedded-io = "0.6.1"
-embedded-io-async = "0.6.1"
+embedded-io-async = "0.7.0"
 embedded-mcu-hal = "0.2.0"
 embassy-futures = "0.1.2"
 embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ debug-service-messages = { path = "./debug-service-messages" }
 embassy-executor = "0.10.0"
 cfu-service = { path = "./cfu-service" }
 embedded-hal-nb = "1.0"
-embedded-io = "0.6.1"
 embedded-io-async = "0.7.0"
 embedded-mcu-hal = "0.2.0"
 embassy-futures = "0.1.2"


### PR DESCRIPTION
Updates uart-service to use the latest `embedded-io-async` (v0.7). Originally used v0.6.1 to support the IMXRT HAL but now we are supporting more platforms which have all moved onto the v0.7 impl of this trait.

Note: No other crate currently uses `embedded-io-async` from the workspace Cargo toml so this won't cause any breakage in other crates.

Can still support the `dev-imxrt` platform by making a wrapper that impls v0.7, which is better than the reverse (wrapping all the v0.7 HALs in v0.6 impls).

See: https://github.com/OpenDevicePartnership/odp-embedded-controller/issues/15 for some context

Resolves #824  