### PR TITLE
Add relayable service event plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,7 @@ name = "uart-service"
 version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
+ "embassy-futures",
  "embassy-sync",
  "embedded-io-async 0.7.0",
  "embedded-services",

--- a/battery-service-relay/src/lib.rs
+++ b/battery-service-relay/src/lib.rs
@@ -23,6 +23,9 @@ impl<S: battery_service_interface::BatteryService> embedded_services::relay::mct
 {
     type RequestType = serialization::AcpiBatteryRequest;
     type ResultType = serialization::AcpiBatteryResult;
+
+    // Temporary until figure out what events want to send
+    type EventType = ();
 }
 
 impl<S: battery_service_interface::BatteryService> embedded_services::relay::mctp::RelayServiceHandler

--- a/debug-service/src/debug_service.rs
+++ b/debug-service/src/debug_service.rs
@@ -37,6 +37,9 @@ impl Service {
 impl embedded_services::relay::mctp::RelayServiceHandlerTypes for Service {
     type RequestType = DebugRequest;
     type ResultType = DebugResult;
+
+    // Temporary until figure out what events want to send
+    type EventType = ();
 }
 
 impl embedded_services::relay::mctp::RelayServiceHandler for Service {

--- a/embedded-service/src/event.rs
+++ b/embedded-service/src/event.rs
@@ -291,7 +291,7 @@ impl<E> Receiver<E> for NeverReceiver<E> {
     }
 }
 
-/// Combines multiple receivers into one by racing them and returning
+/// Combines multiple receivers into one by racing them (with left-bias) and returning
 /// the first event that becomes available mapped to a common event type.
 pub struct MuxReceiver<E, L: Receiver<E>, R: Receiver<E>> {
     left: L,

--- a/embedded-service/src/event.rs
+++ b/embedded-service/src/event.rs
@@ -191,3 +191,157 @@ impl<I, O, S: Sender<O>, F: FnMut(I) -> O> Sender<I> for MapSender<I, O, S, F> {
         self.sender.send((self.map_fn)(event))
     }
 }
+
+/// Applies a function on events received from the wrapped receiver.
+pub struct MapReceiver<I, O, R: Receiver<I>, F: FnMut(I) -> O> {
+    receiver: R,
+    map_fn: F,
+    _phantom: PhantomData<(I, O)>,
+}
+
+impl<I, O, R: Receiver<I>, F: FnMut(I) -> O> MapReceiver<I, O, R, F> {
+    /// Create a new MapReceiver.
+    pub fn new(receiver: R, map_fn: F) -> Self {
+        Self {
+            receiver,
+            map_fn,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, O, R: Receiver<I>, F: FnMut(I) -> O> Receiver<O> for MapReceiver<I, O, R, F> {
+    fn try_next(&mut self) -> Option<O> {
+        self.receiver.try_next().map(&mut self.map_fn)
+    }
+
+    async fn wait_next(&mut self) -> O {
+        (self.map_fn)(self.receiver.wait_next().await)
+    }
+}
+
+/// Filters events from the wrapped receiver, only yielding events that pass the predicate.
+///
+/// Events that do not pass the filter are consumed and discarded.
+pub struct FilterReceiver<E, R: Receiver<E>, F: FnMut(&E) -> bool> {
+    receiver: R,
+    filter_fn: F,
+    _phantom: PhantomData<E>,
+}
+
+impl<E, R: Receiver<E>, F: FnMut(&E) -> bool> FilterReceiver<E, R, F> {
+    /// Create a new FilterReceiver.
+    pub fn new(receiver: R, filter_fn: F) -> Self {
+        Self {
+            receiver,
+            filter_fn,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E, R: Receiver<E>, F: FnMut(&E) -> bool> Receiver<E> for FilterReceiver<E, R, F> {
+    fn try_next(&mut self) -> Option<E> {
+        loop {
+            match self.receiver.try_next() {
+                Some(e) if (self.filter_fn)(&e) => return Some(e),
+                Some(_) => continue,
+                None => return None,
+            }
+        }
+    }
+
+    async fn wait_next(&mut self) -> E {
+        loop {
+            let e = self.receiver.wait_next().await;
+            if (self.filter_fn)(&e) {
+                return e;
+            }
+        }
+    }
+}
+
+/// A receiver that never produces events.
+///
+/// This is mainly used to make it easier to construct a `MuxReceiver`
+/// via macro since we don't need to handle the special start case
+/// when chaining `with` calls.
+pub struct NeverReceiver<E>(PhantomData<E>);
+
+impl<E> NeverReceiver<E> {
+    /// Create a new NeverReceiver.
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<E> Default for NeverReceiver<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> Receiver<E> for NeverReceiver<E> {
+    fn try_next(&mut self) -> Option<E> {
+        None
+    }
+
+    async fn wait_next(&mut self) -> E {
+        core::future::pending().await
+    }
+}
+
+/// Combines multiple receivers into one by racing them and returning
+/// the first event that becomes available mapped to a common event type.
+pub struct MuxReceiver<E, L: Receiver<E>, R: Receiver<E>> {
+    left: L,
+    right: R,
+    _phantom: PhantomData<E>,
+}
+
+impl<E> MuxReceiver<E, NeverReceiver<E>, NeverReceiver<E>> {
+    /// Create an empty MuxReceiver.
+    ///
+    /// Use `.with()` to add receivers.
+    pub fn new() -> Self {
+        Self {
+            left: NeverReceiver::new(),
+            right: NeverReceiver::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E> Default for MuxReceiver<E, NeverReceiver<E>, NeverReceiver<E>> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E, L: Receiver<E>, R1: Receiver<E>> MuxReceiver<E, L, R1> {
+    /// Add another receiver to multiplex with this one.
+    pub fn with<I, R2: Receiver<I>, F: FnMut(I) -> E>(
+        self,
+        receiver: R2,
+        map_fn: F,
+    ) -> MuxReceiver<E, Self, MapReceiver<I, E, R2, F>> {
+        MuxReceiver {
+            left: self,
+            right: MapReceiver::new(receiver, map_fn),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E, L: Receiver<E>, R: Receiver<E>> Receiver<E> for MuxReceiver<E, L, R> {
+    fn try_next(&mut self) -> Option<E> {
+        self.left.try_next().or_else(|| self.right.try_next())
+    }
+
+    async fn wait_next(&mut self) -> E {
+        match embassy_futures::select::select(self.left.wait_next(), self.right.wait_next()).await {
+            embassy_futures::select::Either::First(e) => e,
+            embassy_futures::select::Either::Second(e) => e,
+        }
+    }
+}

--- a/embedded-service/src/event.rs
+++ b/embedded-service/src/event.rs
@@ -32,6 +32,11 @@ pub trait Receiver<E> {
     /// Return none if there are no pending events
     fn try_next(&mut self) -> Option<E>;
     /// Receive an event
+    ///
+    /// # Cancel Safety
+    ///
+    /// The implementation MUST be cancel-safe as the `wait_next` method
+    /// is typically called inside a `select!` and thus may be cancelled.
     fn wait_next(&mut self) -> impl Future<Output = E>;
 }
 

--- a/embedded-service/src/relay/mod.rs
+++ b/embedded-service/src/relay/mod.rs
@@ -116,6 +116,9 @@ pub mod mctp {
 
         /// The result type that this service handler processes
         type ResultType: super::SerializableResult;
+
+        /// The event type that this service emits.
+        type EventType;
     }
 
     /// Trait for a service that can be relayed over an external bus (e.g. battery service, thermal service, time-alarm service)
@@ -448,6 +451,14 @@ pub mod mctp {
                     }
 
 
+                    /// A common event type wrapper for all relayable service events.
+                    #[derive(Debug)]
+                    pub enum ServiceEvent {
+                        $(
+                            $service_name(<$service_handler_type as $crate::relay::mctp::RelayServiceHandlerTypes>::EventType),
+                        )+
+                    }
+
                     pub struct $relay_type_name {
                         $(
                             [<$service_name:snake _handler>]: $service_handler_type,
@@ -465,6 +476,33 @@ pub mod mctp {
                                     [<$service_name:snake _handler>],
                                 )+
                             }
+                        }
+
+                        /// Build an event multiplexer from the provided relayable services.
+                        ///
+                        /// This is generic over the receiver type used for each service, so callers
+                        /// can decide at the call site which concrete `Receiver<EventType>` impl to
+                        /// supply for each relayed service (e.g. `NeverReceiver`, an embassy channel
+                        /// `Receiver`, a `DynamicReceiver`, or a custom impl).
+                        ///
+                        /// The caller will then need to further filter this event mux to whatever
+                        /// events they consider worth notifying the host about.
+                        ///
+                        /// Lastly, the caller will then need to map the events into a format the
+                        /// relay service understands (e.g. a single u8 for uart-service).
+                        pub fn event_mux<
+                            $(
+                                [<$service_name Rx>]: $crate::event::Receiver<
+                                    <$service_handler_type as $crate::relay::mctp::RelayServiceHandlerTypes>::EventType
+                                >,
+                            )+
+                        >(
+                            $(
+                                [<$service_name:snake _event_rx>]: [<$service_name Rx>],
+                            )+
+                        ) -> impl $crate::event::Receiver<ServiceEvent> {
+                            $crate::event::MuxReceiver::new()
+                                $(.with([<$service_name:snake _event_rx>], ServiceEvent::$service_name))+
                         }
                     }
 
@@ -494,6 +532,7 @@ pub mod mctp {
 
                 // Allows this generated relay type to be publicly re-exported
                 pub use [< _odp_impl_ $relay_type_name:snake >]::$relay_type_name;
+                pub use [< _odp_impl_ $relay_type_name:snake >]::ServiceEvent;
 
             } // end paste!
         }; // end macro arm

--- a/embedded-service/src/relay/mod.rs
+++ b/embedded-service/src/relay/mod.rs
@@ -172,6 +172,11 @@ pub mod mctp {
             &'a self,
             message: Self::RequestEnumType,
         ) -> impl core::future::Future<Output = Self::ResultEnumType> + 'a;
+
+        /// Returns a mutable reference to the multiplexed receiver of all relayable service events.
+        ///
+        /// Each service's events are mapped to the service's u8 ID.
+        fn receiver(&mut self) -> &mut impl crate::event::Receiver<u8>;
     }
 
     /// This macro generates a relay type over a collection of message types, which can be used by a relay service to
@@ -451,46 +456,17 @@ pub mod mctp {
                     }
 
 
-                    /// A common event type wrapper for all relayable service events.
-                    #[derive(Debug)]
-                    pub enum ServiceEvent {
-                        $(
-                            $service_name(<$service_handler_type as $crate::relay::mctp::RelayServiceHandlerTypes>::EventType),
-                        )+
-                    }
-
-                    pub struct $relay_type_name {
+                    pub struct $relay_type_name<T: $crate::event::Receiver<u8>> {
                         $(
                             [<$service_name:snake _handler>]: $service_handler_type,
                         )+
+                        receiver: T,
                     }
 
-                    impl $relay_type_name {
-                        pub fn new(
-                            $(
-                                [<$service_name:snake _handler>]: $service_handler_type,
-                            )+
-                        ) -> Self {
-                            Self {
-                                $(
-                                    [<$service_name:snake _handler>],
-                                )+
-                            }
-                        }
-
-                        /// Build an event multiplexer from the provided relayable services.
-                        ///
-                        /// This is generic over the receiver type used for each service, so callers
-                        /// can decide at the call site which concrete `Receiver<EventType>` impl to
-                        /// supply for each relayed service (e.g. `NeverReceiver`, an embassy channel
-                        /// `Receiver`, a `DynamicReceiver`, or a custom impl).
-                        ///
-                        /// The caller will then need to further filter this event mux to whatever
-                        /// events they consider worth notifying the host about.
-                        ///
-                        /// Lastly, the caller will then need to map the events into a format the
-                        /// relay service understands (e.g. a single u8 for uart-service).
-                        pub fn event_mux<
+                    // Note: Need a concrete type here to satisfy the type system,
+                    // so we just use `NeverReceiver` as a placeholder
+                    impl $relay_type_name<$crate::event::NeverReceiver<u8>> {
+                        pub fn new<
                             $(
                                 [<$service_name Rx>]: $crate::event::Receiver<
                                     <$service_handler_type as $crate::relay::mctp::RelayServiceHandlerTypes>::EventType
@@ -498,15 +474,24 @@ pub mod mctp {
                             )+
                         >(
                             $(
+                                [<$service_name:snake _handler>]: $service_handler_type,
+                            )+
+                            $(
                                 [<$service_name:snake _event_rx>]: [<$service_name Rx>],
                             )+
-                        ) -> impl $crate::event::Receiver<ServiceEvent> {
-                            $crate::event::MuxReceiver::new()
-                                $(.with([<$service_name:snake _event_rx>], ServiceEvent::$service_name))+
+                        ) -> $relay_type_name<impl $crate::event::Receiver<u8>> {
+                            let receiver = $crate::event::MuxReceiver::new()
+                                $(.with([<$service_name:snake _event_rx>], |_| $service_id as u8))+;
+                            $relay_type_name {
+                                $(
+                                    [<$service_name:snake _handler>],
+                                )+
+                                receiver,
+                            }
                         }
                     }
 
-                    impl $crate::relay::mctp::RelayHandler for $relay_type_name {
+                    impl<T: $crate::event::Receiver<u8>> $crate::relay::mctp::RelayHandler for $relay_type_name<T> {
                         type ServiceIdType = OdpService;
                         type HeaderType = OdpHeader;
                         type RequestEnumType = HostRequest;
@@ -527,12 +512,15 @@ pub mod mctp {
                                 }
                             }
                         }
+
+                        fn receiver(&mut self) -> &mut impl $crate::event::Receiver<u8> {
+                            &mut self.receiver
+                        }
                     }
                 } // end mod __odp_impl
 
                 // Allows this generated relay type to be publicly re-exported
                 pub use [< _odp_impl_ $relay_type_name:snake >]::$relay_type_name;
-                pub use [< _odp_impl_ $relay_type_name:snake >]::ServiceEvent;
 
             } // end paste!
         }; // end macro arm

--- a/examples/rt685s-evk/src/bin/time_alarm.rs
+++ b/examples/rt685s-evk/src/bin/time_alarm.rs
@@ -51,7 +51,10 @@ async fn main(spawner: embassy_executor::Spawner) {
         TimeAlarm, 0x0B, crate::TimeAlarmServiceRelayHandlerType;
     );
 
-    let _relay_handler = EspiRelayHandler::new(TimeAlarmServiceRelayHandlerType::new(time_service));
+    let _relay_handler = EspiRelayHandler::new(
+        TimeAlarmServiceRelayHandlerType::new(time_service),
+        embedded_services::event::NeverReceiver::new(),
+    );
 
     // Here, you'd normally pass _relay_handler to your relay service (e.g. eSPI service).
     // In this example, we're not leveraging a relay service, so we'll just demonstrate some direct calls.

--- a/thermal-service-interface/src/lib.rs
+++ b/thermal-service-interface/src/lib.rs
@@ -3,6 +3,17 @@
 pub mod fan;
 pub mod sensor;
 
+/// Thermal service event.
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Event {
+    /// A sensor event occurred.
+    Sensor(u8, sensor::Event),
+    /// A fan event occurred.
+    Fan(u8, fan::Event),
+}
+
 /// Thermal service interface trait.
 pub trait ThermalService {
     /// Associated type for registered sensor services.

--- a/thermal-service-relay/src/lib.rs
+++ b/thermal-service-relay/src/lib.rs
@@ -3,6 +3,7 @@
 mod serialization;
 
 pub use serialization::{ThermalError, ThermalRequest, ThermalResponse, ThermalResult};
+use thermal_service_interface::Event as ThermalEvent;
 use thermal_service_interface::ThermalService;
 use thermal_service_interface::fan::{self, FanService};
 use thermal_service_interface::sensor::{self, SensorService};
@@ -194,6 +195,7 @@ impl<T: ThermalService> ThermalServiceRelayHandler<T> {
 impl<T: ThermalService> embedded_services::relay::mctp::RelayServiceHandlerTypes for ThermalServiceRelayHandler<T> {
     type RequestType = ThermalRequest;
     type ResultType = ThermalResult;
+    type EventType = ThermalEvent;
 }
 
 impl<T: ThermalService> embedded_services::relay::mctp::RelayServiceHandler for ThermalServiceRelayHandler<T> {

--- a/time-alarm-service-relay/src/lib.rs
+++ b/time-alarm-service-relay/src/lib.rs
@@ -20,6 +20,9 @@ impl<T: TimeAlarmService> TimeAlarmServiceRelayHandler<T> {
 impl<T: TimeAlarmService> embedded_services::relay::mctp::RelayServiceHandlerTypes for TimeAlarmServiceRelayHandler<T> {
     type RequestType = AcpiTimeAlarmRequest;
     type ResultType = AcpiTimeAlarmResult;
+
+    // Temporary until figure out what events want to send
+    type EventType = ();
 }
 
 impl<T: TimeAlarmService> embedded_services::relay::mctp::RelayServiceHandler for TimeAlarmServiceRelayHandler<T> {

--- a/uart-service/Cargo.toml
+++ b/uart-service/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 embedded-services.workspace = true
 defmt = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
+embassy-futures.workspace = true
 embassy-sync.workspace = true
 mctp-rs = { workspace = true }
 embedded-io-async.workspace = true

--- a/uart-service/src/lib.rs
+++ b/uart-service/src/lib.rs
@@ -81,8 +81,12 @@ pub enum Error<M: MctpMedium> {
 ///
 /// [`MctpPacketContext`]: mctp_rs::MctpPacketContext
 pub struct Service<R: RelayHandler, M: MctpMedium + Copy> {
+    pub(crate) inner: ServiceInner<R, M>,
+    pub(crate) relay_handler: R,
+}
+
+pub(crate) struct ServiceInner<R: RelayHandler, M: MctpMedium + Copy> {
     host_tx_queue: Channel<GlobalRawMutex, HostResultMessage<R>, HOST_TX_QUEUE_SIZE>,
-    relay_handler: R,
     medium: M,
     reply_context: mctp_rs::MctpReplyContext<M>,
 }
@@ -90,13 +94,46 @@ pub struct Service<R: RelayHandler, M: MctpMedium + Copy> {
 impl<R: RelayHandler, M: MctpMedium + Copy> Service<R, M> {
     pub fn new(relay_handler: R, medium: M, reply_context: mctp_rs::MctpReplyContext<M>) -> Result<Self, Error<M>> {
         Ok(Self {
-            host_tx_queue: Channel::new(),
+            inner: ServiceInner {
+                host_tx_queue: Channel::new(),
+                medium,
+                reply_context,
+            },
             relay_handler,
-            medium,
-            reply_context,
         })
     }
 
+    // Deserialize the request and forward it to correct service for processing
+    async fn process_request(&self, state: &ReadState, packet_len: usize) -> Result<(), Error<M>> {
+        let mut assembly_buf = [0u8; BUF_SIZE];
+        let mut mctp_ctx = mctp_rs::MctpPacketContext::<M>::new(self.inner.medium, &mut assembly_buf);
+
+        let message = mctp_ctx
+            .deserialize_packet(
+                state
+                    .buf
+                    .get(..packet_len)
+                    .ok_or(Error::Serialize("frame exceeds BUF_SIZE"))?,
+            )
+            .map_err(Error::Mctp)?
+            .ok_or(Error::Serialize("Partial message not supported"))?;
+
+        let (header, body) = message.parse_as::<R::RequestEnumType>().map_err(Error::Mctp)?;
+        trace!("Received host request");
+
+        let response = self.relay_handler.process_request(body).await;
+        self.inner.host_tx_queue
+            .try_send(HostResultMessage {
+                handler_service_id: header.get_service_id(),
+                message: response,
+            })
+            .map_err(|_| Error::Comms)?;
+
+        Ok(())
+    }
+}
+
+impl<R: RelayHandler, M: MctpMedium + Copy> ServiceInner<R, M> {
     async fn process_response<T: UartWrite>(
         &self,
         uart: &mut T,
@@ -123,6 +160,10 @@ impl<R: RelayHandler, M: MctpMedium + Copy> Service<R, M> {
         }
 
         Ok(())
+    }
+
+    async fn wait_for_response(&self) -> HostResultMessage<R> {
+        self.host_tx_queue.receive().await
     }
 
     // Read bytes from UART until a complete request is assembled.
@@ -159,39 +200,6 @@ impl<R: RelayHandler, M: MctpMedium + Copy> Service<R, M> {
                 None => continue,
             }
         }
-    }
-
-    // Deserialize the request and forward it to correct service for processing
-    async fn process_request(&self, state: &ReadState, packet_len: usize) -> Result<(), Error<M>> {
-        let mut assembly_buf = [0u8; BUF_SIZE];
-        let mut mctp_ctx = mctp_rs::MctpPacketContext::<M>::new(self.medium, &mut assembly_buf);
-
-        let message = mctp_ctx
-            .deserialize_packet(
-                state
-                    .buf
-                    .get(..packet_len)
-                    .ok_or(Error::Serialize("frame exceeds BUF_SIZE"))?,
-            )
-            .map_err(Error::Mctp)?
-            .ok_or(Error::Serialize("Partial message not supported"))?;
-
-        let (header, body) = message.parse_as::<R::RequestEnumType>().map_err(Error::Mctp)?;
-        trace!("Received host request");
-
-        let response = self.relay_handler.process_request(body).await;
-        self.host_tx_queue
-            .try_send(HostResultMessage {
-                handler_service_id: header.get_service_id(),
-                message: response,
-            })
-            .map_err(|_| Error::Comms)?;
-
-        Ok(())
-    }
-
-    async fn wait_for_response(&self) -> HostResultMessage<R> {
-        self.host_tx_queue.receive().await
     }
 }
 

--- a/uart-service/src/lib.rs
+++ b/uart-service/src/lib.rs
@@ -4,9 +4,6 @@
 //! Use [`DefaultService`] for the SmbusEspi-medium baseline; use
 //! [`Service::new`] directly with another medium (e.g. DSP0253 serial)
 //! for non-SmbusEspi callers.
-//!
-//! Revisit: Will also need to consider how to handle notifications (likely need to have user
-//! provide GPIO pin we can use).
 #![no_std]
 
 pub mod task;
@@ -23,6 +20,27 @@ use mctp_rs::smbus_espi::{SmbusEspiMedium, SmbusEspiReplyContext};
 // Should be as large as the largest possible MCTP packet and its metadata.
 const BUF_SIZE: usize = 256;
 const HOST_TX_QUEUE_SIZE: usize = 5;
+
+// Persistent state for UART request reading
+//
+// Necessary to make sure the request reading process is cancel-safe
+struct ReadState {
+    buf: [u8; BUF_SIZE],
+    filled: usize,
+}
+
+impl ReadState {
+    fn new() -> Self {
+        Self {
+            buf: [0u8; BUF_SIZE],
+            filled: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.filled = 0;
+    }
+}
 
 #[derive(Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -107,13 +125,18 @@ impl<R: RelayHandler, M: MctpMedium + Copy> Service<R, M> {
         Ok(())
     }
 
-    async fn wait_for_request<T: UartRead>(&self, uart: &mut T) -> Result<(), Error<M>> {
-        // Incremental read loop: read bytes, ask the medium whether the
-        // assembled prefix is a complete frame, repeat until it is.
-        let mut buf = [0u8; BUF_SIZE];
-        let mut filled = 0usize;
-        let packet_len = loop {
-            let dst = buf.get_mut(filled..).ok_or(Error::Serialize("buffer overrun"))?;
+    // Read bytes from UART until a complete request is assembled.
+    //
+    // # Cancel Safety
+    //
+    // This method is cancel-safe because partial read progress is stored in `state`
+    // and will be resumed on the next call.
+    async fn wait_for_request<T: UartRead>(&self, uart: &mut T, state: &mut ReadState) -> Result<usize, Error<M>> {
+        loop {
+            let dst = state
+                .buf
+                .get_mut(state.filled..)
+                .ok_or(Error::Serialize("buffer overrun"))?;
             if dst.is_empty() {
                 return Err(Error::Serialize("frame exceeds BUF_SIZE"));
             }
@@ -121,23 +144,33 @@ impl<R: RelayHandler, M: MctpMedium + Copy> Service<R, M> {
             if n == 0 {
                 return Err(Error::Comms);
             }
-            filled += n;
+            state.filled += n;
             match self
                 .medium
-                .frame_complete(buf.get(..filled).ok_or(Error::Serialize("buffer overrun"))?)
+                .frame_complete(
+                    state
+                        .buf
+                        .get(..state.filled)
+                        .ok_or(Error::Serialize("buffer overrun"))?,
+                )
                 .map_err(Error::Mctp)?
             {
-                Some(len) => break len,
+                Some(len) => return Ok(len),
                 None => continue,
             }
-        };
+        }
+    }
 
+    // Deserialize the request and forward it to correct service for processing
+    async fn process_request(&self, state: &ReadState, packet_len: usize) -> Result<(), Error<M>> {
         let mut assembly_buf = [0u8; BUF_SIZE];
         let mut mctp_ctx = mctp_rs::MctpPacketContext::<M>::new(self.medium, &mut assembly_buf);
 
         let message = mctp_ctx
             .deserialize_packet(
-                buf.get(..packet_len)
+                state
+                    .buf
+                    .get(..packet_len)
                     .ok_or(Error::Serialize("frame exceeds BUF_SIZE"))?,
             )
             .map_err(Error::Mctp)?

--- a/uart-service/src/lib.rs
+++ b/uart-service/src/lib.rs
@@ -122,7 +122,8 @@ impl<R: RelayHandler, M: MctpMedium + Copy> Service<R, M> {
         trace!("Received host request");
 
         let response = self.relay_handler.process_request(body).await;
-        self.inner.host_tx_queue
+        self.inner
+            .host_tx_queue
             .try_send(HostResultMessage {
                 handler_service_id: header.get_service_id(),
                 message: response,

--- a/uart-service/src/lib.rs
+++ b/uart-service/src/lib.rs
@@ -171,8 +171,8 @@ impl<R: RelayHandler, M: MctpMedium + Copy> ServiceInner<R, M> {
     //
     // # Cancel Safety
     //
-    // This method is cancel-safe because partial read progress is stored in `state`
-    // and will be resumed on the next call.
+    // This method is cancel-safe (assuming the embedded-io-async `read` implementation is cancel-safe)
+    // because partial read progress is stored in `state` and will be resumed on the next call.
     async fn wait_for_request<T: UartRead>(&self, uart: &mut T, state: &mut ReadState) -> Result<usize, Error<M>> {
         loop {
             let dst = state

--- a/uart-service/src/task.rs
+++ b/uart-service/src/task.rs
@@ -7,6 +7,11 @@ use embedded_services::relay::mctp::RelayHandler;
 use embedded_services::{error, warn};
 use mctp_rs::MctpMedium;
 
+/// Start the UART service task.
+///
+/// # Requirements
+///
+/// The `embedded-io-async` `Read` implementation used for the uart **MUST** be cancel-safe.
 pub async fn uart_service<R: RelayHandler, M: MctpMedium + Copy, T: UartRead + UartWrite>(
     mut service: Service<R, M>,
     mut uart: T,

--- a/uart-service/src/task.rs
+++ b/uart-service/src/task.rs
@@ -2,30 +2,30 @@ use crate::{Error, ReadState, Service};
 use embassy_futures::select::{Either, select};
 use embedded_io_async::Read as UartRead;
 use embedded_io_async::Write as UartWrite;
+use embedded_services::event::Receiver;
 use embedded_services::relay::mctp::RelayHandler;
 use embedded_services::{error, warn};
 use mctp_rs::MctpMedium;
 
 pub async fn uart_service<R: RelayHandler, M: MctpMedium + Copy, T: UartRead + UartWrite>(
-    uart_service: &Service<R, M>,
+    mut service: Service<R, M>,
     mut uart: T,
-    mut notifiable_events: impl embedded_services::event::Receiver<u8>,
 ) -> Result<embedded_services::Never, Error<M>> {
     let mut read_state = ReadState::new();
 
     loop {
         match select(
-            uart_service.wait_for_request(&mut uart, &mut read_state),
-            notifiable_events.wait_next(),
+            service.inner.wait_for_request(&mut uart, &mut read_state),
+            service.relay_handler.receiver().wait_next(),
         )
         .await
         {
             Either::First(Ok(packet_len)) => {
-                if let Err(e) = uart_service.process_request(&read_state, packet_len).await {
+                if let Err(e) = service.process_request(&read_state, packet_len).await {
                     log_error("request", &e);
                 } else {
-                    let host_msg = uart_service.wait_for_response().await;
-                    if let Err(e) = uart_service.process_response(&mut uart, host_msg).await {
+                    let host_msg = service.inner.wait_for_response().await;
+                    if let Err(e) = service.inner.process_response(&mut uart, host_msg).await {
                         log_error("response", &e);
                     }
                 }

--- a/uart-service/src/task.rs
+++ b/uart-service/src/task.rs
@@ -1,26 +1,59 @@
-use crate::{Error, Service};
+use crate::{Error, ReadState, Service};
+use embassy_futures::select::{Either, select};
 use embedded_io_async::Read as UartRead;
 use embedded_io_async::Write as UartWrite;
-use embedded_services::error;
 use embedded_services::relay::mctp::RelayHandler;
+use embedded_services::{error, warn};
 use mctp_rs::MctpMedium;
 
 pub async fn uart_service<R: RelayHandler, M: MctpMedium + Copy, T: UartRead + UartWrite>(
     uart_service: &Service<R, M>,
     mut uart: T,
+    mut notifiable_events: impl embedded_services::event::Receiver<u8>,
 ) -> Result<embedded_services::Never, Error<M>> {
-    // Note: eSPI service uses `select!` to seemingly allow asyncrhonous `responses` from services,
-    // but there are concerns around async cancellation here at least for UART service.
-    //
-    // Thus this assumes services will only send messages in response to requests from the host,
-    // so we handle this in order.
+    let mut read_state = ReadState::new();
+
     loop {
-        if let Err(e) = uart_service.wait_for_request(&mut uart).await {
-            log_error("request", &e);
-        } else {
-            let host_msg = uart_service.wait_for_response().await;
-            if let Err(e) = uart_service.process_response(&mut uart, host_msg).await {
-                log_error("response", &e);
+        match select(
+            uart_service.wait_for_request(&mut uart, &mut read_state),
+            notifiable_events.wait_next(),
+        )
+        .await
+        {
+            Either::First(Ok(packet_len)) => {
+                if let Err(e) = uart_service.process_request(&read_state, packet_len).await {
+                    log_error("request", &e);
+                } else {
+                    let host_msg = uart_service.wait_for_response().await;
+                    if let Err(e) = uart_service.process_response(&mut uart, host_msg).await {
+                        log_error("response", &e);
+                    }
+                }
+                read_state.reset();
+            }
+            Either::First(Err(e)) => {
+                log_error("request", &e);
+                read_state.reset();
+            }
+            Either::Second(event) => {
+                warn!(
+                    "uart-service received notifiable event ({}) from relayable service",
+                    event
+                );
+
+                // TODO: Here we would do something like:
+                //
+                // if let Err(_e) = uart.write_all(&[0x42, event]).await {
+                //     error!("uart-service failed to send notification");
+                // } else {
+                //     warn!("uart-service sent notification for event {}", event);
+                // }
+                //
+                // Where we TX some starter byte(s) to tell host its about to receive a notification,
+                // then the notification ID itself.
+                //
+                // This is TODO until the whole stack is ready to receive notifications
+                // otherwise TXing here could break things.
             }
         }
     }

--- a/uart-service/src/task.rs
+++ b/uart-service/src/task.rs
@@ -49,7 +49,7 @@ pub async fn uart_service<R: RelayHandler, M: MctpMedium + Copy, T: UartRead + U
                 //     warn!("uart-service sent notification for event {}", event);
                 // }
                 //
-                // Where we TX some starter byte(s) to tell host its about to receive a notification,
+                // Where we TX some starter byte(s) to tell host it's about to receive a notification,
                 // then the notification ID itself.
                 //
                 // This is TODO until the whole stack is ready to receive notifications


### PR DESCRIPTION
As discussed, a grand unified notification handling system is not really feasible, so this PR does a few things.

First, it adds some plumbing though that should make it easier for all relay services to handle notifications to host:
- Introduces several new generic Receiver types: A MapReceiver which is self-explanatory and a MuxReceiver which allows an arbitrary number of heterogeneous Receiver types to be combined into a single Receiver. The relay handler macro for MCTP relay services uses these to construct a mapped and muxed receiver of all relayable service events which relay service tasks can make use of. Also added a FilterReceiver for reasons I'll discuss in next paragraph.
- Adds associated types to service relay traits for specifying the event that relayable service emits (added a ThermalEvent which just wraps Sensor and Fan events, and left the other services unit type for now until we know what they want to emit).

Second, updated the uart service to turn events into notifications. I had to make the `wait_for_request` method cancel-safe, so split it up and added an external struct for storing read state in case it is cancelled. This now allows us to select over requests from the host and events from the services.

The uart service now takes a "notifiable event" receiver. This is the part I'm not entirely happy with and can't think of a very clean approach. The problem is a relay service like the uart service doesn't know what services ahead of time will be declared relayable by the relay macro, and additionally it doesn't know which events the caller wants to consider notifiable.

And the way the MCTP uart service might choose to handle notifications over the wire is different from say HID I3C. So, I added an additional FilterReceiver type with the idea that the caller first needs to take the MUXed receiver produced by the macro, filter it for events they consider notifiable on their platform, then finally map them to a single u8 which the uart service will TX to the host (with the assumption that the caller ensures host agrees on what these u8s mean). Right now that part is TODO because we have to get the plumbing all the way through otherwise this can cause issues.

The reason I'm not too happy with this is because the caller has to handle creating a channel for each relayable service, ensuring the receiver passed to the `event_mux` function belongs to the same channel that the sender which was passed to the service belongs to, and then they have to set up the filter+map of events to something the relay service understands. But again, a clean solution to this is not coming to me that still allows flexibility for all kinds of relay serivces... You can see an example of how it's setup in this branch on odp-ec: https://github.com/kurtjd/odp-embedded-controller/blob/baa55f1bc6af1839f27e092d9602e27dbd8a1aa3/platform/dev-qemu/src/main.rs#L37

Resolves #733 

Assisted-by: GitHub Copilot:claude-opus-4.6