### PR TITLE
power-policy-service: Introduce customization

### DIFF
--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -2,6 +2,8 @@ use core::cmp::Ordering;
 use embedded_services::error;
 use embedded_services::named::Named;
 
+use crate::service::config::Config;
+
 use super::*;
 
 use power_policy_interface::psu;
@@ -26,12 +28,12 @@ impl<'device, Psu: Lockable<Inner: psu::Psu>> Clone for AvailableConsumer<'devic
 
 impl<'device, Psu: Lockable<Inner: psu::Psu>> Copy for AvailableConsumer<'device, Psu> {}
 
-/// Compare two consumer capabilities to determine which one is better
+/// Default function for comparing two consumer capabilities to determine which one is better
 ///
 /// This is not part of the `Ord` implementation for `ConsumerPowerCapability`, because it's specific to this implementation.
 /// *_is_current indicate if the device with that capability is the currently connected consumer. This is used to make the
 /// implementation stick so as to avoid switching between otherwise equivalent consumers.
-fn cmp_consumer_capability(
+pub fn cmp_consumer_capability_default(
     a: &ConsumerPowerCapability,
     a_is_current: bool,
     b: &ConsumerPowerCapability,
@@ -40,61 +42,70 @@ fn cmp_consumer_capability(
     (a.capability, a_is_current).cmp(&(b.capability, b_is_current))
 }
 
-impl<'device, Reg: Registration<'device>> Service<'device, Reg> {
-    /// Iterate over all devices to determine what is best power port provides the highest power
-    async fn find_best_consumer(&self) -> Result<Option<AvailableConsumer<'device, Reg::Psu>>, Error> {
-        let mut best_consumer = None;
-        let current_consumer = self.state.current_consumer_state.as_ref().map(|f| f.psu);
+/// Default logic for finding the best consumer
+pub async fn find_best_consumer_default<
+    'device,
+    Reg: Registration<'device>,
+    Cmp: Fn(&ConsumerPowerCapability, bool, &ConsumerPowerCapability, bool) -> Ordering,
+>(
+    config: &Config,
+    state: &InternalState<'device, Reg::Psu>,
+    registration: &Reg,
+    cmp: Cmp,
+) -> Result<Option<AvailableConsumer<'device, Reg::Psu>>, Error> {
+    let mut best_consumer = None;
+    let current_consumer = state.current_consumer_state.as_ref().map(|f| f.psu);
 
-        for psu in self.registration.psus() {
-            let locked_psu = psu.lock().await;
-            let consumer_capability = locked_psu.state().consumer_capability;
-            // Don't consider consumers below minimum threshold
-            if consumer_capability
-                .zip(self.config.min_consumer_threshold_mw)
-                .is_some_and(|(cap, min)| cap.capability.max_power_mw() < min)
-            {
-                info!(
-                    "({}): Not considering consumer, power capability is too low",
-                    locked_psu.name(),
-                );
-                continue;
-            }
-
-            // Update the best available consumer
-            best_consumer = match (best_consumer, consumer_capability) {
-                // Nothing available
-                (None, None) => None,
-                // No existing consumer
-                (None, Some(power_capability)) => Some(AvailableConsumer {
-                    psu: *psu,
-                    consumer_power_capability: power_capability,
-                }),
-                // Existing consumer, no new consumer
-                (Some(_), None) => best_consumer,
-                // Existing consumer, new available consumer
-                (Some(best), Some(available)) => {
-                    if cmp_consumer_capability(
-                        &available,
-                        current_consumer.is_some_and(|current_consumer| ptr::eq(current_consumer, *psu)),
-                        &best.consumer_power_capability,
-                        current_consumer.is_some_and(|current_consumer| ptr::eq(current_consumer, best.psu)),
-                    ) == core::cmp::Ordering::Greater
-                    {
-                        Some(AvailableConsumer {
-                            psu,
-                            consumer_power_capability: available,
-                        })
-                    } else {
-                        best_consumer
-                    }
-                }
-            };
+    for psu in registration.psus() {
+        let locked_psu = psu.lock().await;
+        let consumer_capability = locked_psu.state().consumer_capability;
+        // Don't consider consumers below minimum threshold
+        if consumer_capability
+            .zip(config.min_consumer_threshold_mw)
+            .is_some_and(|(cap, min)| cap.capability.max_power_mw() < min)
+        {
+            info!(
+                "({}): Not considering consumer, power capability is too low",
+                locked_psu.name(),
+            );
+            continue;
         }
 
-        Ok(best_consumer)
+        // Update the best available consumer
+        best_consumer = match (best_consumer, consumer_capability) {
+            // Nothing available
+            (None, None) => None,
+            // No existing consumer
+            (None, Some(power_capability)) => Some(AvailableConsumer {
+                psu: *psu,
+                consumer_power_capability: power_capability,
+            }),
+            // Existing consumer, no new consumer
+            (Some(_), None) => best_consumer,
+            // Existing consumer, new available consumer
+            (Some(best), Some(available)) => {
+                if cmp(
+                    &available,
+                    current_consumer.is_some_and(|current_consumer| ptr::eq(current_consumer, *psu)),
+                    &best.consumer_power_capability,
+                    current_consumer.is_some_and(|current_consumer| ptr::eq(current_consumer, best.psu)),
+                ) == core::cmp::Ordering::Greater
+                {
+                    Some(AvailableConsumer {
+                        psu,
+                        consumer_power_capability: available,
+                    })
+                } else {
+                    best_consumer
+                }
+            }
+        };
     }
 
+    Ok(best_consumer)
+}
+
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg>> Service<'device, Reg, Hooks> {
     /// Update unconstrained state and broadcast notifications if needed
     async fn update_unconstrained_state(&mut self) -> Result<(), Error> {
         // Count how many available unconstrained devices we have
@@ -233,7 +244,10 @@ impl<'device, Reg: Registration<'device>> Service<'device, Reg> {
         };
         info!("Selecting power port, current power: {:#?}", current_consumer_name);
 
-        let best_consumer = self.find_best_consumer().await?;
+        let best_consumer = self
+            .hooks
+            .find_best_consumer(&self.config, &self.state, &self.registration)
+            .await?;
         let best_consumer_name = if let Some(best_consumer) = best_consumer {
             best_consumer.psu.lock().await.name()
         } else {
@@ -276,8 +290,11 @@ mod tests {
         let p0 = P0.into();
         let p1 = P1.into();
 
-        assert_eq!(cmp_consumer_capability(&p0, false, &p1, false), Ordering::Less);
-        assert_eq!(cmp_consumer_capability(&p1, false, &p1, false), Ordering::Equal);
-        assert_eq!(cmp_consumer_capability(&p1, false, &p0, false), Ordering::Greater);
+        assert_eq!(cmp_consumer_capability_default(&p0, false, &p1, false), Ordering::Less);
+        assert_eq!(cmp_consumer_capability_default(&p1, false, &p1, false), Ordering::Equal);
+        assert_eq!(
+            cmp_consumer_capability_default(&p1, false, &p0, false),
+            Ordering::Greater
+        );
     }
 }

--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -105,7 +105,7 @@ pub async fn find_best_consumer_default<
     Ok(best_consumer)
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg>> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, Reg, Hooks> {
     /// Update unconstrained state and broadcast notifications if needed
     async fn update_unconstrained_state(&mut self) -> Result<(), Error> {
         // Count how many available unconstrained devices we have

--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -105,7 +105,9 @@ pub async fn find_best_consumer_default<
     Ok(best_consumer)
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Cusomization: customization::Customization>
+    Service<'device, Reg, Cusomization>
+{
     /// Update unconstrained state and broadcast notifications if needed
     async fn update_unconstrained_state(&mut self) -> Result<(), Error> {
         // Count how many available unconstrained devices we have
@@ -245,7 +247,7 @@ impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, 
         info!("Selecting power port, current power: {:#?}", current_consumer_name);
 
         let best_consumer = self
-            .hooks
+            .customization
             .find_best_consumer(&self.config, &self.state, &self.registration)
             .await?;
         let best_consumer_name = if let Some(best_consumer) = best_consumer {

--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -105,8 +105,8 @@ pub async fn find_best_consumer_default<
     Ok(best_consumer)
 }
 
-impl<'device, Reg: Registration<'device>, Cusomization: customization::Customization>
-    Service<'device, Reg, Cusomization>
+impl<'device, Reg: Registration<'device>, Customization: customization::Customization>
+    Service<'device, Reg, Customization>
 {
     /// Update unconstrained state and broadcast notifications if needed
     async fn update_unconstrained_state(&mut self) -> Result<(), Error> {

--- a/power-policy-service/src/service/customization.rs
+++ b/power-policy-service/src/service/customization.rs
@@ -7,8 +7,8 @@ use crate::service::{
     registration::Registration,
 };
 
-/// Power policy service hooks
-pub trait Hooks {
+/// Power policy service customization
+pub trait Customization {
     /// Find the best available consumer based on the current state and configuration.
     fn find_best_consumer<'device, Reg: Registration<'device>>(
         &mut self,
@@ -20,8 +20,8 @@ pub trait Hooks {
     }
 }
 
-/// Default hooks implementation
+/// Default customization implementation
 #[derive(Debug, Clone, Default)]
-pub struct DefaultHooks;
+pub struct DefaultCustomization;
 
-impl Hooks for DefaultHooks {}
+impl Customization for DefaultCustomization {}

--- a/power-policy-service/src/service/hooks.rs
+++ b/power-policy-service/src/service/hooks.rs
@@ -8,9 +8,9 @@ use crate::service::{
 };
 
 /// Power policy service hooks
-pub trait Hooks<'device, Reg: Registration<'device>> {
+pub trait Hooks {
     /// Find the best available consumer based on the current state and configuration.
-    fn find_best_consumer(
+    fn find_best_consumer<'device, Reg: Registration<'device>>(
         &mut self,
         config: &Config,
         state: &InternalState<'device, Reg::Psu>,
@@ -24,4 +24,4 @@ pub trait Hooks<'device, Reg: Registration<'device>> {
 #[derive(Debug, Clone, Default)]
 pub struct DefaultHooks;
 
-impl<'device, Reg: Registration<'device>> Hooks<'device, Reg> for DefaultHooks {}
+impl Hooks for DefaultHooks {}

--- a/power-policy-service/src/service/hooks.rs
+++ b/power-policy-service/src/service/hooks.rs
@@ -1,0 +1,27 @@
+use power_policy_interface::psu::Error;
+
+use crate::service::{
+    InternalState,
+    config::Config,
+    consumer::{AvailableConsumer, cmp_consumer_capability_default, find_best_consumer_default},
+    registration::Registration,
+};
+
+/// Power policy service hooks
+pub trait Hooks<'device, Reg: Registration<'device>> {
+    /// Find the best available consumer based on the current state and configuration.
+    fn find_best_consumer(
+        &mut self,
+        config: &Config,
+        state: &InternalState<'device, Reg::Psu>,
+        registration: &Reg,
+    ) -> impl Future<Output = Result<Option<AvailableConsumer<'device, Reg::Psu>>, Error>> {
+        find_best_consumer_default(config, state, registration, cmp_consumer_capability_default)
+    }
+}
+
+/// Default hooks implementation
+#[derive(Debug, Clone, Default)]
+pub struct DefaultHooks;
+
+impl<'device, Reg: Registration<'device>> Hooks<'device, Reg> for DefaultHooks {}

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -57,7 +57,7 @@ where
 }
 
 /// Power policy service
-pub struct Service<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg> = hooks::DefaultHooks> {
+pub struct Service<'device, Reg: Registration<'device>, Hooks: hooks::Hooks = hooks::DefaultHooks> {
     /// Service registration
     registration: Reg,
     /// State
@@ -68,14 +68,14 @@ pub struct Service<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'dev
     hooks: Hooks,
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg> + Default> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks + Default> Service<'device, Reg, Hooks> {
     /// Create a new power policy
     pub fn new(registration: Reg, config: config::Config) -> Self {
         Self::new_with_hooks(registration, config, Hooks::default())
     }
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg>> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, Reg, Hooks> {
     /// Create a new power policy with custom hooks
     pub fn new_with_hooks(registration: Reg, config: config::Config, hooks: Hooks) -> Self {
         Self {

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -3,7 +3,7 @@ use core::ptr;
 
 pub mod config;
 pub mod consumer;
-pub mod hooks;
+pub mod customization;
 pub mod provider;
 pub mod registration;
 pub mod task;
@@ -57,32 +57,40 @@ where
 }
 
 /// Power policy service
-pub struct Service<'device, Reg: Registration<'device>, Hooks: hooks::Hooks = hooks::DefaultHooks> {
+pub struct Service<
+    'device,
+    Reg: Registration<'device>,
+    Customization: customization::Customization = customization::DefaultCustomization,
+> {
     /// Service registration
     registration: Reg,
     /// State
     state: InternalState<'device, Reg::Psu>,
     /// Config
     config: config::Config,
-    /// Hooks
-    hooks: Hooks,
+    /// Customization
+    customization: Customization,
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks + Default> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Customization: customization::Customization + Default>
+    Service<'device, Reg, Customization>
+{
     /// Create a new power policy
     pub fn new(registration: Reg, config: config::Config) -> Self {
-        Self::new_with_hooks(registration, config, Hooks::default())
+        Self::new_with_customization(registration, config, Customization::default())
     }
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, Reg, Hooks> {
-    /// Create a new power policy with custom hooks
-    pub fn new_with_hooks(registration: Reg, config: config::Config, hooks: Hooks) -> Self {
+impl<'device, Reg: Registration<'device>, Customization: customization::Customization>
+    Service<'device, Reg, Customization>
+{
+    /// Create a new power policy with customization
+    pub fn new_with_customization(registration: Reg, config: config::Config, customization: Customization) -> Self {
         Self {
             registration,
             state: InternalState::default(),
             config,
-            hooks,
+            customization,
         }
     }
 

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -3,6 +3,7 @@ use core::ptr;
 
 pub mod config;
 pub mod consumer;
+pub mod hooks;
 pub mod provider;
 pub mod registration;
 pub mod task;
@@ -27,18 +28,18 @@ use crate::service::registration::Registration;
 const MAX_CONNECTED_PROVIDERS: usize = 4;
 
 #[derive(Clone)]
-struct InternalState<'device, PSU: Lockable>
+pub struct InternalState<'device, PSU: Lockable>
 where
     PSU::Inner: Psu,
 {
     /// Current consumer state, if any
-    current_consumer_state: Option<consumer::AvailableConsumer<'device, PSU>>,
+    pub current_consumer_state: Option<consumer::AvailableConsumer<'device, PSU>>,
     /// Current provider global state
-    current_provider_state: provider::State,
+    pub current_provider_state: provider::State,
     /// System unconstrained power
-    unconstrained: UnconstrainedState,
+    pub unconstrained: UnconstrainedState,
     /// Connected providers
-    connected_providers: heapless::index_set::FnvIndexSet<usize, MAX_CONNECTED_PROVIDERS>,
+    pub connected_providers: heapless::index_set::FnvIndexSet<usize, MAX_CONNECTED_PROVIDERS>,
 }
 
 impl<PSU: Lockable> Default for InternalState<'_, PSU>
@@ -56,22 +57,32 @@ where
 }
 
 /// Power policy service
-pub struct Service<'device, Reg: Registration<'device>> {
+pub struct Service<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg> = hooks::DefaultHooks> {
     /// Service registration
     registration: Reg,
     /// State
     state: InternalState<'device, Reg::Psu>,
     /// Config
     config: config::Config,
+    /// Hooks
+    hooks: Hooks,
 }
 
-impl<'device, Reg: Registration<'device>> Service<'device, Reg> {
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg> + Default> Service<'device, Reg, Hooks> {
     /// Create a new power policy
     pub fn new(registration: Reg, config: config::Config) -> Self {
+        Self::new_with_hooks(registration, config, Hooks::default())
+    }
+}
+
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg>> Service<'device, Reg, Hooks> {
+    /// Create a new power policy with custom hooks
+    pub fn new_with_hooks(registration: Reg, config: config::Config, hooks: Hooks) -> Self {
         Self {
             registration,
             state: InternalState::default(),
             config,
+            hooks,
         }
     }
 

--- a/power-policy-service/src/service/provider.rs
+++ b/power-policy-service/src/service/provider.rs
@@ -24,12 +24,12 @@ pub enum PowerState {
 
 /// Power policy provider global state
 #[derive(Clone, Copy, Default)]
-pub(super) struct State {
+pub struct State {
     /// Current power state
     state: PowerState,
 }
 
-impl<'device, Reg: Registration<'device>> Service<'device, Reg> {
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg>> Service<'device, Reg, Hooks> {
     /// Attempt to connect the requester as a provider
     pub(super) async fn connect_provider(&mut self, requester: &'device Reg::Psu) -> Result<(), Error> {
         let requested_power_capability = {

--- a/power-policy-service/src/service/provider.rs
+++ b/power-policy-service/src/service/provider.rs
@@ -29,7 +29,7 @@ pub struct State {
     state: PowerState,
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks<'device, Reg>> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, Reg, Hooks> {
     /// Attempt to connect the requester as a provider
     pub(super) async fn connect_provider(&mut self, requester: &'device Reg::Psu) -> Result<(), Error> {
         let requested_power_capability = {

--- a/power-policy-service/src/service/provider.rs
+++ b/power-policy-service/src/service/provider.rs
@@ -29,7 +29,9 @@ pub struct State {
     state: PowerState,
 }
 
-impl<'device, Reg: Registration<'device>, Hooks: hooks::Hooks> Service<'device, Reg, Hooks> {
+impl<'device, Reg: Registration<'device>, Customization: customization::Customization>
+    Service<'device, Reg, Customization>
+{
     /// Attempt to connect the requester as a provider
     pub(super) async fn connect_provider(&mut self, requester: &'device Reg::Psu) -> Result<(), Error> {
         let requested_power_capability = {

--- a/power-policy-service/src/service/task.rs
+++ b/power-policy-service/src/service/task.rs
@@ -4,6 +4,7 @@ use embedded_services::event::Receiver;
 use power_policy_interface::charger;
 use power_policy_interface::psu::event::EventData;
 
+use crate::service::hooks;
 use crate::service::registration::Registration;
 
 use super::Service;
@@ -12,8 +13,9 @@ use super::Service;
 pub async fn psu_task<
     'device,
     const PSU_COUNT: usize,
-    S: Lockable<Inner = Service<'device, Reg>>,
+    S: Lockable<Inner = Service<'device, Reg, Hooks>>,
     Reg: Registration<'device>,
+    Hooks: hooks::Hooks,
     PsuReceiver: Receiver<EventData>,
 >(
     mut psu_events: crate::psu::PsuEventReceivers<'device, PSU_COUNT, Reg::Psu, PsuReceiver>,
@@ -33,8 +35,9 @@ pub async fn psu_task<
 pub async fn charger_task<
     'device,
     const CHARGER_COUNT: usize,
-    S: Lockable<Inner = Service<'device, Reg>>,
+    S: Lockable<Inner = Service<'device, Reg, Hooks>>,
     Reg: Registration<'device>,
+    Hooks: hooks::Hooks,
     ChargerReceiver: Receiver<charger::EventData>,
 >(
     mut charger_events: crate::charger::ChargerEventReceivers<'device, CHARGER_COUNT, Reg::Charger, ChargerReceiver>,
@@ -55,8 +58,9 @@ pub async fn task<
     'device,
     const PSU_COUNT: usize,
     const CHARGER_COUNT: usize,
-    S: Lockable<Inner = Service<'device, Reg>>,
+    S: Lockable<Inner = Service<'device, Reg, Hooks>>,
     Reg: Registration<'device>,
+    Hooks: hooks::Hooks,
     PsuReceiver: Receiver<EventData>,
     ChargerReceiver: Receiver<charger::EventData>,
 >(

--- a/power-policy-service/src/service/task.rs
+++ b/power-policy-service/src/service/task.rs
@@ -4,7 +4,7 @@ use embedded_services::event::Receiver;
 use power_policy_interface::charger;
 use power_policy_interface::psu::event::EventData;
 
-use crate::service::hooks;
+use crate::service::customization;
 use crate::service::registration::Registration;
 
 use super::Service;
@@ -13,9 +13,9 @@ use super::Service;
 pub async fn psu_task<
     'device,
     const PSU_COUNT: usize,
-    S: Lockable<Inner = Service<'device, Reg, Hooks>>,
+    S: Lockable<Inner = Service<'device, Reg, Customization>>,
     Reg: Registration<'device>,
-    Hooks: hooks::Hooks,
+    Customization: customization::Customization,
     PsuReceiver: Receiver<EventData>,
 >(
     mut psu_events: crate::psu::PsuEventReceivers<'device, PSU_COUNT, Reg::Psu, PsuReceiver>,
@@ -35,9 +35,9 @@ pub async fn psu_task<
 pub async fn charger_task<
     'device,
     const CHARGER_COUNT: usize,
-    S: Lockable<Inner = Service<'device, Reg, Hooks>>,
+    S: Lockable<Inner = Service<'device, Reg, Customization>>,
     Reg: Registration<'device>,
-    Hooks: hooks::Hooks,
+    Customization: customization::Customization,
     ChargerReceiver: Receiver<charger::EventData>,
 >(
     mut charger_events: crate::charger::ChargerEventReceivers<'device, CHARGER_COUNT, Reg::Charger, ChargerReceiver>,
@@ -58,9 +58,9 @@ pub async fn task<
     'device,
     const PSU_COUNT: usize,
     const CHARGER_COUNT: usize,
-    S: Lockable<Inner = Service<'device, Reg, Hooks>>,
+    S: Lockable<Inner = Service<'device, Reg, Customization>>,
     Reg: Registration<'device>,
-    Hooks: hooks::Hooks,
+    Customization: customization::Customization,
     PsuReceiver: Receiver<EventData>,
     ChargerReceiver: Receiver<charger::EventData>,
 >(

--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -20,7 +20,7 @@ use power_policy_interface::{
     capability::{ConsumerPowerCapability, PowerCapability, ProviderPowerCapability},
     service::{UnconstrainedState, event::Event as ServiceEvent},
 };
-use power_policy_service::service::{Service, config::Config, hooks};
+use power_policy_service::service::{Service, config::Config, customization};
 use power_policy_service::{psu::PsuEventReceivers, service::registration::ArrayRegistration};
 
 pub mod mock;
@@ -50,7 +50,7 @@ pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 const EVENT_CHANNEL_SIZE: usize = 4;
 
 pub type DeviceType<'a> = Mutex<GlobalRawMutex, Mock<'a, DynamicSender<'a, EventData>>>;
-pub type ServiceType<'device, 'sender, Hooks> = Service<
+pub type ServiceType<'device, 'sender, Customization> = Service<
     'device,
     ArrayRegistration<
         'device,
@@ -61,14 +61,15 @@ pub type ServiceType<'device, 'sender, Hooks> = Service<
         ChargerType<'device>,
         0,
     >,
-    Hooks,
+    Customization,
 >;
 
-pub type ServiceMutex<'device, 'sender, Hooks> = Mutex<GlobalRawMutex, ServiceType<'device, 'sender, Hooks>>;
+pub type ServiceMutex<'device, 'sender, Customization> =
+    Mutex<GlobalRawMutex, ServiceType<'device, 'sender, Customization>>;
 
-async fn power_policy_task<'device, 'sender, const N: usize, Hooks: hooks::Hooks>(
+async fn power_policy_task<'device, 'sender, const N: usize, Customization: customization::Customization>(
     completion_signal: &'device Signal<GlobalRawMutex, ()>,
-    power_policy: &ServiceMutex<'device, 'sender, Hooks>,
+    power_policy: &ServiceMutex<'device, 'sender, Customization>,
     mut event_receivers: PsuEventReceivers<'device, N, DeviceType<'device>, DynamicReceiver<'device, EventData>>,
 ) {
     while let Either::First(result) = select(event_receivers.wait_event(), completion_signal.wait()).await {
@@ -81,11 +82,11 @@ async fn power_policy_task<'device, 'sender, const N: usize, Hooks: hooks::Hooks
 /// This exists because there are lifetime issues with being generic over FnOnce or FnMut.
 /// Those can be resolved, but having a dedicated trait is simpler.
 pub trait Test {
-    type Hooks: hooks::Hooks;
+    type Customization: customization::Customization;
 
     fn run<'a>(
         &mut self,
-        service: &'a ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &'a ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &'a DeviceType<'a>,
         device0_signal: &'a Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -94,7 +95,7 @@ pub trait Test {
     ) -> impl Future<Output = ()>;
 }
 
-pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, hooks: T::Hooks) {
+pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, customization: T::Customization) {
     // Tokio runs tests in parallel, but logging is global so we need to run tests sequentially to avoid interleaved logs.
     static TEST_MUTEX: OnceLock<Mutex<GlobalRawMutex, ()>> = OnceLock::new();
     let test_mutex = TEST_MUTEX.get_or_init(|| Mutex::new(()));
@@ -131,10 +132,10 @@ pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, h
         chargers: [],
     };
 
-    let power_policy = Mutex::new(power_policy_service::service::Service::new_with_hooks(
+    let power_policy = Mutex::new(power_policy_service::service::Service::new_with_customization(
         power_policy_registration,
         config,
-        hooks,
+        customization,
     ));
 
     with_timeout(

--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -20,7 +20,7 @@ use power_policy_interface::{
     capability::{ConsumerPowerCapability, PowerCapability, ProviderPowerCapability},
     service::{UnconstrainedState, event::Event as ServiceEvent},
 };
-use power_policy_service::service::{Service, config::Config};
+use power_policy_service::service::{Service, config::Config, hooks};
 use power_policy_service::{psu::PsuEventReceivers, service::registration::ArrayRegistration};
 
 pub mod mock;
@@ -50,7 +50,7 @@ pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 const EVENT_CHANNEL_SIZE: usize = 4;
 
 pub type DeviceType<'a> = Mutex<GlobalRawMutex, Mock<'a, DynamicSender<'a, EventData>>>;
-pub type ServiceType<'device, 'sender> = Service<
+pub type ServiceType<'device, 'sender, Hooks> = Service<
     'device,
     ArrayRegistration<
         'device,
@@ -61,13 +61,14 @@ pub type ServiceType<'device, 'sender> = Service<
         ChargerType<'device>,
         0,
     >,
+    Hooks,
 >;
 
-pub type ServiceMutex<'device, 'sender> = Mutex<GlobalRawMutex, ServiceType<'device, 'sender>>;
+pub type ServiceMutex<'device, 'sender, Hooks> = Mutex<GlobalRawMutex, ServiceType<'device, 'sender, Hooks>>;
 
-async fn power_policy_task<'device, 'sender, const N: usize>(
+async fn power_policy_task<'device, 'sender, const N: usize, Hooks: hooks::Hooks>(
     completion_signal: &'device Signal<GlobalRawMutex, ()>,
-    power_policy: &ServiceMutex<'device, 'sender>,
+    power_policy: &ServiceMutex<'device, 'sender, Hooks>,
     mut event_receivers: PsuEventReceivers<'device, N, DeviceType<'device>, DynamicReceiver<'device, EventData>>,
 ) {
     while let Either::First(result) = select(event_receivers.wait_event(), completion_signal.wait()).await {
@@ -80,9 +81,11 @@ async fn power_policy_task<'device, 'sender, const N: usize>(
 /// This exists because there are lifetime issues with being generic over FnOnce or FnMut.
 /// Those can be resolved, but having a dedicated trait is simpler.
 pub trait Test {
+    type Hooks: hooks::Hooks;
+
     fn run<'a>(
         &mut self,
-        service: &'a ServiceMutex<'a, 'a>,
+        service: &'a ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &'a DeviceType<'a>,
         device0_signal: &'a Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -91,7 +94,7 @@ pub trait Test {
     ) -> impl Future<Output = ()>;
 }
 
-pub async fn run_test(timeout: Duration, mut test: impl Test, config: Config) {
+pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, hooks: T::Hooks) {
     // Tokio runs tests in parallel, but logging is global so we need to run tests sequentially to avoid interleaved logs.
     static TEST_MUTEX: OnceLock<Mutex<GlobalRawMutex, ()>> = OnceLock::new();
     let test_mutex = TEST_MUTEX.get_or_init(|| Mutex::new(()));
@@ -128,9 +131,10 @@ pub async fn run_test(timeout: Duration, mut test: impl Test, config: Config) {
         chargers: [],
     };
 
-    let power_policy = Mutex::new(power_policy_service::service::Service::new(
+    let power_policy = Mutex::new(power_policy_service::service::Service::new_with_hooks(
         power_policy_registration,
         config,
+        hooks,
     ));
 
     with_timeout(

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -4,6 +4,7 @@ use embassy_sync::signal::Signal;
 use embassy_time::{Duration, TimeoutError, with_timeout};
 use embedded_services::GlobalRawMutex;
 use embedded_services::info;
+use embedded_services::sync::Lockable;
 use power_policy_interface::capability::ProviderFlags;
 use power_policy_interface::capability::ProviderPowerCapability;
 use power_policy_interface::capability::{ConsumerFlags, ConsumerPowerCapability};
@@ -11,8 +12,16 @@ use power_policy_interface::capability::{ConsumerFlags, ConsumerPowerCapability}
 mod common;
 
 use common::{LOW_POWER, ServiceMutex};
+use power_policy_interface::psu::Psu;
 use power_policy_interface::service::event::Event as ServiceEvent;
+use power_policy_service::service::InternalState;
 use power_policy_service::service::config::Config;
+use power_policy_service::service::consumer::AvailableConsumer;
+use power_policy_service::service::consumer::cmp_consumer_capability_default;
+use power_policy_service::service::consumer::find_best_consumer_default;
+use power_policy_service::service::hooks;
+use power_policy_service::service::hooks::DefaultHooks;
+use power_policy_service::service::registration::Registration;
 
 use crate::common::DeviceType;
 use crate::common::MINIMAL_POWER;
@@ -32,9 +41,11 @@ const MIN_CONSUMER_THRESHOLD_MW: u32 = 7500;
 struct TestSingle;
 
 impl Test for TestSingle {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -99,9 +110,11 @@ impl Test for TestSingle {
 struct TestSwapHigher;
 
 impl Test for TestSwapHigher {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -231,9 +244,11 @@ impl Test for TestSwapHigher {
 struct TestDisconnect;
 
 impl Test for TestDisconnect {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -364,9 +379,11 @@ impl Test for TestDisconnect {
 struct TestDisconnectOtherConsumer;
 
 impl Test for TestDisconnectOtherConsumer {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -451,9 +468,11 @@ impl Test for TestDisconnectOtherConsumer {
 struct TestDisconnectOtherProvider;
 
 impl Test for TestDisconnectOtherProvider {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -550,9 +569,11 @@ impl Test for TestDisconnectOtherProvider {
 struct TestMinConsumerPower;
 
 impl Test for TestMinConsumerPower {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -588,9 +609,11 @@ impl Test for TestMinConsumerPower {
 struct TestNoSwap;
 
 impl Test for TestNoSwap {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -660,29 +683,149 @@ impl Test for TestNoSwap {
         assert_no_event(service_receiver);
     }
 }
+
+/// Power policy hooks that always returns the first PSU if it's available
+struct AlwaysFirstConsumerHooks;
+
+impl hooks::Hooks for AlwaysFirstConsumerHooks {
+    async fn find_best_consumer<'device, Reg: Registration<'device>>(
+        &mut self,
+        config: &Config,
+        state: &InternalState<'device, Reg::Psu>,
+        registration: &Reg,
+    ) -> Result<Option<AvailableConsumer<'device, Reg::Psu>>, power_policy_interface::psu::Error> {
+        let psu0 = registration.psus().iter().next().unwrap();
+        if let Some(consumer_power_capability) = psu0.lock().await.state().consumer_capability {
+            Ok(Some(AvailableConsumer {
+                psu: psu0,
+                consumer_power_capability,
+            }))
+        } else {
+            find_best_consumer_default(config, state, registration, cmp_consumer_capability_default).await
+        }
+    }
+}
+
+/// Verify that [`hooks::Hooks::find_find_best_consumer`] is called
+struct TestFindBestConsumerHook;
+
+impl Test for TestFindBestConsumerHook {
+    type Hooks = AlwaysFirstConsumerHooks;
+
+    async fn run<'a>(
+        &mut self,
+        _service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running TestFindBestConsumerHook");
+
+        // Device1 connection at high power
+        {
+            device1
+                .lock()
+                .await
+                .simulate_consumer_connection(HIGH_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: HIGH_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device1_signal.reset();
+
+            assert_consumer_connected(
+                service_receiver,
+                device1,
+                ConsumerPowerCapability {
+                    capability: HIGH_POWER,
+                    flags: ConsumerFlags::none(),
+                },
+            )
+            .await;
+        }
+
+        // Device0 connection at low power
+        // Since we're using a custom hook, we expect to switch to it
+        {
+            device0
+                .lock()
+                .await
+                .simulate_consumer_connection(LOW_POWER.into())
+                .await;
+
+            assert_eq!(
+                with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+                (
+                    1,
+                    FnCall::ConnectConsumer(ConsumerPowerCapability {
+                        capability: LOW_POWER,
+                        flags: ConsumerFlags::none(),
+                    })
+                )
+            );
+            device0_signal.reset();
+
+            // Should receive a disconnect event from device1 first
+            assert_consumer_disconnected(service_receiver, device1).await;
+
+            assert_consumer_connected(
+                service_receiver,
+                device0,
+                ConsumerPowerCapability {
+                    capability: LOW_POWER,
+                    flags: ConsumerFlags::none(),
+                },
+            )
+            .await;
+        }
+    }
+}
+
 #[tokio::test]
 async fn run_test_swap_higher() {
-    run_test(DEFAULT_TIMEOUT, TestSwapHigher, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestSwapHigher, Default::default(), DefaultHooks).await;
 }
 
 #[tokio::test]
 async fn run_test_single() {
-    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default(), DefaultHooks).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect() {
-    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default(), DefaultHooks).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect_other_consumer() {
-    run_test(DEFAULT_TIMEOUT, TestDisconnectOtherConsumer, Default::default()).await;
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestDisconnectOtherConsumer,
+        Default::default(),
+        DefaultHooks,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect_other_provider() {
-    run_test(DEFAULT_TIMEOUT, TestDisconnectOtherProvider, Default::default()).await;
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestDisconnectOtherProvider,
+        Default::default(),
+        DefaultHooks,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -690,10 +833,21 @@ async fn run_test_min_consumer_power() {
     let mut config = Config::default();
     config.min_consumer_threshold_mw = Some(MIN_CONSUMER_THRESHOLD_MW);
 
-    run_test(DEFAULT_TIMEOUT, TestMinConsumerPower, config).await;
+    run_test(DEFAULT_TIMEOUT, TestMinConsumerPower, config, DefaultHooks).await;
 }
 
 #[tokio::test]
 async fn run_test_no_swap() {
-    run_test(DEFAULT_TIMEOUT, TestNoSwap, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestNoSwap, Default::default(), DefaultHooks).await;
+}
+
+#[tokio::test]
+async fn run_test_find_best_consumer_hook() {
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestFindBestConsumerHook,
+        Default::default(),
+        AlwaysFirstConsumerHooks,
+    )
+    .await;
 }

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -19,8 +19,8 @@ use power_policy_service::service::config::Config;
 use power_policy_service::service::consumer::AvailableConsumer;
 use power_policy_service::service::consumer::cmp_consumer_capability_default;
 use power_policy_service::service::consumer::find_best_consumer_default;
-use power_policy_service::service::hooks;
-use power_policy_service::service::hooks::DefaultHooks;
+use power_policy_service::service::customization;
+use power_policy_service::service::customization::DefaultCustomization;
 use power_policy_service::service::registration::Registration;
 
 use crate::common::DeviceType;
@@ -41,11 +41,11 @@ const MIN_CONSUMER_THRESHOLD_MW: u32 = 7500;
 struct TestSingle;
 
 impl Test for TestSingle {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -110,11 +110,11 @@ impl Test for TestSingle {
 struct TestSwapHigher;
 
 impl Test for TestSwapHigher {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -244,11 +244,11 @@ impl Test for TestSwapHigher {
 struct TestDisconnect;
 
 impl Test for TestDisconnect {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -379,11 +379,11 @@ impl Test for TestDisconnect {
 struct TestDisconnectOtherConsumer;
 
 impl Test for TestDisconnectOtherConsumer {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -468,11 +468,11 @@ impl Test for TestDisconnectOtherConsumer {
 struct TestDisconnectOtherProvider;
 
 impl Test for TestDisconnectOtherProvider {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -569,11 +569,11 @@ impl Test for TestDisconnectOtherProvider {
 struct TestMinConsumerPower;
 
 impl Test for TestMinConsumerPower {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -609,11 +609,11 @@ impl Test for TestMinConsumerPower {
 struct TestNoSwap;
 
 impl Test for TestNoSwap {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -684,10 +684,10 @@ impl Test for TestNoSwap {
     }
 }
 
-/// Power policy hooks that always returns the first PSU if it's available
-struct AlwaysFirstConsumerHooks;
+/// Power policy customization that always returns the first PSU if it's available
+struct AlwaysFirstConsumerCustomization;
 
-impl hooks::Hooks for AlwaysFirstConsumerHooks {
+impl customization::Customization for AlwaysFirstConsumerCustomization {
     async fn find_best_consumer<'device, Reg: Registration<'device>>(
         &mut self,
         config: &Config,
@@ -706,15 +706,15 @@ impl hooks::Hooks for AlwaysFirstConsumerHooks {
     }
 }
 
-/// Verify that [`hooks::Hooks::find_find_best_consumer`] is called
+/// Verify that [`customization::Customization::find_find_best_consumer`] is called
 struct TestFindBestConsumerHook;
 
 impl Test for TestFindBestConsumerHook {
-    type Hooks = AlwaysFirstConsumerHooks;
+    type Customization = AlwaysFirstConsumerCustomization;
 
     async fn run<'a>(
         &mut self,
-        _service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        _service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -793,17 +793,29 @@ impl Test for TestFindBestConsumerHook {
 
 #[tokio::test]
 async fn run_test_swap_higher() {
-    run_test(DEFAULT_TIMEOUT, TestSwapHigher, Default::default(), DefaultHooks).await;
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestSwapHigher,
+        Default::default(),
+        DefaultCustomization,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn run_test_single() {
-    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default(), DefaultHooks).await;
+    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default(), DefaultCustomization).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect() {
-    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default(), DefaultHooks).await;
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestDisconnect,
+        Default::default(),
+        DefaultCustomization,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -812,7 +824,7 @@ async fn run_test_disconnect_other_consumer() {
         DEFAULT_TIMEOUT,
         TestDisconnectOtherConsumer,
         Default::default(),
-        DefaultHooks,
+        DefaultCustomization,
     )
     .await;
 }
@@ -823,7 +835,7 @@ async fn run_test_disconnect_other_provider() {
         DEFAULT_TIMEOUT,
         TestDisconnectOtherProvider,
         Default::default(),
-        DefaultHooks,
+        DefaultCustomization,
     )
     .await;
 }
@@ -833,12 +845,12 @@ async fn run_test_min_consumer_power() {
     let mut config = Config::default();
     config.min_consumer_threshold_mw = Some(MIN_CONSUMER_THRESHOLD_MW);
 
-    run_test(DEFAULT_TIMEOUT, TestMinConsumerPower, config, DefaultHooks).await;
+    run_test(DEFAULT_TIMEOUT, TestMinConsumerPower, config, DefaultCustomization).await;
 }
 
 #[tokio::test]
 async fn run_test_no_swap() {
-    run_test(DEFAULT_TIMEOUT, TestNoSwap, Default::default(), DefaultHooks).await;
+    run_test(DEFAULT_TIMEOUT, TestNoSwap, Default::default(), DefaultCustomization).await;
 }
 
 #[tokio::test]
@@ -847,7 +859,7 @@ async fn run_test_find_best_consumer_hook() {
         DEFAULT_TIMEOUT,
         TestFindBestConsumerHook,
         Default::default(),
-        AlwaysFirstConsumerHooks,
+        AlwaysFirstConsumerCustomization,
     )
     .await;
 }

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -706,10 +706,10 @@ impl customization::Customization for AlwaysFirstConsumerCustomization {
     }
 }
 
-/// Verify that [`customization::Customization::find_find_best_consumer`] is called
-struct TestFindBestConsumerHook;
+/// Verify that [`customization::Customization::find_best_consumer`] is called
+struct TestFindBestConsumerCustomization;
 
-impl Test for TestFindBestConsumerHook {
+impl Test for TestFindBestConsumerCustomization {
     type Customization = AlwaysFirstConsumerCustomization;
 
     async fn run<'a>(
@@ -721,7 +721,7 @@ impl Test for TestFindBestConsumerHook {
         device1: &DeviceType<'a>,
         device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
     ) {
-        info!("Running TestFindBestConsumerHook");
+        info!("Running TestFindBestConsumerCustomization");
 
         // Device1 connection at high power
         {
@@ -857,7 +857,7 @@ async fn run_test_no_swap() {
 async fn run_test_find_best_consumer_hook() {
     run_test(
         DEFAULT_TIMEOUT,
-        TestFindBestConsumerHook,
+        TestFindBestConsumerCustomization,
         Default::default(),
         AlwaysFirstConsumerCustomization,
     )

--- a/power-policy-service/tests/provider.rs
+++ b/power-policy-service/tests/provider.rs
@@ -11,7 +11,7 @@ mod common;
 
 use common::{LOW_POWER, ServiceMutex};
 use power_policy_interface::service::event::Event as ServiceEvent;
-use power_policy_service::service::hooks::DefaultHooks;
+use power_policy_service::service::customization::DefaultCustomization;
 
 use crate::common::DeviceType;
 use crate::common::HIGH_POWER;
@@ -25,11 +25,11 @@ const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 struct TestSingle;
 
 impl Test for TestSingle {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        _service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        _service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -85,11 +85,11 @@ impl Test for TestSingle {
 struct TestUpgrade;
 
 impl Test for TestUpgrade {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -244,11 +244,11 @@ impl Test for TestUpgrade {
 struct TestDisconnect;
 
 impl Test for TestDisconnect {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -304,15 +304,21 @@ impl Test for TestDisconnect {
 
 #[tokio::test]
 async fn run_test_single() {
-    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default(), DefaultHooks).await;
+    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default(), DefaultCustomization).await;
 }
 
 #[tokio::test]
 async fn run_test_upgrade() {
-    run_test(DEFAULT_TIMEOUT, TestUpgrade, Default::default(), DefaultHooks).await;
+    run_test(DEFAULT_TIMEOUT, TestUpgrade, Default::default(), DefaultCustomization).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect() {
-    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default(), DefaultHooks).await;
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestDisconnect,
+        Default::default(),
+        DefaultCustomization,
+    )
+    .await;
 }

--- a/power-policy-service/tests/provider.rs
+++ b/power-policy-service/tests/provider.rs
@@ -11,6 +11,7 @@ mod common;
 
 use common::{LOW_POWER, ServiceMutex};
 use power_policy_interface::service::event::Event as ServiceEvent;
+use power_policy_service::service::hooks::DefaultHooks;
 
 use crate::common::DeviceType;
 use crate::common::HIGH_POWER;
@@ -24,9 +25,11 @@ const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 struct TestSingle;
 
 impl Test for TestSingle {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        _service: &ServiceMutex<'a, 'a>,
+        _service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -82,9 +85,11 @@ impl Test for TestSingle {
 struct TestUpgrade;
 
 impl Test for TestUpgrade {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -239,9 +244,11 @@ impl Test for TestUpgrade {
 struct TestDisconnect;
 
 impl Test for TestDisconnect {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        service: &ServiceMutex<'a, 'a>,
+        service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -297,15 +304,15 @@ impl Test for TestDisconnect {
 
 #[tokio::test]
 async fn run_test_single() {
-    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestSingle, Default::default(), DefaultHooks).await;
 }
 
 #[tokio::test]
 async fn run_test_upgrade() {
-    run_test(DEFAULT_TIMEOUT, TestUpgrade, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestUpgrade, Default::default(), DefaultHooks).await;
 }
 
 #[tokio::test]
 async fn run_test_disconnect() {
-    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestDisconnect, Default::default(), DefaultHooks).await;
 }

--- a/power-policy-service/tests/unconstrained.rs
+++ b/power-policy-service/tests/unconstrained.rs
@@ -12,7 +12,7 @@ mod common;
 use common::LOW_POWER;
 use power_policy_interface::service::UnconstrainedState;
 use power_policy_interface::service::event::Event as ServiceEvent;
-use power_policy_service::service::hooks::DefaultHooks;
+use power_policy_service::service::customization::DefaultCustomization;
 
 use crate::common::HIGH_POWER;
 use crate::common::{
@@ -27,11 +27,11 @@ const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 struct TestUnconstrained;
 
 impl Test for TestUnconstrained {
-    type Hooks = DefaultHooks;
+    type Customization = DefaultCustomization;
 
     async fn run<'a>(
         &mut self,
-        _service: &ServiceMutex<'a, 'a, Self::Hooks>,
+        _service: &ServiceMutex<'a, 'a, Self::Customization>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -176,5 +176,11 @@ impl Test for TestUnconstrained {
 
 #[tokio::test]
 async fn run_test_unconstrained() {
-    run_test(DEFAULT_TIMEOUT, TestUnconstrained, Default::default(), DefaultHooks).await;
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestUnconstrained,
+        Default::default(),
+        DefaultCustomization,
+    )
+    .await;
 }

--- a/power-policy-service/tests/unconstrained.rs
+++ b/power-policy-service/tests/unconstrained.rs
@@ -12,6 +12,7 @@ mod common;
 use common::LOW_POWER;
 use power_policy_interface::service::UnconstrainedState;
 use power_policy_interface::service::event::Event as ServiceEvent;
+use power_policy_service::service::hooks::DefaultHooks;
 
 use crate::common::HIGH_POWER;
 use crate::common::{
@@ -26,9 +27,11 @@ const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
 struct TestUnconstrained;
 
 impl Test for TestUnconstrained {
+    type Hooks = DefaultHooks;
+
     async fn run<'a>(
         &mut self,
-        _service: &ServiceMutex<'a, 'a>,
+        _service: &ServiceMutex<'a, 'a, Self::Hooks>,
         service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
         device0: &DeviceType<'a>,
         device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
@@ -173,5 +176,5 @@ impl Test for TestUnconstrained {
 
 #[tokio::test]
 async fn run_test_unconstrained() {
-    run_test(DEFAULT_TIMEOUT, TestUnconstrained, Default::default()).await;
+    run_test(DEFAULT_TIMEOUT, TestUnconstrained, Default::default(), DefaultHooks).await;
 }


### PR DESCRIPTION
OEMs may want to provide their own behavior to determine which PSU is selected as the next consumer. Introduce a `Customization` trait to contain this and anything else that may be needed in the future.