### PR TITLE
Non-exhaustive clean up

### DIFF
--- a/power-policy-interface/src/psu/event.rs
+++ b/power-policy-interface/src/psu/event.rs
@@ -9,6 +9,7 @@ use crate::{
 /// Data for an event broadcast from a PSU.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum EventData {
     /// Notify that a device has attached
     Attached,

--- a/power-policy-interface/src/service/event.rs
+++ b/power-policy-interface/src/service/event.rs
@@ -13,6 +13,7 @@ use crate::{
 /// and allows for receivers that don't need to be generic over the device type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum EventData {
     /// Consumer disconnected
     ConsumerDisconnected,
@@ -44,6 +45,7 @@ where
 /// Events broadcast from the service.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Event<'device, PSU: Lockable>
 where
     PSU::Inner: Psu,

--- a/power-policy-service/src/service/config.rs
+++ b/power-policy-service/src/service/config.rs
@@ -3,6 +3,7 @@
 use power_policy_interface::capability::PowerCapability;
 
 #[derive(Clone, Copy)]
+#[non_exhaustive]
 pub struct Config {
     /// Above this threshold, the system is in limited power mode
     pub limited_power_threshold_mw: u32,

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -159,6 +159,14 @@ impl<'device, Reg: Registration<'device>> Service<'device, Reg> {
                     .await
             }
             PsuEventData::Disconnected => self.process_notify_disconnect(device).await,
+            _ => {
+                info!(
+                    "Received unknown PSU event from ({}): {:?}",
+                    device.lock().await.name(),
+                    event.event
+                );
+                Ok(())
+            }
         }
     }
 

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -687,15 +687,10 @@ async fn run_test_disconnect_other_provider() {
 
 #[tokio::test]
 async fn run_test_min_consumer_power() {
-    run_test(
-        DEFAULT_TIMEOUT,
-        TestMinConsumerPower,
-        Config {
-            min_consumer_threshold_mw: Some(MIN_CONSUMER_THRESHOLD_MW),
-            ..Default::default()
-        },
-    )
-    .await;
+    let mut config = Config::default();
+    config.min_consumer_threshold_mw = Some(MIN_CONSUMER_THRESHOLD_MW);
+
+    run_test(DEFAULT_TIMEOUT, TestMinConsumerPower, config).await;
 }
 
 #[tokio::test]

--- a/type-c-interface/src/port/event.rs
+++ b/type-c-interface/src/port/event.rs
@@ -272,6 +272,7 @@ impl PortNotificationEventBitfield {
 /// Individual VDM notifications
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum VdmNotification {
     /// Custom mode entered
     Entered,
@@ -286,6 +287,7 @@ pub enum VdmNotification {
 /// VDM event data
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum VdmData {
     /// Entered custom mode
     Entered(OtherVdm),
@@ -300,6 +302,7 @@ pub enum VdmData {
 /// Enum to contain all port event variants
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum PortEvent {
     /// Port status change events
     StatusChanged(PortStatusEventBitfield),

--- a/type-c-interface/src/service/event.rs
+++ b/type-c-interface/src/service/event.rs
@@ -26,6 +26,7 @@ pub struct StatusChangedData {
 /// Enum to contain all port event variants
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum PortEventData {
     /// Port status change events
     StatusChanged(StatusChangedData),
@@ -70,6 +71,7 @@ pub struct UsciChangeIndicatorData {
 /// Top-level comms message
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum EventData {
     DebugAccessory(DebugAccessoryData),
     UsciChangeIndicator(UsciChangeIndicatorData),

--- a/type-c-service/src/controller/config.rs
+++ b/type-c-service/src/controller/config.rs
@@ -1,6 +1,7 @@
 /// Configuration for Type-C controller wrapper
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct Config {
     /// Unconstrained behavior for sink role
     pub unconstrained_sink: UnconstrainedSink,
@@ -9,6 +10,7 @@ pub struct Config {
 /// Unconstrained behavior for sink role
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum UnconstrainedSink {
     /// Automatically signal unconstrained power based on unconstrained bit in PDO
     #[default]

--- a/type-c-service/src/controller/mod.rs
+++ b/type-c-service/src/controller/mod.rs
@@ -104,7 +104,7 @@ impl<
                 self.process_port_status_changed(status_event).await.map(Some)
             }
             InterfacePortEvent::Alert => self.process_pd_alert().await,
-            InterfacePortEvent::Vdm(vdm_event) => self.process_vdm_event(vdm_event).await.map(Some),
+            InterfacePortEvent::Vdm(vdm_event) => self.process_vdm_event(vdm_event).await,
             InterfacePortEvent::DpStatusUpdate => self.process_dp_status_update().await.map(Some),
             rest => {
                 // Nothing currently implemented for these

--- a/type-c-service/src/controller/pd.rs
+++ b/type-c-service/src/controller/pd.rs
@@ -28,7 +28,10 @@ impl<
 > Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
 {
     /// Process a VDM event by retrieving the relevant VDM data from the `controller` for the appropriate `port`.
-    pub(super) async fn process_vdm_event(&mut self, event: VdmNotification) -> Result<ServicePortEventData, PdError> {
+    pub(super) async fn process_vdm_event(
+        &mut self,
+        event: VdmNotification,
+    ) -> Result<Option<ServicePortEventData>, PdError> {
         debug!("({}): Processing VDM event: {:?}", self.name, event);
         let vdm_data = {
             let mut controller = self.controller.lock().await;
@@ -37,12 +40,16 @@ impl<
                 VdmNotification::Exited => VdmData::Exited(controller.get_other_vdm(self.port).await?),
                 VdmNotification::OtherReceived => VdmData::ReceivedOther(controller.get_other_vdm(self.port).await?),
                 VdmNotification::AttentionReceived => VdmData::ReceivedAttn(controller.get_attn_vdm(self.port).await?),
+                _ => {
+                    info!("({}): Received unknown VDM event: {:?}", self.name, event);
+                    return Ok(None);
+                }
             }
         };
 
         let event = ServicePortEventData::Vdm(vdm_data);
         self.type_c_sender.send(event).await;
-        Ok(event)
+        Ok(Some(event))
     }
 
     /// Process a DisplayPort status update by retrieving the current DP status from the `controller` for the appropriate `port`.

--- a/type-c-service/src/service/config.rs
+++ b/type-c-service/src/service/config.rs
@@ -11,6 +11,7 @@ use embedded_usb_pd::ucsi::{self, lpm::get_connector_status::BatteryChargingCapa
 /// The [`Default`][`Self::default`] implementation creates a configuration where the status of all power levels is
 /// considered [`Nominal`][BatteryChargingCapabilityStatus::Nominal].
 #[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
 pub struct UcsiBatteryChargingThresholdConfig {
     /// Power threshold (in milliwatts) to be considered not charging.
     ///


### PR DESCRIPTION
Mark various config and event types as `non_exhaustive` to help provide better backward compatibility.