### PR TITLE
Pin git dependencies to release tags for v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0#583015c08ad9855f310bdb25d5cf9abff77b5e08"
 dependencies = [
  "num-traits",
 ]
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#d95ffe560071e942d917b422bbdea7e73f6c4602"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt?tag=v0.1.0#6524cbabcc12016f1aea4c0ffa2f1354c3f8c6d1"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -510,7 +510,9 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-nb",
  "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "embedded-mcu-hal",
  "embedded-storage",
  "fixed",
@@ -606,7 +608,7 @@ dependencies = [
 [[package]]
 name = "embedded-cfu-protocol"
 version = "0.2.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#a4cc8707842b878048447abbf2af4efa79fed368"
+source = "git+https://github.com/OpenDevicePartnership/embedded-cfu?tag=v0.1.0#523a83919c3535e8ccead031d80b715d77395f81"
 dependencies = [
  "defmt 0.3.100",
  "embedded-io-async 0.6.1",
@@ -783,7 +785,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#21d0e228d21ddc6ccaeffc01d98ef9a5b87941ef"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -801,7 +803,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#9805f13c044b0e314d415410c57a8a59a40eabeb"
+source = "git+https://github.com/OpenDevicePartnership/odp-secure-services?tag=v0.1.0#290aa80a4c281857f3bed94581200b330119286c"
 dependencies = [
  "bit-register",
  "bitflags 2.9.4",
@@ -1016,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "keyberon"
 version = "0.2.0"
-source = "git+https://github.com/TeXitoi/keyberon#362c209f729d05505abb1984a0ddb321ec9ebf53"
+source = "git+https://github.com/TeXitoi/keyberon?rev=362c209f729d05505abb1984a0ddb321ec9ebf53#362c209f729d05505abb1984a0ddb321ec9ebf53"
 dependencies = [
  "arraydeque",
  "either",
@@ -1029,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "keyberon-macros"
 version = "0.1.0"
-source = "git+https://github.com/TeXitoi/keyberon#362c209f729d05505abb1984a0ddb321ec9ebf53"
+source = "git+https://github.com/TeXitoi/keyberon?rev=362c209f729d05505abb1984a0ddb321ec9ebf53#362c209f729d05505abb1984a0ddb321ec9ebf53"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1117,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/dymk/mctp-rs#3d941ba5205ca7781bf37e3dc7c5dfdc99a082d6"
+source = "git+https://github.com/OpenDevicePartnership/mctp-rs?tag=v0.1.0#986d6640570a52d6020529926f3914b44872e54a"
 dependencies = [
  "bit-register",
  "defmt 0.3.100",
@@ -1675,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#528045934782abc704531aa423169c75016e7727"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu?tag=storage_bus_v0.1.0#8580385bf4a035299cacddef8796c17694655a17"
 
 [[package]]
 name = "subenum"
@@ -1826,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#ba1b3b17ebf048fc007eb2107a4d2ab8cb545adf"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.0#0c2f495621faf48f4042012e0fb5c1cfc9b29320"
 dependencies = [
  "bincode",
  "bitfield 0.19.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,18 +55,18 @@ cortex-m-rt = "0.7.5"
 critical-section = "1.1"
 defmt = "0.3"
 embassy-futures = "0.1.2"
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt" }
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", tag = "v0.1.0"  }
 embassy-sync = "0.8"
 embassy-time = "0.5.1"
 embassy-time-driver = "0.2.2"
 embedded-batteries-async = "0.3"
-embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", tag = "v0.1.0"  }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-services = { path = "./embedded-service" }
 embedded-storage-async = "0.4.1"
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false }
-mctp-rs = { git = "https://github.com/dymk/mctp-rs" }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0" , default-features = false }
+mctp-rs = { git = "https://github.com/OpenDevicePartnership/mctp-rs", tag = "v0.1.0" }
 num_enum = { version = "0.7.5", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
 heapless = "0.9.2"
@@ -78,6 +78,6 @@ serde = { version = "1.0.*", default-features = false }
 static_cell = "2.1.0"
 toml = { version = "0.8", default-features = false }
 syn = "2.0"
-tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x" }
+tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v0.1.0" }
 tokio = { version = "1.42.0" }
 uuid = { version = "=1.17.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ cortex-m-rt = "0.7.5"
 critical-section = "1.1"
 defmt = "0.3"
 embassy-futures = "0.1.2"
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", tag = "v0.1.0"  }
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", tag = "v0.1.0" }
 embassy-sync = "0.8"
 embassy-time = "0.5.1"
 embassy-time-driver = "0.2.2"
 embedded-batteries-async = "0.3"
-embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", tag = "v0.1.0"  }
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", tag = "v0.1.0" }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-services = { path = "./embedded-service" }

--- a/embedded-service/src/ec_type/protocols/mctp.rs
+++ b/embedded-service/src/ec_type/protocols/mctp.rs
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[allow(dead_code)]
     mod test_util {
-        use mctp_rs::{MctpMedium, MctpMediumFrame, MctpPacketError, error::MctpPacketResult};
+        use mctp_rs::{MctpMedium, MctpMediumFrame, MctpPacketError, EncodingDecoder, EncodingEncoder, PassthroughEncoding, error::MctpPacketResult};
 
         #[derive(Debug, PartialEq, Eq, Copy, Clone)]
         pub struct TestMedium {
@@ -1235,8 +1235,9 @@ mod tests {
             type Frame = TestMediumFrame;
             type Error = &'static str;
             type ReplyContext = ();
+            type Encoding = PassthroughEncoding;
 
-            fn deserialize<'buf>(&self, packet: &'buf [u8]) -> MctpPacketResult<(Self::Frame, &'buf [u8]), Self> {
+            fn deserialize<'buf>(&self, packet: &'buf [u8]) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
                 let packet_len = packet.len();
 
                 // check that header / trailer is present and correct
@@ -1251,7 +1252,7 @@ mod tests {
                 }
 
                 let packet = &packet[self.header.len()..packet_len - self.trailer.len()];
-                Ok((TestMediumFrame(packet_len), packet))
+                Ok((TestMediumFrame(packet_len), EncodingDecoder::new(packet)))
             }
             fn max_message_body_size(&self) -> usize {
                 self.mtu
@@ -1263,7 +1264,7 @@ mod tests {
                 message_writer: F,
             ) -> MctpPacketResult<&'buf [u8], Self>
             where
-                F: for<'a> FnOnce(&'a mut [u8]) -> MctpPacketResult<usize, Self>,
+                F: for<'a> FnOnce(&mut EncodingEncoder<'a, Self::Encoding>) -> MctpPacketResult<(), Self>,
             {
                 let header_len = self.header.len();
                 let trailer_len = self.trailer.len();
@@ -1281,7 +1282,12 @@ mod tests {
                 let max_message_size = max_packet_size - header_len - trailer_len;
 
                 buffer[0..header_len].copy_from_slice(self.header);
-                let size = message_writer(&mut buffer[header_len..header_len + max_message_size])?;
+                let size = {
+                    let body_buf = &mut buffer[header_len..header_len + max_message_size];
+                    let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
+                    message_writer(&mut encoder)?;
+                    encoder.wire_position()
+                };
                 let len = header_len + size;
                 buffer[len..len + trailer_len].copy_from_slice(self.trailer);
                 Ok(&buffer[..len + trailer_len])

--- a/embedded-service/src/ec_type/protocols/mctp.rs
+++ b/embedded-service/src/ec_type/protocols/mctp.rs
@@ -1201,7 +1201,10 @@ mod tests {
 
     #[allow(dead_code)]
     mod test_util {
-        use mctp_rs::{MctpMedium, MctpMediumFrame, MctpPacketError, EncodingDecoder, EncodingEncoder, PassthroughEncoding, error::MctpPacketResult};
+        use mctp_rs::{
+            EncodingDecoder, EncodingEncoder, MctpMedium, MctpMediumFrame, MctpPacketError, PassthroughEncoding,
+            error::MctpPacketResult,
+        };
 
         #[derive(Debug, PartialEq, Eq, Copy, Clone)]
         pub struct TestMedium {
@@ -1237,7 +1240,10 @@ mod tests {
             type ReplyContext = ();
             type Encoding = PassthroughEncoding;
 
-            fn deserialize<'buf>(&self, packet: &'buf [u8]) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
+            fn deserialize<'buf>(
+                &self,
+                packet: &'buf [u8],
+            ) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
                 let packet_len = packet.len();
 
                 // check that header / trailer is present and correct

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -70,15 +70,7 @@ dependencies = [
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238#2f79d238149049d458199a9a9129b54be7893aee"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "bit-register"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0#583015c08ad9855f310bdb25d5cf9abff77b5e08"
 dependencies = [
  "num-traits",
 ]
@@ -115,17 +107,6 @@ name = "bitfield-macros"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "bitfield-struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -544,24 +525,11 @@ dependencies = [
 
 [[package]]
 name = "embedded-batteries"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e14d288a59ef41f4e05468eae9b1c9fef6866977cea86d3f1a1ced295b6cab"
-dependencies = [
- "bitfield-struct 0.10.1",
- "bitflags 2.9.1",
- "defmt 0.3.100",
- "embedded-hal 1.0.0",
- "zerocopy",
-]
-
-[[package]]
-name = "embedded-batteries"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40f975432b4e146342a1589c563cffab6b7a692024cb511bf87b6bfe78c84125"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct",
  "bitflags 2.9.1",
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
@@ -574,9 +542,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3bf0e4be67770cfc31f1cea8b73baf98c0baf2c57d6bd8c3a4c315acb1d8bd4"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct",
  "defmt 0.3.100",
- "embedded-batteries 0.3.4",
+ "embedded-batteries",
  "embedded-hal 1.0.0",
 ]
 
@@ -723,9 +691,9 @@ dependencies = [
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#8cdd61095471903b1b438dbb0eee142676cc3d74"
+source = "git+https://github.com/OpenDevicePartnership/odp-secure-services?tag=v0.1.0#290aa80a4c281857f3bed94581200b330119286c"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238)",
+ "bit-register",
  "bitflags 2.9.1",
  "num-traits",
  "num_enum",
@@ -931,11 +899,11 @@ dependencies = [
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/dymk/mctp-rs#4456c65131366acd5e605c7d88a707881fa9e9f0"
+source = "git+https://github.com/OpenDevicePartnership/mctp-rs?tag=v0.1.0#986d6640570a52d6020529926f3914b44872e54a"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
+ "bit-register",
  "defmt 0.3.100",
- "embedded-batteries 0.2.1",
+ "embedded-batteries",
  "espi-device",
  "num_enum",
  "smbus-pec",

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -52,7 +52,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-batteries-async",
  "embedded-services",
@@ -376,31 +376,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
-dependencies = [
- "embassy-futures",
- "embassy-hal-internal 0.3.0",
- "embassy-sync 0.7.2",
- "embassy-time",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-storage",
- "embedded-storage-async",
- "nb 1.1.0",
-]
-
-[[package]]
-name = "embassy-embedded-hal"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal 0.4.0",
- "embassy-sync 0.8.0",
+ "embassy-sync",
+ "embassy-time",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -472,7 +455,7 @@ dependencies = [
 [[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#581f66e68ceaefb77e35f230dfb114322912dd6b"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt?tag=v0.1.0#6524cbabcc12016f1aea4c0ffa2f1354c3f8c6d1"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -480,10 +463,10 @@ dependencies = [
  "critical-section",
  "defmt 1.0.1",
  "document-features",
- "embassy-embedded-hal 0.5.0",
+ "embassy-embedded-hal",
  "embassy-futures",
  "embassy-hal-internal 0.3.0",
- "embassy-sync 0.7.2",
+ "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -492,7 +475,9 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-nb",
  "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "embedded-mcu-hal",
  "embedded-storage",
  "fixed",
@@ -508,21 +493,6 @@ dependencies = [
 
 [[package]]
 name = "embassy-sync"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
-dependencies = [
- "cfg-if",
- "critical-section",
- "defmt 1.0.1",
- "embedded-io-async 0.6.1",
- "futures-core",
- "futures-sink",
- "heapless 0.8.0",
-]
-
-[[package]]
-name = "embassy-sync"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
@@ -533,7 +503,7 @@ dependencies = [
  "embedded-io-async 0.7.0",
  "futures-core",
  "futures-sink",
- "heapless 0.9.2",
+ "heapless",
 ]
 
 [[package]]
@@ -569,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.9.2",
+ "heapless",
 ]
 
 [[package]]
@@ -613,7 +583,7 @@ dependencies = [
 [[package]]
 name = "embedded-cfu-protocol"
 version = "0.2.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#a4cc8707842b878048447abbf2af4efa79fed368"
+source = "git+https://github.com/OpenDevicePartnership/embedded-cfu?tag=v0.1.0#523a83919c3535e8ccead031d80b715d77395f81"
 dependencies = [
  "defmt 0.3.100",
  "embedded-io-async 0.6.1",
@@ -692,10 +662,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt 1.0.1",
+ "num_enum",
 ]
 
 [[package]]
@@ -708,12 +680,12 @@ dependencies = [
  "cortex-m-rt",
  "critical-section",
  "defmt 0.3.100",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-batteries-async",
  "embedded-cfu-protocol",
  "embedded-usb-pd",
- "heapless 0.9.2",
+ "heapless",
  "mctp-rs",
  "num_enum",
  "portable-atomic",
@@ -739,7 +711,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#21d0e228d21ddc6ccaeffc01d98ef9a5b87941ef"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -770,7 +742,7 @@ dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
  "embassy-imxrt",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embedded-services",
  "mctp-rs",
 ]
@@ -849,16 +821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -997,27 +959,27 @@ dependencies = [
 
 [[package]]
 name = "mimxrt633s-pac"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c1c63c367293e4fa270cc161b5bdfef55b4c6a0a18768f737241fb24be70c"
+checksum = "a580cd0048e0e5b1eee17208b7f95ba05ec7ca0175789333b2fa7241798d3cdc"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "mimxrt685s-pac"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0b80e5add9dc74500acbb1ca70248e237d242b77988631e41db40a225f3a40"
+checksum = "8c8860258951178c4f91e42581ae8f33241a0e9a3e89bf2721d932ef366db51b"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "vcell",
 ]
 
@@ -1157,9 +1119,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "regex-automata"
@@ -1188,10 +1150,10 @@ dependencies = [
  "cortex-m-rt",
  "defmt 0.3.100",
  "defmt-rtt",
- "embassy-embedded-hal 0.6.0",
+ "embassy-embedded-hal",
  "embassy-executor",
  "embassy-imxrt",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-batteries-async",
  "embedded-services",
@@ -1311,7 +1273,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu?tag=storage_bus_v0.1.0#8580385bf4a035299cacddef8796c17694655a17"
 
 [[package]]
 name = "strsim"

--- a/examples/rt633/Cargo.toml
+++ b/examples/rt633/Cargo.toml
@@ -24,7 +24,7 @@ cortex-m-rt = "0.7.3"
 defmt = "0.3.6"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features = ["print-defmt"] }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", tag = "v0.1.0", features = [
     "defmt",
     "time-driver-os-timer",
     "time",

--- a/examples/rt633/src/bin/espi_battery.rs
+++ b/examples/rt633/src/bin/espi_battery.rs
@@ -307,6 +307,7 @@ async fn main(spawner: Spawner) {
     let config = embassy_imxrt::i2c::master::Config {
         speed: embassy_imxrt::i2c::master::Speed::Standard,
         duty_cycle: embassy_imxrt::i2c::master::DutyCycle::new(50).unwrap(),
+        strict_mode: true,
     };
 
     let i2c_fg = embassy_imxrt::i2c::master::I2cMaster::new_async(

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -68,15 +68,7 @@ dependencies = [
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238#2f79d238149049d458199a9a9129b54be7893aee"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "bit-register"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0#583015c08ad9855f310bdb25d5cf9abff77b5e08"
 dependencies = [
  "num-traits",
 ]
@@ -113,17 +105,6 @@ name = "bitfield-macros"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52511b09931f7d5fe3a14f23adefbc23e5725b184013e96c8419febb61f14734"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "bitfield-struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -546,24 +527,11 @@ dependencies = [
 
 [[package]]
 name = "embedded-batteries"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e14d288a59ef41f4e05468eae9b1c9fef6866977cea86d3f1a1ced295b6cab"
-dependencies = [
- "bitfield-struct 0.10.1",
- "bitflags 2.9.4",
- "defmt 0.3.100",
- "embedded-hal 1.0.0",
- "zerocopy",
-]
-
-[[package]]
-name = "embedded-batteries"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40f975432b4e146342a1589c563cffab6b7a692024cb511bf87b6bfe78c84125"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct",
  "bitflags 2.9.4",
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
@@ -576,9 +544,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3bf0e4be67770cfc31f1cea8b73baf98c0baf2c57d6bd8c3a4c315acb1d8bd4"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct",
  "defmt 0.3.100",
- "embedded-batteries 0.3.4",
+ "embedded-batteries",
  "embedded-hal 1.0.0",
 ]
 
@@ -728,9 +696,9 @@ dependencies = [
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#8cdd61095471903b1b438dbb0eee142676cc3d74"
+source = "git+https://github.com/OpenDevicePartnership/odp-secure-services?tag=v0.1.0#290aa80a4c281857f3bed94581200b330119286c"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238)",
+ "bit-register",
  "bitflags 2.9.4",
  "num-traits",
  "num_enum",
@@ -941,11 +909,11 @@ dependencies = [
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/dymk/mctp-rs#4456c65131366acd5e605c7d88a707881fa9e9f0"
+source = "git+https://github.com/OpenDevicePartnership/mctp-rs?tag=v0.1.0#986d6640570a52d6020529926f3914b44872e54a"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
+ "bit-register",
  "defmt 0.3.100",
- "embedded-batteries 0.2.1",
+ "embedded-batteries",
  "espi-device",
  "num_enum",
  "smbus-pec",

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -377,24 +377,6 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
-dependencies = [
- "embassy-futures",
- "embassy-hal-internal 0.3.0",
- "embassy-sync 0.7.2",
- "embassy-time",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-storage",
- "embedded-storage-async",
- "nb 1.1.0",
-]
-
-[[package]]
-name = "embassy-embedded-hal"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
@@ -402,7 +384,8 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-hal-internal 0.4.0",
- "embassy-sync 0.8.0",
+ "embassy-sync",
+ "embassy-time",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -474,7 +457,7 @@ dependencies = [
 [[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#581f66e68ceaefb77e35f230dfb114322912dd6b"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt?tag=v0.1.0#6524cbabcc12016f1aea4c0ffa2f1354c3f8c6d1"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -482,10 +465,10 @@ dependencies = [
  "critical-section",
  "defmt 1.0.1",
  "document-features",
- "embassy-embedded-hal 0.5.0",
+ "embassy-embedded-hal",
  "embassy-futures",
  "embassy-hal-internal 0.3.0",
- "embassy-sync 0.7.2",
+ "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -494,7 +477,9 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-nb",
  "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "embedded-mcu-hal",
  "embedded-storage",
  "fixed",
@@ -506,21 +491,6 @@ dependencies = [
  "paste",
  "rand_core",
  "storage_bus",
-]
-
-[[package]]
-name = "embassy-sync"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
-dependencies = [
- "cfg-if",
- "critical-section",
- "defmt 1.0.1",
- "embedded-io-async 0.6.1",
- "futures-core",
- "futures-sink",
- "heapless 0.8.0",
 ]
 
 [[package]]
@@ -615,7 +585,7 @@ dependencies = [
 [[package]]
 name = "embedded-cfu-protocol"
 version = "0.2.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#a4cc8707842b878048447abbf2af4efa79fed368"
+source = "git+https://github.com/OpenDevicePartnership/embedded-cfu?tag=v0.1.0#523a83919c3535e8ccead031d80b715d77395f81"
 dependencies = [
  "defmt 0.3.100",
  "embedded-io-async 0.6.1",
@@ -697,10 +667,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt 1.0.1",
+ "num_enum",
 ]
 
 [[package]]
@@ -713,7 +685,7 @@ dependencies = [
  "cortex-m-rt",
  "critical-section",
  "defmt 0.3.100",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-batteries-async",
  "embedded-cfu-protocol",
@@ -744,7 +716,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#21d0e228d21ddc6ccaeffc01d98ef9a5b87941ef"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -1006,27 +978,27 @@ dependencies = [
 
 [[package]]
 name = "mimxrt633s-pac"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c1c63c367293e4fa270cc161b5bdfef55b4c6a0a18768f737241fb24be70c"
+checksum = "a580cd0048e0e5b1eee17208b7f95ba05ec7ca0175789333b2fa7241798d3cdc"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "mimxrt685s-pac"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0b80e5add9dc74500acbb1ca70248e237d242b77988631e41db40a225f3a40"
+checksum = "8c8860258951178c4f91e42581ae8f33241a0e9a3e89bf2721d932ef366db51b"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "vcell",
 ]
 
@@ -1120,7 +1092,7 @@ dependencies = [
  "crc",
  "defmt 0.3.100",
  "embassy-imxrt",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-services",
 ]
@@ -1147,7 +1119,7 @@ version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-services",
  "heapless 0.9.2",
@@ -1201,9 +1173,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "regex-automata"
@@ -1231,11 +1203,11 @@ dependencies = [
  "crc",
  "defmt 0.3.100",
  "defmt-rtt",
- "embassy-embedded-hal 0.6.0",
+ "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
  "embassy-imxrt",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-services",
@@ -1360,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu?tag=storage_bus_v0.1.0#8580385bf4a035299cacddef8796c17694655a17"
 
 [[package]]
 name = "strsim"
@@ -1440,13 +1412,13 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#ba1b3b17ebf048fc007eb2107a4d2ab8cb545adf"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.0#0c2f495621faf48f4042012e0fb5c1cfc9b29320"
 dependencies = [
  "bincode",
  "bitfield 0.19.2",
  "defmt 0.3.100",
  "device-driver",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -1525,7 +1497,7 @@ dependencies = [
  "bitflags 2.9.4",
  "defmt 0.3.100",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync",
  "embassy-time",
  "embedded-cfu-protocol",
  "embedded-hal-async",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -25,7 +25,7 @@ crc = "3.2.1"
 defmt = "0.3.6"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features = ["print-defmt"] }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt", tag = "v0.1.0", features = [
     "defmt",
     "time-driver-os-timer",
     "time",
@@ -48,7 +48,7 @@ embassy-time = { version = "0.5.1", features = [
 ] }
 mimxrt600-fcb = "0.1.0"
 
-embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", tag = "v0.1.0" }
 embedded-services = { path = "../../embedded-service", features = ["defmt"] }
 power-button-service = { path = "../../power-button-service", features = [
     "defmt",
@@ -56,11 +56,11 @@ power-button-service = { path = "../../power-button-service", features = [
 power-policy-service = { path = "../../power-policy-service", features = [
     "defmt",
 ] }
-tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", features = [
+tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v0.1.0", features = [
     "defmt",
     "embassy",
 ] }
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false, features = [
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0",  default-features = false, features = [
     "defmt",
 ] }
 type-c-service = { path = "../../type-c-service", features = ["defmt"] }

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -60,7 +60,7 @@ tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v
     "defmt",
     "embassy",
 ] }
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0",  default-features = false, features = [
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false, features = [
     "defmt",
 ] }
 type-c-service = { path = "../../type-c-service", features = ["defmt"] }

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "embedded-cfu-protocol"
 version = "0.2.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-cfu#a4cc8707842b878048447abbf2af4efa79fed368"
+source = "git+https://github.com/OpenDevicePartnership/embedded-cfu?tag=v0.1.0#523a83919c3535e8ccead031d80b715d77395f81"
 dependencies = [
  "embedded-io-async 0.6.1",
  "log",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#21d0e228d21ddc6ccaeffc01d98ef9a5b87941ef"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x#ba1b3b17ebf048fc007eb2107a4d2ab8cb545adf"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.0#0c2f495621faf48f4042012e0fb5c1cfc9b29320"
 dependencies = [
  "bincode",
  "bitfield 0.19.2",

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -96,15 +96,7 @@ dependencies = [
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238#2f79d238149049d458199a9a9129b54be7893aee"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "bit-register"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0#583015c08ad9855f310bdb25d5cf9abff77b5e08"
 dependencies = [
  "num-traits",
 ]
@@ -677,9 +669,9 @@ dependencies = [
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#8cdd61095471903b1b438dbb0eee142676cc3d74"
+source = "git+https://github.com/OpenDevicePartnership/odp-secure-services?tag=v0.1.0#290aa80a4c281857f3bed94581200b330119286c"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?rev=2f79d238)",
+ "bit-register",
  "bitflags 2.9.4",
  "num-traits",
  "num_enum",
@@ -888,9 +880,9 @@ dependencies = [
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/dymk/mctp-rs#4456c65131366acd5e605c7d88a707881fa9e9f0"
+source = "git+https://github.com/OpenDevicePartnership/mctp-rs?tag=v0.1.0#986d6640570a52d6020529926f3914b44872e54a"
 dependencies = [
- "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
+ "bit-register",
  "espi-device",
  "num_enum",
  "smbus-pec",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -25,13 +25,13 @@ embassy-executor = { version = "0.10.0", features = [
 
 defmt = "0.3"
 
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd" }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0" }
 embedded-services = { path = "../../embedded-service", features = ["log"] }
 power-policy-service = { path = "../../power-policy-service", features = [
     "log",
 ] }
 cfu-service = { path = "../../cfu-service", features = ["log"] }
-embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", tag = "v0.1.0" }
 
 embedded-batteries-async = "0.3"
 battery-service = { path = "../../battery-service", features = ["log"] }

--- a/keyboard-service/Cargo.toml
+++ b/keyboard-service/Cargo.toml
@@ -21,7 +21,7 @@ embedded-hal.workspace = true
 static_cell.workspace = true
 bitflags.workspace = true
 hid-service = { path = "../hid-service" }
-keyberon = { git = "https://github.com/TeXitoi/keyberon" }
+keyberon = { git = "https://github.com/TeXitoi/keyberon", rev = "362c209f729d05505abb1984a0ddb321ec9ebf53" }
 
 [features]
 default = []


### PR DESCRIPTION
This pull request updates several dependencies to use fixed versions or tags, improving build reproducibility and stability across the project. Additionally, it refactors the MCTP protocol test utilities to use encoding types for greater flexibility and type safety. There is also a minor configuration change to enable strict mode in I2C master configuration.

**Dependency version pinning and updates:**
- Updated multiple dependencies in `Cargo.toml` files to use specific tags (e.g., `tag = "v0.1.0"`) or commit hashes instead of tracking the latest code on the main branch. This applies to `embassy-imxrt`, `embedded-cfu-protocol`, `embedded-usb-pd`, `mctp-rs`, and `tps6699x` across several project and example manifests, as well as `keyberon` in `keyboard-service/Cargo.toml` [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L58-R69) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L81-R81) [[3]](diffhunk://#diff-35bae31daaac35fed05a697004659ad4a293192b72f733f1a658a7d3eb8a79d4L27-R27) [[4]](diffhunk://#diff-2c72d6598e84d8d9d139c8cc8155df71986db75b1f4a4116935992c8612313a0L28-R28) [[5]](diffhunk://#diff-2c72d6598e84d8d9d139c8cc8155df71986db75b1f4a4116935992c8612313a0L51-R63) [[6]](diffhunk://#diff-448f2457b3febd367c73a2857bfadf1cab024cc977214f95bbc8723569de89ecL28-R34) [[7]](diffhunk://#diff-d83eb308462d4bd3a2f7b47dfe40030b6ddebbf581c7db5b48e0d5049e18ab4dL24-R24).

**MCTP protocol test refactor:**
- Refactored the MCTP protocol test utilities in `embedded-service/src/ec_type/protocols/mctp.rs` to use `EncodingDecoder`, `EncodingEncoder`, and `PassthroughEncoding` types, improving type safety and future extensibility for encoded payloads [[1]](diffhunk://#diff-f6a591d83129f84ebbd4b91178b4262bae6f57b93f348aa84f73cb341b14a7f9L1204-R1207) [[2]](diffhunk://#diff-f6a591d83129f84ebbd4b91178b4262bae6f57b93f348aa84f73cb341b14a7f9R1241-R1246) [[3]](diffhunk://#diff-f6a591d83129f84ebbd4b91178b4262bae6f57b93f348aa84f73cb341b14a7f9L1254-R1261) [[4]](diffhunk://#diff-f6a591d83129f84ebbd4b91178b4262bae6f57b93f348aa84f73cb341b14a7f9L1266-R1273) [[5]](diffhunk://#diff-f6a591d83129f84ebbd4b91178b4262bae6f57b93f348aa84f73cb341b14a7f9L1284-R1296).

**Configuration improvements:**
- Enabled `strict_mode` in the I2C master configuration in `examples/rt633/src/bin/espi_battery.rs` for stricter protocol compliance.