### PR TITLE
Update embedded-mcu-hal to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
  "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
  "embedded-io-async 0.7.0",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.2.0",
  "embedded-storage",
  "fixed",
  "itertools 0.11.0",
@@ -723,6 +723,9 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+dependencies = [
+ "defmt 0.3.100",
+]
 
 [[package]]
 name = "embedded-hal-async"
@@ -730,6 +733,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "defmt 0.3.100",
  "embedded-hal 1.0.0",
 ]
 
@@ -784,6 +788,19 @@ checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt 1.1.0",
  "num_enum",
+]
+
+[[package]]
+name = "embedded-mcu-hal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0563f27b8ea59eb57e2c5926db6ee311d0a24ab9912adf82b9f418cc9799b0ff"
+dependencies = [
+ "defmt 1.1.0",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "num_enum",
+ "smbus-pec",
 ]
 
 [[package]]
@@ -1978,7 +1995,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.3.0",
  "embedded-services",
  "log",
  "odp-service-common",
@@ -1994,7 +2011,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield 0.17.0",
  "defmt 0.3.100",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.3.0",
  "log",
  "num_enum",
  "zerocopy",
@@ -2005,7 +2022,7 @@ name = "time-alarm-service-relay"
 version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.3.0",
  "embedded-services",
  "log",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#6524cbabcc12016f1aea4c0ffa2f1354c3f8c6d1"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#8b9a6f0e11d9b65f1616a9e487af2cf04aef3584"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -581,7 +581,7 @@ dependencies = [
  "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
  "embedded-io-async 0.7.0",
- "embedded-mcu-hal 0.2.0",
+ "embedded-mcu-hal",
  "embedded-storage",
  "fixed",
  "itertools 0.11.0",
@@ -778,16 +778,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
 dependencies = [
  "embedded-io 0.7.1",
-]
-
-[[package]]
-name = "embedded-mcu-hal"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
-dependencies = [
- "defmt 1.1.0",
- "num_enum",
 ]
 
 [[package]]
@@ -1995,7 +1985,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
- "embedded-mcu-hal 0.3.0",
+ "embedded-mcu-hal",
  "embedded-services",
  "log",
  "odp-service-common",
@@ -2011,7 +2001,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield 0.17.0",
  "defmt 0.3.100",
- "embedded-mcu-hal 0.3.0",
+ "embedded-mcu-hal",
  "log",
  "num_enum",
  "zerocopy",
@@ -2022,7 +2012,7 @@ name = "time-alarm-service-relay"
 version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
- "embedded-mcu-hal 0.3.0",
+ "embedded-mcu-hal",
  "embedded-services",
  "log",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ embassy-executor = "0.10.0"
 cfu-service = { path = "./cfu-service" }
 embedded-hal-nb = "1.0"
 embedded-io-async = "0.7.0"
