### PR TITLE
Add expected_response_size to GetReport command

### DIFF
--- a/embedded-service/src/hid/command.rs
+++ b/embedded-service/src/hid/command.rs
@@ -225,7 +225,7 @@ impl Opcode {
 #[allow(missing_docs)]
 pub enum Command<'a> {
     Reset,
-    GetReport(ReportType, ReportId),
+    GetReport(ReportType, ReportId, Option<u16>),
     SetReport(ReportType, ReportId, SharedRef<'a, u8>),
     GetIdle(ReportId),
     SetIdle(ReportId, ReportFreq),
@@ -239,7 +239,7 @@ impl From<Command<'_>> for Opcode {
     fn from(value: Command<'_>) -> Self {
         match value {
             Command::Reset => Opcode::Reset,
-            Command::GetReport(_, _) => Opcode::GetReport,
+            Command::GetReport(_, _, _) => Opcode::GetReport,
             Command::SetReport(_, _, _) => Opcode::SetReport,
             Command::GetIdle(_) => Opcode::GetIdle,
             Command::SetIdle(_, _) => Opcode::SetIdle,
@@ -293,6 +293,7 @@ impl<'a> Command<'a> {
         report_type: Option<ReportType>,
         report_id: Option<ReportId>,
         data: Option<SharedRef<'a, u8>>,
+        expected_response_size: Option<u16>,
     ) -> Result<Self, Error> {
         if opcode.requires_report_id() && report_id.is_none() {
             return Err(Error::RequiresReportId);
@@ -310,7 +311,11 @@ impl<'a> Command<'a> {
             Opcode::Reset => Command::Reset,
             Opcode::GetReport => {
                 if report_type? == ReportType::Input || report_type? == ReportType::Feature {
-                    Command::GetReport(report_type?, report_id.ok_or(Error::RequiresReportId)?)
+                    Command::GetReport(
+                        report_type?,
+                        report_id.ok_or(Error::RequiresReportId)?,
+                        expected_response_size,
+                    )
                 } else {
                     return Err(Error::InvalidReportType);
                 }
@@ -476,7 +481,7 @@ impl<'a> Command<'a> {
                 let (command_len, _) = Self::encode_basic_op(buf, Opcode::Reset)?;
                 len += command_len;
             }
-            Command::GetReport(report_type, report_id) => {
+            Command::GetReport(report_type, report_id, _expected_size) => {
                 let (command_len, buf) = Self::encode_common(buf, Opcode::GetReport, Some(*report_type), *report_id)?;
                 len += command_len;
 
@@ -594,35 +599,35 @@ mod test {
         let mut test_buffer = [0u8; 7];
 
         // Test input report
-        let len = Command::GetReport(ReportType::Input, REPORT_ID)
+        let len = Command::GetReport(ReportType::Input, REPORT_ID, None)
             .encode_into_slice(&mut test_buffer, None, None)
             .unwrap();
         assert_eq!(&test_buffer[0..len], [0x18, 0x02]);
 
         // Test feature report
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Feature, REPORT_ID)
+        let len = Command::GetReport(ReportType::Feature, REPORT_ID, None)
             .encode_into_slice(&mut test_buffer, None, None)
             .unwrap();
         assert_eq!(&test_buffer[0..len], [0x38, 0x02]);
 
         // Test extended report
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Input, EXT_REPORT_ID)
+        let len = Command::GetReport(ReportType::Input, EXT_REPORT_ID, None)
             .encode_into_slice(&mut test_buffer, None, None)
             .unwrap();
         assert_eq!(&test_buffer[0..len], [0x1f, 0x02, EXTENDED_REPORT_ID]);
 
         // Test standard report id with registers
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Feature, REPORT_ID)
+        let len = Command::GetReport(ReportType::Feature, REPORT_ID, Some(64))
             .encode_into_slice(&mut test_buffer, Some(CMD_REG), Some(DATA_REG))
             .unwrap();
         assert_eq!(&test_buffer[0..len], [0x05, 0x00, 0x38, 0x02, 0x06, 0x00]);
 
         // Test extended report id with registers
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Input, EXT_REPORT_ID)
+        let len = Command::GetReport(ReportType::Input, EXT_REPORT_ID, None)
             .encode_into_slice(&mut test_buffer, Some(CMD_REG), Some(DATA_REG))
             .unwrap();
         assert_eq!(

--- a/embedded-service/src/hid/command.rs
+++ b/embedded-service/src/hid/command.rs
@@ -225,7 +225,14 @@ impl Opcode {
 #[allow(missing_docs)]
 pub enum Command<'a> {
     Reset,
-    GetReport(ReportType, ReportId, Option<u16>),
+    GetReport {
+        /// Report type (Input or Feature)
+        report_type: ReportType,
+        /// Report ID
+        report_id: ReportId,
+        /// Expected payload size in bytes, used to constrain the response read length
+        expected_payload_size: Option<u16>,
+    },
     SetReport(ReportType, ReportId, SharedRef<'a, u8>),
     GetIdle(ReportId),
     SetIdle(ReportId, ReportFreq),
@@ -239,7 +246,7 @@ impl From<Command<'_>> for Opcode {
     fn from(value: Command<'_>) -> Self {
         match value {
             Command::Reset => Opcode::Reset,
-            Command::GetReport(_, _, _) => Opcode::GetReport,
+            Command::GetReport { .. } => Opcode::GetReport,
             Command::SetReport(_, _, _) => Opcode::SetReport,
             Command::GetIdle(_) => Opcode::GetIdle,
             Command::SetIdle(_, _) => Opcode::SetIdle,
@@ -311,11 +318,11 @@ impl<'a> Command<'a> {
             Opcode::Reset => Command::Reset,
             Opcode::GetReport => {
                 if report_type? == ReportType::Input || report_type? == ReportType::Feature {
-                    Command::GetReport(
-                        report_type?,
-                        report_id.ok_or(Error::RequiresReportId)?,
-                        expected_response_size,
-                    )
+                    Command::GetReport {
+                        report_type: report_type?,
+                        report_id: report_id.ok_or(Error::RequiresReportId)?,
+                        expected_payload_size: expected_response_size,
+                    }
                 } else {
                     return Err(Error::InvalidReportType);
                 }
@@ -481,7 +488,11 @@ impl<'a> Command<'a> {
                 let (command_len, _) = Self::encode_basic_op(buf, Opcode::Reset)?;
                 len += command_len;
             }
-            Command::GetReport(report_type, report_id, _expected_size) => {
+            Command::GetReport {
+                report_type,
+                report_id,
+                expected_payload_size: _,
+            } => {
                 let (command_len, buf) = Self::encode_common(buf, Opcode::GetReport, Some(*report_type), *report_id)?;
                 len += command_len;
 
@@ -599,37 +610,57 @@ mod test {
         let mut test_buffer = [0u8; 7];
 
         // Test input report
-        let len = Command::GetReport(ReportType::Input, REPORT_ID, None)
-            .encode_into_slice(&mut test_buffer, None, None)
-            .unwrap();
+        let len = Command::GetReport {
+            report_type: ReportType::Input,
+            report_id: REPORT_ID,
+            expected_payload_size: None,
+        }
+        .encode_into_slice(&mut test_buffer, None, None)
+        .unwrap();
         assert_eq!(&test_buffer[0..len], [0x18, 0x02]);
 
         // Test feature report
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Feature, REPORT_ID, None)
-            .encode_into_slice(&mut test_buffer, None, None)
-            .unwrap();
+        let len = Command::GetReport {
+            report_type: ReportType::Feature,
+            report_id: REPORT_ID,
+            expected_payload_size: None,
+        }
+        .encode_into_slice(&mut test_buffer, None, None)
+        .unwrap();
         assert_eq!(&test_buffer[0..len], [0x38, 0x02]);
 
         // Test extended report
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Input, EXT_REPORT_ID, None)
-            .encode_into_slice(&mut test_buffer, None, None)
-            .unwrap();
+        let len = Command::GetReport {
+            report_type: ReportType::Input,
+            report_id: EXT_REPORT_ID,
+            expected_payload_size: None,
+        }
+        .encode_into_slice(&mut test_buffer, None, None)
+        .unwrap();
         assert_eq!(&test_buffer[0..len], [0x1f, 0x02, EXTENDED_REPORT_ID]);
 
         // Test standard report id with registers
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Feature, REPORT_ID, Some(64))
-            .encode_into_slice(&mut test_buffer, Some(CMD_REG), Some(DATA_REG))
-            .unwrap();
+        let len = Command::GetReport {
+            report_type: ReportType::Feature,
+            report_id: REPORT_ID,
+            expected_payload_size: Some(64),
+        }
+        .encode_into_slice(&mut test_buffer, Some(CMD_REG), Some(DATA_REG))
+        .unwrap();
         assert_eq!(&test_buffer[0..len], [0x05, 0x00, 0x38, 0x02, 0x06, 0x00]);
 
         // Test extended report id with registers
         test_buffer.fill(0);
-        let len = Command::GetReport(ReportType::Input, EXT_REPORT_ID, None)
-            .encode_into_slice(&mut test_buffer, Some(CMD_REG), Some(DATA_REG))
-            .unwrap();
+        let len = Command::GetReport {
+            report_type: ReportType::Input,
+            report_id: EXT_REPORT_ID,
+            expected_payload_size: None,
+        }
+        .encode_into_slice(&mut test_buffer, Some(CMD_REG), Some(DATA_REG))
+        .unwrap();
         assert_eq!(
             &test_buffer[0..len],
             [0x05, 0x00, 0x1f, 0x02, EXTENDED_REPORT_ID, 0x06, 0x00]

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -10,8 +10,6 @@ use embedded_services::{error, hid, info, trace};
 use crate::Error;
 
 const LENGTH_PREFIX_SIZE: usize = 2;
-const LENGTH_LO_OFFSET: usize = 0;
-const LENGTH_HI_OFFSET: usize = 1;
 
 /// Timeout configuration for I2C HID device operations.
 pub struct Config {
@@ -253,8 +251,13 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
             })?;
 
             if constrained {
-                let actual_frame_len =
-                    u16::from_le_bytes([read_buf[LENGTH_LO_OFFSET], read_buf[LENGTH_HI_OFFSET]]) as usize;
+                let actual_frame_len = read_buf
+                    .first_chunk::<LENGTH_PREFIX_SIZE>()
+                    .map(|b| u16::from_le_bytes(*b) as usize)
+                    .ok_or(Error::Hid(hid::Error::InvalidSize(InvalidSizeError {
+                        expected: LENGTH_PREFIX_SIZE,
+                        actual: read_buf.len(),
+                    })))?;
                 if actual_frame_len != response_size {
                     error!(
                         "Length mismatch: declared={} expected={}",

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -258,7 +258,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                         expected: LENGTH_PREFIX_SIZE,
                         actual: read_buf.len(),
                     })))?;
-                if actual_frame_len != response_size {
+                if actual_frame_len > response_size {
                     error!(
                         "Length mismatch: declared={} expected={}",
                         actual_frame_len, response_size

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -10,6 +10,8 @@ use embedded_services::{error, hid, info, trace};
 use crate::Error;
 
 const LENGTH_PREFIX_SIZE: usize = 2;
+const LENGTH_LO_OFFSET: usize = 0;
+const LENGTH_HI_OFFSET: usize = 1;
 
 /// Timeout configuration for I2C HID device operations.
 pub struct Config {
@@ -211,11 +213,11 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                     Error::Hid(hid::Error::Serialize)
                 })?;
 
-            let response_size = match cmd {
+            let (response_size, constrained) = match cmd {
                 hid::Command::GetReport(_, _, Some(expected_payload_size)) => {
-                    *expected_payload_size as usize + LENGTH_PREFIX_SIZE
+                    (*expected_payload_size as usize + LENGTH_PREFIX_SIZE, true)
                 }
-                _ => buffer_len,
+                _ => (buffer_len, false),
             };
             let read_buf =
                 buf.get_mut(0..response_size)
@@ -248,6 +250,21 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                 error!("Failed to execute command write_read");
                 Error::Bus(e)
             })?;
+
+            if constrained {
+                let actual_frame_len =
+                    u16::from_le_bytes([read_buf[LENGTH_LO_OFFSET], read_buf[LENGTH_HI_OFFSET]]) as usize;
+                if actual_frame_len != response_size {
+                    error!(
+                        "Length mismatch: declared={} expected={}",
+                        actual_frame_len, response_size
+                    );
+                    return Err(Error::Hid(hid::Error::InvalidSize(InvalidSizeError {
+                        expected: response_size,
+                        actual: actual_frame_len,
+                    })));
+                }
+            }
 
             Ok(Some(Response::FeatureReport(
                 self.buffer.reference().slice(0..response_size).map_err(Error::Buffer)?,

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -9,6 +9,8 @@ use embedded_services::{error, hid, info, trace};
 
 use crate::Error;
 
+const LENGTH_PREFIX_SIZE: usize = 2;
+
 /// Timeout configuration for I2C HID device operations.
 pub struct Config {
     /// Timeout for descriptor reads and commands.
@@ -209,6 +211,19 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                     Error::Hid(hid::Error::Serialize)
                 })?;
 
+            let response_size = match cmd {
+                hid::Command::GetReport(_, _, Some(expected_payload_size)) => {
+                    *expected_payload_size as usize + LENGTH_PREFIX_SIZE
+                }
+                _ => buffer_len,
+            };
+            let read_buf =
+                buf.get_mut(0..response_size)
+                    .ok_or(Error::Hid(hid::Error::InvalidSize(InvalidSizeError {
+                        expected: response_size,
+                        actual: buffer_len,
+                    })))?;
+
             let mut bus = self.bus.lock().await;
 
             with_timeout(
@@ -221,7 +236,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                             expected: len,
                             actual: temp_w_buf.len(),
                         })))?,
-                    buf,
+                    read_buf,
                 ),
             )
             .await
@@ -234,7 +249,9 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                 Error::Bus(e)
             })?;
 
-            Ok(Some(Response::FeatureReport(self.buffer.reference())))
+            Ok(Some(Response::FeatureReport(
+                self.buffer.reference().slice(0..response_size).map_err(Error::Buffer)?,
+            )))
         } else {
             let len = cmd
                 .encode_into_slice(

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -1,10 +1,10 @@
 use core::borrow::BorrowMut;
 
 use embassy_sync::mutex::Mutex;
-use embassy_time::{Duration, with_timeout};
+use embassy_time::{with_timeout, Duration};
 use embedded_hal_async::i2c::{AddressMode, I2c};
 use embedded_services::hid::{DeviceContainer, InvalidSizeError, Opcode, Response};
-use embedded_services::{GlobalRawMutex, buffer::*};
+use embedded_services::{buffer::*, GlobalRawMutex};
 use embedded_services::{error, hid, info, trace};
 
 use crate::Error;
@@ -214,9 +214,10 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                 })?;
 
             let (response_size, constrained) = match cmd {
-                hid::Command::GetReport(_, _, Some(expected_payload_size)) => {
-                    (*expected_payload_size as usize + LENGTH_PREFIX_SIZE, true)
-                }
+                hid::Command::GetReport {
+                    expected_payload_size: Some(expected_payload_size),
+                    ..
+                } => (*expected_payload_size as usize + LENGTH_PREFIX_SIZE, true),
                 _ => (buffer_len, false),
             };
             let read_buf =

--- a/hid-service/src/i2c/device.rs
+++ b/hid-service/src/i2c/device.rs
@@ -1,10 +1,10 @@
 use core::borrow::BorrowMut;
 
 use embassy_sync::mutex::Mutex;
-use embassy_time::{with_timeout, Duration};
+use embassy_time::{Duration, with_timeout};
 use embedded_hal_async::i2c::{AddressMode, I2c};
 use embedded_services::hid::{DeviceContainer, InvalidSizeError, Opcode, Response};
-use embedded_services::{buffer::*, GlobalRawMutex};
+use embedded_services::{GlobalRawMutex, buffer::*};
 use embedded_services::{error, hid, info, trace};
 
 use crate::Error;
@@ -250,7 +250,7 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                 Error::Bus(e)
             })?;
 
-            if constrained {
+            let returned_len = if constrained {
                 let actual_frame_len = read_buf
                     .first_chunk::<LENGTH_PREFIX_SIZE>()
                     .map(|b| u16::from_le_bytes(*b) as usize)
@@ -258,20 +258,23 @@ impl<A: AddressMode + Copy, B: I2c<A>> Device<A, B> {
                         expected: LENGTH_PREFIX_SIZE,
                         actual: read_buf.len(),
                     })))?;
-                if actual_frame_len > response_size {
+                if actual_frame_len < LENGTH_PREFIX_SIZE || actual_frame_len > response_size {
                     error!(
-                        "Length mismatch: declared={} expected={}",
-                        actual_frame_len, response_size
+                        "Length mismatch: declared={} expected<={} min={}",
+                        actual_frame_len, response_size, LENGTH_PREFIX_SIZE
                     );
                     return Err(Error::Hid(hid::Error::InvalidSize(InvalidSizeError {
                         expected: response_size,
                         actual: actual_frame_len,
                     })));
                 }
-            }
+                actual_frame_len
+            } else {
+                response_size
+            };
 
             Ok(Some(Response::FeatureReport(
-                self.buffer.reference().slice(0..response_size).map_err(Error::Buffer)?,
+                self.buffer.reference().slice(0..returned_len).map_err(Error::Buffer)?,
             )))
         } else {
             let len = cmd

--- a/hid-service/src/i2c/host.rs
+++ b/hid-service/src/i2c/host.rs
@@ -227,7 +227,7 @@ impl<B: I2cSlaveAsync> Host<B> {
 
         // Create command
         let report_type = hid::ReportType::try_from(cmd).ok();
-        let command = hid::Command::new(cmd, opcode, report_type, report_id, buffer);
+        let command = hid::Command::new(cmd, opcode, report_type, report_id, buffer, None);
         match command {
             Ok(command) => Ok(command),
             Err(e) => {

--- a/keyboard-service/src/hid_kb.rs
+++ b/keyboard-service/src/hid_kb.rs
@@ -168,7 +168,11 @@ pub async fn handle_keyboard<T: HidKeyboard>(mut hid_kb: T) -> Result<embedded_s
                 }
 
                 // Instructs the keyboard to immediately return the latest input/feature report
-                hid::Command::GetReport(report_type, report_id, _expected_size) => {
+                hid::Command::GetReport {
+                    report_type,
+                    report_id,
+                    expected_payload_size: _,
+                } => {
                     {
                         let report = hid_kb.get_report(report_type, report_id);
                         let report = HidI2cReport::from_report_slice(report, max_input_len).to_bytes();

--- a/keyboard-service/src/hid_kb.rs
+++ b/keyboard-service/src/hid_kb.rs
@@ -5,12 +5,12 @@ use embassy_sync::channel::Channel;
 use embassy_sync::once_lock::OnceLock;
 use embassy_sync::signal::Signal;
 use embedded_hal::digital::OutputPin;
+use embedded_services::GlobalRawMutex;
 use embedded_services::buffer::SharedRef;
 use embedded_services::comms;
 use embedded_services::error;
 use embedded_services::hid;
 use embedded_services::ipc::deferred as ipc;
-use embedded_services::GlobalRawMutex;
 use hid_service::i2c::I2cSlaveAsync;
 use static_cell::StaticCell;
 

--- a/keyboard-service/src/hid_kb.rs
+++ b/keyboard-service/src/hid_kb.rs
@@ -5,12 +5,12 @@ use embassy_sync::channel::Channel;
 use embassy_sync::once_lock::OnceLock;
 use embassy_sync::signal::Signal;
 use embedded_hal::digital::OutputPin;
-use embedded_services::GlobalRawMutex;
 use embedded_services::buffer::SharedRef;
 use embedded_services::comms;
 use embedded_services::error;
 use embedded_services::hid;
 use embedded_services::ipc::deferred as ipc;
+use embedded_services::GlobalRawMutex;
 use hid_service::i2c::I2cSlaveAsync;
 use static_cell::StaticCell;
 
@@ -168,7 +168,7 @@ pub async fn handle_keyboard<T: HidKeyboard>(mut hid_kb: T) -> Result<embedded_s
                 }
 
                 // Instructs the keyboard to immediately return the latest input/feature report
-                hid::Command::GetReport(report_type, report_id) => {
+                hid::Command::GetReport(report_type, report_id, _expected_size) => {
                     {
                         let report = hid_kb.get_report(report_type, report_id);
                         let report = HidI2cReport::from_report_slice(report, max_input_len).to_bytes();


### PR DESCRIPTION
Add an optional buffer size parameter to GetReport so the I2C device layer can limit the read length to the actual expected payload size instead of always reading the full buffer. This avoids over-reading response in write_read transactions.