### PR TITLE
type-c-service/ucsi: Fix excessive OPM notification

### DIFF
--- a/type-c-service/src/service/power.rs
+++ b/type-c-service/src/service/power.rs
@@ -77,13 +77,17 @@ impl<'a, Reg: Registration<'a>> Service<'a, Reg> {
             PowerPolicyEventData::ConsumerDisconnected => {
                 self.ucsi.psu_connected = false;
                 // Notify OPM because this can affect battery charging capability status
-                self.pend_ucsi_connected_ports().await;
+                if self.ucsi.notifications_enabled.battery_charge_change() {
+                    self.pend_ucsi_connected_ports().await;
+                }
                 Ok(())
             }
             PowerPolicyEventData::ConsumerConnected(_) => {
                 self.ucsi.psu_connected = true;
                 // Notify OPM because this can affect battery charging capability status
-                self.pend_ucsi_connected_ports().await;
+                if self.ucsi.notifications_enabled.battery_charge_change() {
+                    self.pend_ucsi_connected_ports().await;
+                }
                 Ok(())
             }
             _ => Ok(()), // Other events don't require any action from the service

--- a/type-c-service/src/service/ucsi.rs
+++ b/type-c-service/src/service/ucsi.rs
@@ -31,18 +31,18 @@ pub struct UcsiResponse {
 #[derive(Default)]
 pub(super) struct State {
     /// PPM state machine
-    ppm_state_machine: StateMachine,
+    pub ppm_state_machine: StateMachine,
     /// Currently enabled notifications
-    notifications_enabled: NotificationEnable,
+    pub notifications_enabled: NotificationEnable,
     /// Queued pending port notifications
-    pending_ports: heapless::Deque<GlobalPortId, MAX_SUPPORTED_PORTS>,
+    pub pending_ports: heapless::Deque<GlobalPortId, MAX_SUPPORTED_PORTS>,
     /// Ports that have a valid battery charging status capability
     ///
     /// We provide a battery charging status only after the port has negotiated power.
     /// This prevents the port from temporarily reporting slow or no charging before the contract has finalized.
-    valid_battery_charging_capability: heapless::index_set::FnvIndexSet<GlobalPortId, MAX_SUPPORTED_PORTS>,
+    pub valid_battery_charging_capability: heapless::index_set::FnvIndexSet<GlobalPortId, MAX_SUPPORTED_PORTS>,
     /// PSU connected
-    pub(super) psu_connected: bool,
+    pub psu_connected: bool,
 }
 
 impl<'port, Reg: Registration<'port>> Service<'port, Reg> {


### PR DESCRIPTION
The existing implementation will always notify the OPM on PSU connect/disconnect even if the OPM hasn't enabled the corresponding notification.