-embedded-mcu-hal = "0.2.0"
+embedded-mcu-hal = "0.3.0"
 embassy-futures = "0.1.2"
 embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt"}
 embassy-sync = "0.8"

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities#ff4829bd16c6d9da609c59c98783b474ab9e3d23"
 dependencies = [
  "num-traits",
 ]
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "embassy-imxrt"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#6524cbabcc12016f1aea4c0ffa2f1354c3f8c6d1"
+source = "git+https://github.com/OpenDevicePartnership/embassy-imxrt#8b9a6f0e11d9b65f1616a9e487af2cf04aef3584"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -471,7 +471,7 @@ dependencies = [
  "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
  "embedded-io-async 0.7.0",
- "embedded-mcu-hal 0.2.0",
+ "embedded-mcu-hal",
  "embedded-storage",
  "fixed",
  "itertools 0.11.0",
@@ -648,16 +648,6 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
-dependencies = [
- "defmt 1.1.0",
- "num_enum",
-]
-
-[[package]]
-name = "embedded-mcu-hal"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0563f27b8ea59eb57e2c5926db6ee311d0a24ab9912adf82b9f418cc9799b0ff"
@@ -715,7 +705,7 @@ dependencies = [
 [[package]]
 name = "espi-device"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#290aa80a4c281857f3bed94581200b330119286c"
+source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#fe63c1fc0bb2463922d956003caf8ac9d6224231"
 dependencies = [
  "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0)",
  "bitflags 2.11.1",
@@ -1215,7 +1205,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-cfu-protocol",
- "embedded-mcu-hal 0.2.0",
+ "embedded-mcu-hal",
  "embedded-services",
  "embedded-usb-pd",
  "mimxrt600-fcb 0.1.0",
@@ -1422,7 +1412,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
- "embedded-mcu-hal 0.3.0",
+ "embedded-mcu-hal",
  "embedded-services",
  "odp-service-common",
  "time-alarm-service-interface",
@@ -1435,7 +1425,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield 0.17.0",
  "defmt 0.3.100",
- "embedded-mcu-hal 0.3.0",
+ "embedded-mcu-hal",
  "num_enum",
  "zerocopy",
 ]
@@ -1445,7 +1435,7 @@ name = "time-alarm-service-relay"
 version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
- "embedded-mcu-hal 0.3.0",
+ "embedded-mcu-hal",
  "embedded-services",
  "num_enum",
  "time-alarm-service-interface",

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
  "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
  "embedded-io-async 0.7.0",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.2.0",
  "embedded-storage",
  "fixed",
  "itertools 0.11.0",
@@ -589,6 +589,9 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+dependencies = [
+ "defmt 0.3.100",
+]
 
 [[package]]
 name = "embedded-hal-async"
@@ -596,6 +599,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "defmt 0.3.100",
  "embedded-hal 1.0.0",
 ]
 
@@ -650,6 +654,19 @@ checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt 1.1.0",
  "num_enum",
+]
+
+[[package]]
+name = "embedded-mcu-hal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0563f27b8ea59eb57e2c5926db6ee311d0a24ab9912adf82b9f418cc9799b0ff"
+dependencies = [
+ "defmt 1.1.0",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "num_enum",
+ "smbus-pec",
 ]
 
 [[package]]
@@ -1198,7 +1215,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-cfu-protocol",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.2.0",
  "embedded-services",
  "embedded-usb-pd",
  "mimxrt600-fcb 0.1.0",
@@ -1405,7 +1422,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.3.0",
  "embedded-services",
  "odp-service-common",
  "time-alarm-service-interface",
@@ -1418,7 +1435,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield 0.17.0",
  "defmt 0.3.100",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.3.0",
  "num_enum",
  "zerocopy",
 ]
@@ -1428,7 +1445,7 @@ name = "time-alarm-service-relay"
 version = "0.1.0"
 dependencies = [
  "defmt 0.3.100",
- "embedded-mcu-hal",
+ "embedded-mcu-hal 0.3.0",
  "embedded-services",
  "num_enum",
  "time-alarm-service-interface",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -48,7 +48,7 @@ embassy-time = { version = "0.5.1", features = [
 ] }
 mimxrt600-fcb = "0.1.0"
 
-embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu"}
+embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu" }
 embedded-services = { path = "../../embedded-service", features = ["defmt"] }
 odp-service-common = { path = "../../odp-service-common" }
 power-button-service = { path = "../../power-button-service", features = [
@@ -83,7 +83,7 @@ platform-service = { path = "../../platform-service", features = [
     "defmt",
     "imxrt685",
 ] }
-embedded-mcu-hal = "0.2.0"
+embedded-mcu-hal = "0.3.0"
 
 cfu-service = { path = "../../cfu-service", features = ["defmt"] }
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -210,6 +210,12 @@ criteria = "safe-to-deploy"
 version = "0.2.7"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.OpenDevicePartnership.audits.embedded-mcu-hal]]
+who = "Felipe Balbi <febalbi@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-mcu/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.OpenDevicePartnership.audits.mimxrt600-fcb]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Bumps the workspace `embedded-mcu-hal` dependency from `0.2.0` to `0.3.0`.

The 0.3.0 release is API-compatible with the parts used in this workspace; `cargo check --workspace` and `cargo clippy --workspace --all-targets` both pass with no source changes required.

Assisted-by: GitHub Copilot:claude-opus-4.7