### PR TITLE
type-C: Port corrected implicit source contract logic

### DIFF
--- a/type-c-service/src/controller/mod.rs
+++ b/type-c-service/src/controller/mod.rs
@@ -132,7 +132,7 @@ impl<
             self.process_new_consumer_contract(&new_status).await?;
         }
 
-        if status_event.new_power_contract_as_provider() {
+        if new_status.is_connected() && new_status.available_source_contract != self.status.available_source_contract {
             self.process_new_provider_contract(&new_status).await?;
         }
 


### PR DESCRIPTION
Non-PD capable devices do not result in `new_power_contract_as_provider` contracts. Update logic to detect changes to the provider contract that works for PD and non-PD capable devices.

Logic ported from #751 