### PR TITLE
keyboard-service: Add constructor to HidReportSlice

### DIFF
--- a/keyboard-service/src/lib.rs
+++ b/keyboard-service/src/lib.rs
@@ -40,7 +40,14 @@ pub enum KeyboardError {
 /// The HID backend will add the appropriate header for underlying protocol (e.g. HID over i2c header).
 pub struct HidReportSlice<'a>(&'a [u8]);
 
-impl HidReportSlice<'_> {
+impl<'a> HidReportSlice<'a> {
+    /// Creates a new HID report slice from a raw byte slice.
+    ///
+    /// The slice should contain a single key modifiers byte followed by KRO usage codes.
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self(bytes)
+    }
+
     /// Returns the HID report as a raw byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         self.0

--- a/keyboard-service/src/lib.rs
+++ b/keyboard-service/src/lib.rs
@@ -44,7 +44,7 @@ impl<'a> HidReportSlice<'a> {
     /// Creates a new HID report slice from a raw byte slice.
     ///
     /// The slice should contain a single key modifiers byte followed by KRO usage codes.
-    pub fn new(bytes: &'a [u8]) -> Self {
+    pub const fn new(bytes: &'a [u8]) -> Self {
         Self(bytes)
     }
 


### PR DESCRIPTION
There was no way previously to actually create a `HidReportSlice` (since the wrapped slice is not public) from outside this crate, so add a public constructor so people can actually implement their own HID keyboard.

Context: Just discovered this issue when creating a virtual UART keyboard demo and had to create my own custom keyboard implementation (as opposed to the given GPIO-based keyboard).