### PR TITLE
Make battery data caches OEM extensible

### DIFF
--- a/battery-service-interface/src/fuel_gauge.rs
+++ b/battery-service-interface/src/fuel_gauge.rs
@@ -11,7 +11,11 @@ use core::future::Future;
 
 use embedded_batteries_async::{
     acpi::{BmcControlFlags, BmdCapabilityFlags, BmdStatusFlags, PowerThresholdSupport},
-    smart_battery::BatteryModeFields,
+    charger::{MilliAmps, MilliVolts},
+    smart_battery::{
+        BatteryModeFields, CapacityModeSignedValue, CapacityModeValue, Cycles, DeciKelvin, ManufactureDate,
+        MilliAmpsSigned, Minutes, Percent,
+    },
 };
 
 /// Fuel gauge errors.
@@ -43,7 +47,7 @@ pub const DEVICE_CHEMISTRY_ID_SIZE: usize = 2;
 pub const SERIAL_NUM_SIZE: usize = 4;
 
 /// Standard static battery data cache.
-#[derive(Default, Clone, Copy)]
+#[derive(Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StaticBatteryMsgs {
     /// Manufacturer Name.
@@ -55,11 +59,11 @@ pub struct StaticBatteryMsgs {
     /// Device Chemistry.
     pub device_chemistry: [u8; DEVICE_CHEMISTRY_SIZE],
 
-    /// Design Capacity in mWh.
-    pub design_capacity_mwh: u32,
+    /// Design Capacity. Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub design_capacity: CapacityModeValue,
 
     /// Design Voltage in mV.
-    pub design_voltage_mv: u16,
+    pub design_voltage: MilliVolts,
 
     /// Device Chemistry Id.
     pub device_chemistry_id: [u8; DEVICE_CHEMISTRY_ID_SIZE],
@@ -70,94 +74,278 @@ pub struct StaticBatteryMsgs {
     /// Battery Mode.
     pub battery_mode: BatteryModeFields,
 
-    pub design_cap_warning: u32,
+    /// Warning (OEM-designed) capacity threshold.
+    ///
+    /// Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub design_cap_warning: CapacityModeValue,
 
-    pub design_cap_low: u32,
+    /// Low (OEM-designed) capacity threshold.
+    ///
+    /// Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub design_cap_low: CapacityModeValue,
 
+    /// Measurement accuracy in thousandths of a percent (e.g. `80_000` = 80.000%).
     pub measurement_accuracy: u32,
 
+    /// Maximum supported sampling time, in milliseconds.
     pub max_sample_time: u32,
 
+    /// Minimum supported sampling time, in milliseconds.
     pub min_sample_time: u32,
 
+    /// Maximum supported averaging interval, in milliseconds.
     pub max_averaging_interval: u32,
 
+    /// Minimum supported averaging interval, in milliseconds.
     pub min_averaging_interval: u32,
 
-    pub cap_granularity_1: u32,
+    /// Capacity measurement granularity between the low and warning thresholds.
+    ///
+    /// Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub cap_granularity_1: CapacityModeValue,
 
-    pub cap_granularity_2: u32,
+    /// Capacity measurement granularity between the warning and full thresholds.
+    ///
+    /// Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub cap_granularity_2: CapacityModeValue,
 
+    /// Which peak-power thresholds the platform supports (ACPI `_BPC`).
     pub power_threshold_support: PowerThresholdSupport,
 
+    /// Maximum supported threshold for instantaneous peak power, in mW.
     pub max_instant_pwr_threshold: u32,
 
+    /// Maximum supported threshold for sustainable peak power, in mW.
     pub max_sus_pwr_threshold: u32,
 
+    /// Battery maintenance control flags configuring calibration and charger behavior (ACPI `_BMC`).
     pub bmc_flags: BmcControlFlags,
 
+    /// Battery maintenance capability flags indicating supported maintenance features (ACPI `_BMD`).
     pub bmd_capability: BmdCapabilityFlags,
 
+    /// Recommended recalibration count.
+    ///
+    /// `0` means only recalibrate when the recalibration status flag is set;
+    /// otherwise recalibrate after this many battery cycles.
     pub bmd_recalibrate_count: u32,
 
+    /// Estimated time, in seconds, to recalibrate if the system enters standby.
+    ///
+    /// `0` indicates standby is not supported and `0xFFFF_FFFF` indicates the
+    /// time is unknown.
     pub bmd_quick_recalibrate_time: u32,
 
+    /// Estimated time, in seconds, to recalibrate without standby.
+    ///
+    /// `0` indicates calibration may not succeed and `0xFFFF_FFFF` indicates the
+    /// time is unknown.
     pub bmd_slow_recalibrate_time: u32,
+
+    /// Manufacture Date. Fixed manufacturing datum, so cached as static data.
+    pub manufacture_date: ManufactureDate,
+
+    /// Specification Info, stored as the raw `u16` bitfield representation.
+    pub specification_info: u16,
+
+    /// Remaining (low) Capacity Alarm threshold. Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub remaining_capacity_alarm: CapacityModeValue,
+
+    /// Remaining Time Alarm threshold in minutes.
+    pub remaining_time_alarm: Minutes,
+}
+
+impl Default for StaticBatteryMsgs {
+    fn default() -> Self {
+        Self {
+            // Capacity quantities default to the mA variant (matching the SBS
+            // default capacity mode); they have no `Default` of their own.
+            design_capacity: CapacityModeValue::MilliAmpUnsigned(0),
+            remaining_capacity_alarm: CapacityModeValue::MilliAmpUnsigned(0),
+            design_cap_warning: CapacityModeValue::MilliAmpUnsigned(0),
+            design_cap_low: CapacityModeValue::MilliAmpUnsigned(0),
+            cap_granularity_1: CapacityModeValue::MilliAmpUnsigned(0),
+            cap_granularity_2: CapacityModeValue::MilliAmpUnsigned(0),
+            manufacturer_name: Default::default(),
+            device_name: Default::default(),
+            device_chemistry: Default::default(),
+            design_voltage: Default::default(),
+            device_chemistry_id: Default::default(),
+            serial_num: Default::default(),
+            battery_mode: Default::default(),
+            measurement_accuracy: Default::default(),
+            max_sample_time: Default::default(),
+            min_sample_time: Default::default(),
+            max_averaging_interval: Default::default(),
+            min_averaging_interval: Default::default(),
+            power_threshold_support: Default::default(),
+            max_instant_pwr_threshold: Default::default(),
+            max_sus_pwr_threshold: Default::default(),
+            bmc_flags: Default::default(),
+            bmd_capability: Default::default(),
+            bmd_recalibrate_count: Default::default(),
+            bmd_quick_recalibrate_time: Default::default(),
+            bmd_slow_recalibrate_time: Default::default(),
+            manufacture_date: Default::default(),
+            specification_info: Default::default(),
+            remaining_time_alarm: Default::default(),
+        }
+    }
 }
 
 /// Standard dynamic battery data cache.
-#[derive(Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DynamicBatteryMsgs {
     /// Battery Max Power in mW.
-    pub max_power_mw: u32,
+    pub max_power: u32,
 
     /// Battery Sustained Power in mW.
-    pub sus_power_mw: u32,
+    pub sus_power: u32,
 
     /// Turbo Load Voltage in mV.
-    pub turbo_vload_mv: u32,
+    pub turbo_vload: u32,
 
     /// Turbo RHF Effective in mOhm.
-    pub turbo_rhf_effective_mohm: u32,
+    pub turbo_rhf_effective: u32,
 
-    /// Full Charge Capacity in mWh.
-    pub full_charge_capacity_mwh: u32,
+    /// Full Charge Capacity. Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub full_charge_capacity: CapacityModeValue,
 
-    /// Remaining Capacity in mWh.
-    pub remaining_capacity_mwh: u32,
+    /// Remaining Capacity. Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
+    pub remaining_capacity: CapacityModeValue,
 
     /// Rsoc in %.
-    pub relative_soc_pct: u16,
+    pub relative_soc: Percent,
 
     /// Charge/Discharge Cycle Count.
-    pub cycle_count: u16,
+    pub cycle_count: Cycles,
 
     /// Battery Voltage in mV.
-    pub voltage_mv: u16,
+    pub voltage: MilliVolts,
 
     /// Maximum Error in %.
-    pub max_error_pct: u16,
+    pub max_error: Percent,
 
     /// Battery Status (Standard Smart Battery Defined).
     pub battery_status: u16,
 
     /// Desired Charging Voltage in mV.
-    pub charging_voltage_mv: u16,
+    pub charging_voltage: MilliVolts,
 
     /// Desired Charging Current in mA.
-    pub charging_current_ma: u16,
+    pub charging_current: MilliAmps,
 
     /// Battery Temperature in dK.
-    pub battery_temp_dk: u16,
+    pub battery_temp: DeciKelvin,
 
     /// Battery Current in mA.
-    pub current_ma: i16,
+    pub current: MilliAmpsSigned,
 
     /// Battery Avg Current.
-    pub average_current_ma: i16,
+    pub average_current: MilliAmpsSigned,
 
+    /// Battery maintenance status flags indicating the current battery maintenance state (ACPI `_BMD`).
     pub bmd_status: BmdStatusFlags,
+
+    /// Absolute State of Charge in % (relative to design capacity).
+    pub absolute_soc: Percent,
+
+    /// AtRate value. Units (mA or centiWatt) are encoded by the [`CapacityModeSignedValue`] variant.
+    ///
+    /// Host-written scratch value that drives the AtRate predictions below, so
+    /// cached as dynamic data.
+    pub at_rate: CapacityModeSignedValue,
+
+    /// Whether the battery can supply the AtRate value for at least 10 seconds.
+    pub at_rate_ok: bool,
+
+    /// Predicted time to fully charge at the AtRate value, in minutes.
+    pub at_rate_time_to_full: Minutes,
+
+    /// Predicted time to fully discharge at the AtRate value, in minutes.
+    pub at_rate_time_to_empty: Minutes,
+
+    /// Predicted remaining run time to empty at the present discharge rate, in minutes.
+    pub run_time_to_empty: Minutes,
+
+    /// Averaged time to empty, in minutes.
+    pub average_time_to_empty: Minutes,
+
+    /// Averaged time to full, in minutes.
+    pub average_time_to_full: Minutes,
+}
+
+impl Default for DynamicBatteryMsgs {
+    fn default() -> Self {
+        Self {
+            // Capacity/rate quantities default to the mA variant (matching the
+            // SBS default capacity mode); they have no `Default` of their own.
+            full_charge_capacity: CapacityModeValue::MilliAmpUnsigned(0),
+            remaining_capacity: CapacityModeValue::MilliAmpUnsigned(0),
+            at_rate: CapacityModeSignedValue::MilliAmpSigned(0),
+            max_power: Default::default(),
+            sus_power: Default::default(),
+            turbo_vload: Default::default(),
+            turbo_rhf_effective: Default::default(),
+            relative_soc: Default::default(),
+            cycle_count: Default::default(),
+            voltage: Default::default(),
+            max_error: Default::default(),
+            battery_status: Default::default(),
+            charging_voltage: Default::default(),
+            charging_current: Default::default(),
+            battery_temp: Default::default(),
+            current: Default::default(),
+            average_current: Default::default(),
+            bmd_status: Default::default(),
+            absolute_soc: Default::default(),
+            at_rate_ok: Default::default(),
+            at_rate_time_to_full: Default::default(),
+            at_rate_time_to_empty: Default::default(),
+            run_time_to_empty: Default::default(),
+            average_time_to_empty: Default::default(),
+            average_time_to_full: Default::default(),
+        }
+    }
+}
+
+/// Access to the standard [`StaticBatteryMsgs`] within a static battery data type.
+///
+/// The battery service answers standard ACPI queries from the fields in
+/// [`StaticBatteryMsgs`]. A [`FuelGauge`] may cache [`StaticBatteryMsgs`] directly
+/// (the default) or a custom OEM type that embeds it and adds extra fields. In the
+/// latter case the custom type implements this trait so the service can still read
+/// the standard fields, while OEM code reads the extended data from the concrete
+/// type via [`State::static_cache`].
+pub trait StaticBatteryData {
+    /// Returns a reference to the standard static battery data.
+    fn standard(&self) -> &StaticBatteryMsgs;
+}
+
+impl StaticBatteryData for StaticBatteryMsgs {
+    fn standard(&self) -> &StaticBatteryMsgs {
+        self
+    }
+}
+
+/// Access to the standard [`DynamicBatteryMsgs`] within a dynamic battery data type.
+///
+/// The battery service answers standard ACPI queries from the fields in
+/// [`DynamicBatteryMsgs`]. A [`FuelGauge`] may cache [`DynamicBatteryMsgs`] directly
+/// (the default) or a custom OEM type that embeds it and adds extra fields. In the
+/// latter case the custom type implements this trait so the service can still read
+/// the standard fields, while OEM code reads the extended data from the concrete
+/// type via [`State::dynamic_cache`].
+pub trait DynamicBatteryData {
+    /// Returns a reference to the standard dynamic battery data.
+    fn standard(&self) -> &DynamicBatteryMsgs;
+}
+
+impl DynamicBatteryData for DynamicBatteryMsgs {
+    fn standard(&self) -> &DynamicBatteryMsgs {
+        self
+    }
 }
 
 /// Operational state substates.
@@ -196,27 +384,42 @@ pub enum InternalState {
 /// This holds both the fuel gauge state machine state and the cached static and
 /// dynamic battery data. The battery service reads this state (via
 /// [`FuelGauge::state`]) when answering ACPI queries.
+///
+/// The cached data types are generic and default to the standard
+/// [`StaticBatteryMsgs`] / [`DynamicBatteryMsgs`]. OEMs may substitute custom
+/// types that embed the standard data and implement [`StaticBatteryData`] /
+/// [`DynamicBatteryData`] to expose it to the service.
 #[derive(Default)]
-pub struct State {
+pub struct State<S: StaticBatteryData = StaticBatteryMsgs, D: DynamicBatteryData = DynamicBatteryMsgs> {
     state: InternalState,
-    static_cache: StaticBatteryMsgs,
-    dynamic_cache: DynamicBatteryMsgs,
+    static_cache: S,
+    dynamic_cache: D,
 }
 
-impl State {
+impl<S: StaticBatteryData, D: DynamicBatteryData> State<S, D> {
     /// The current internal state.
     pub fn internal_state(&self) -> InternalState {
         self.state
     }
 
     /// A reference to the cached static battery data.
-    pub fn static_cache(&self) -> &StaticBatteryMsgs {
+    pub fn static_cache(&self) -> &S {
         &self.static_cache
     }
 
+    /// A mutable reference to the cached static battery data.
+    pub fn static_cache_mut(&mut self) -> &mut S {
+        &mut self.static_cache
+    }
+
     /// A reference to the cached dynamic battery data.
-    pub fn dynamic_cache(&self) -> &DynamicBatteryMsgs {
+    pub fn dynamic_cache(&self) -> &D {
         &self.dynamic_cache
+    }
+
+    /// A mutable reference to the cached dynamic battery data.
+    pub fn dynamic_cache_mut(&mut self) -> &mut D {
+        &mut self.dynamic_cache
     }
 
     /// Returns `true` if the fuel gauge is present.
@@ -245,24 +448,29 @@ impl State {
         self.state = InternalState::Present(PresentSubstate::Operational(OperationalSubstate::Init));
     }
 
-    /// Cache freshly read static battery data.
+    /// Update the cached static battery data in place.
     ///
-    /// If the fuel gauge is operational this also advances the state to
-    /// `Present(Operational(Polling))`. Should be called by the driver after a
-    /// successful static-data read.
-    pub fn on_static_data(&mut self, data: StaticBatteryMsgs) {
-        self.static_cache = data;
+    /// The `update` closure is given a mutable reference to the cached data and
+    /// writes the freshly read values directly into it, so a (potentially large)
+    /// `S` is never moved or copied through this call. If the fuel gauge is
+    /// operational this also advances the state to `Present(Operational(Polling))`.
+    /// Should be called by the driver after a successful static-data read.
+    pub fn on_static_data(&mut self, update: impl FnOnce(&mut S)) {
+        update(&mut self.static_cache);
         if self.is_operational() {
             self.state = InternalState::Present(PresentSubstate::Operational(OperationalSubstate::Polling));
         }
     }
 
-    /// Cache freshly read dynamic battery data.
+    /// Update the cached dynamic battery data in place.
     ///
-    /// Should be called by the driver after a successful dynamic-data read while
-    /// in the `Present(Operational(Polling))` state.
-    pub fn on_dynamic_data(&mut self, data: DynamicBatteryMsgs) {
-        self.dynamic_cache = data;
+    /// The `update` closure is given a mutable reference to the cached data and
+    /// writes the freshly read values directly into it, so a (potentially large)
+    /// `D` is never moved or copied through this call. Should be called by the
+    /// driver after a successful dynamic-data read while in the
+    /// `Present(Operational(Polling))` state.
+    pub fn on_dynamic_data(&mut self, update: impl FnOnce(&mut D)) {
+        update(&mut self.dynamic_cache);
     }
 
     /// Handle a communication timeout.
@@ -296,6 +504,18 @@ pub trait FuelGauge: embedded_batteries_async::smart_battery::SmartBattery {
     /// Type of error returned by the fuel gauge hardware.
     type FuelGaugeError: Into<FuelGaugeError> + embedded_batteries_async::smart_battery::Error;
 
+    /// The cached static battery data type.
+    ///
+    /// Use [`StaticBatteryMsgs`] (the standard data) directly, or a custom OEM
+    /// type that embeds it and implements [`StaticBatteryData`] to add extra fields.
+    type StaticData: StaticBatteryData;
+
+    /// The cached dynamic battery data type.
+    ///
+    /// Use [`DynamicBatteryMsgs`] (the standard data) directly, or a custom OEM
+    /// type that embeds it and implements [`DynamicBatteryData`] to add extra fields.
+    type DynamicData: DynamicBatteryData;
+
     /// Initialize the fuel gauge hardware.
     ///
     /// The driver should call [`State::on_initialized`] after a successful
@@ -319,8 +539,8 @@ pub trait FuelGauge: embedded_batteries_async::smart_battery::SmartBattery {
     fn update_dynamic_data(&mut self) -> impl Future<Output = Result<(), Self::FuelGaugeError>>;
 
     /// Return an immutable reference to the current fuel gauge state.
-    fn state(&self) -> &State;
+    fn state(&self) -> &State<Self::StaticData, Self::DynamicData>;
 
     /// Return a mutable reference to the current fuel gauge state.
-    fn state_mut(&mut self) -> &mut State;
+    fn state_mut(&mut self) -> &mut State<Self::StaticData, Self::DynamicData>;
 }

--- a/battery-service-interface/src/fuel_gauge.rs
+++ b/battery-service-interface/src/fuel_gauge.rs
@@ -88,16 +88,16 @@ pub struct StaticBatteryMsgs {
     pub measurement_accuracy: u32,
 
     /// Maximum supported sampling time, in milliseconds.
-    pub max_sample_time: u32,
+    pub max_sample_time_ms: u32,
 
     /// Minimum supported sampling time, in milliseconds.
-    pub min_sample_time: u32,
+    pub min_sample_time_ms: u32,
 
     /// Maximum supported averaging interval, in milliseconds.
-    pub max_averaging_interval: u32,
+    pub max_averaging_interval_ms: u32,
 
     /// Minimum supported averaging interval, in milliseconds.
-    pub min_averaging_interval: u32,
+    pub min_averaging_interval_ms: u32,
 
     /// Capacity measurement granularity between the low and warning thresholds.
     ///
@@ -113,10 +113,10 @@ pub struct StaticBatteryMsgs {
     pub power_threshold_support: PowerThresholdSupport,
 
     /// Maximum supported threshold for instantaneous peak power, in mW.
-    pub max_instant_pwr_threshold: u32,
+    pub max_instant_pwr_threshold_mw: u32,
 
     /// Maximum supported threshold for sustainable peak power, in mW.
-    pub max_sus_pwr_threshold: u32,
+    pub max_sus_pwr_threshold_mw: u32,
 
     /// Battery maintenance control flags configuring calibration and charger behavior (ACPI `_BMC`).
     pub bmc_flags: BmcControlFlags,
@@ -134,13 +134,13 @@ pub struct StaticBatteryMsgs {
     ///
     /// `0` indicates standby is not supported and `0xFFFF_FFFF` indicates the
     /// time is unknown.
-    pub bmd_quick_recalibrate_time: u32,
+    pub bmd_quick_recalibrate_time_s: u32,
 
     /// Estimated time, in seconds, to recalibrate without standby.
     ///
     /// `0` indicates calibration may not succeed and `0xFFFF_FFFF` indicates the
     /// time is unknown.
-    pub bmd_slow_recalibrate_time: u32,
+    pub bmd_slow_recalibrate_time_s: u32,
 
     /// Manufacture Date. Fixed manufacturing datum, so cached as static data.
     pub manufacture_date: ManufactureDate,
@@ -174,18 +174,18 @@ impl Default for StaticBatteryMsgs {
             serial_num: Default::default(),
             battery_mode: Default::default(),
             measurement_accuracy: Default::default(),
-            max_sample_time: Default::default(),
-            min_sample_time: Default::default(),
-            max_averaging_interval: Default::default(),
-            min_averaging_interval: Default::default(),
+            max_sample_time_ms: Default::default(),
+            min_sample_time_ms: Default::default(),
+            max_averaging_interval_ms: Default::default(),
+            min_averaging_interval_ms: Default::default(),
             power_threshold_support: Default::default(),
-            max_instant_pwr_threshold: Default::default(),
-            max_sus_pwr_threshold: Default::default(),
+            max_instant_pwr_threshold_mw: Default::default(),
+            max_sus_pwr_threshold_mw: Default::default(),
             bmc_flags: Default::default(),
             bmd_capability: Default::default(),
             bmd_recalibrate_count: Default::default(),
-            bmd_quick_recalibrate_time: Default::default(),
-            bmd_slow_recalibrate_time: Default::default(),
+            bmd_quick_recalibrate_time_s: Default::default(),
+            bmd_slow_recalibrate_time_s: Default::default(),
             manufacture_date: Default::default(),
             specification_info: Default::default(),
             remaining_time_alarm: Default::default(),
@@ -198,16 +198,16 @@ impl Default for StaticBatteryMsgs {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DynamicBatteryMsgs {
     /// Battery Max Power in mW.
-    pub max_power: u32,
+    pub max_power_mw: u32,
 
     /// Battery Sustained Power in mW.
-    pub sus_power: u32,
+    pub sus_power_mw: u32,
 
     /// Turbo Load Voltage in mV.
-    pub turbo_vload: u32,
+    pub turbo_vload: MilliVolts,
 
     /// Turbo RHF Effective in mOhm.
-    pub turbo_rhf_effective: u32,
+    pub turbo_rhf_effective_mohm: u32,
 
     /// Full Charge Capacity. Units (mA/mAh or centiWatt) are encoded by the [`CapacityModeValue`] variant.
     pub full_charge_capacity: CapacityModeValue,
@@ -284,10 +284,10 @@ impl Default for DynamicBatteryMsgs {
             full_charge_capacity: CapacityModeValue::MilliAmpUnsigned(0),
             remaining_capacity: CapacityModeValue::MilliAmpUnsigned(0),
             at_rate: CapacityModeSignedValue::MilliAmpSigned(0),
-            max_power: Default::default(),
-            sus_power: Default::default(),
+            max_power_mw: Default::default(),
+            sus_power_mw: Default::default(),
             turbo_vload: Default::default(),
-            turbo_rhf_effective: Default::default(),
+            turbo_rhf_effective_mohm: Default::default(),
             relative_soc: Default::default(),
             cycle_count: Default::default(),
             voltage: Default::default(),

--- a/battery-service/src/acpi.rs
+++ b/battery-service/src/acpi.rs
@@ -73,10 +73,10 @@ pub(crate) fn compute_bix<S: StaticBatteryData, D: DynamicBatteryData>(
         design_cap_of_low: capacity_raw(static_cache.design_cap_low),
         cycle_count: dynamic_cache.cycle_count.into(),
         measurement_accuracy: static_cache.measurement_accuracy,
-        max_sampling_time: static_cache.max_sample_time,
-        min_sampling_time: static_cache.min_sample_time,
-        max_averaging_interval: static_cache.max_averaging_interval,
-        min_averaging_interval: static_cache.min_averaging_interval,
+        max_sampling_time: static_cache.max_sample_time_ms,
+        min_sampling_time: static_cache.min_sample_time_ms,
+        max_averaging_interval: static_cache.max_averaging_interval_ms,
+        min_averaging_interval: static_cache.min_averaging_interval_ms,
         battery_capacity_granularity_1: capacity_raw(static_cache.cap_granularity_1),
         battery_capacity_granularity_2: capacity_raw(static_cache.cap_granularity_2),
         model_number: [0u8; STD_BIX_MODEL_SIZE],
@@ -121,9 +121,9 @@ pub(crate) fn compute_bps<D: DynamicBatteryData>(dynamic_cache: &D) -> embedded_
     // TODO: period values are correct for bq40z50, add to config to support other fuel gauges
     embedded_batteries_async::acpi::Bps {
         revision: 1,
-        instantaneous_peak_power_level: dynamic_cache.max_power,
+        instantaneous_peak_power_level: dynamic_cache.max_power_mw,
         instantaneous_peak_power_period: 10,
-        sustainable_peak_power_level: dynamic_cache.sus_power,
+        sustainable_peak_power_level: dynamic_cache.sus_power_mw,
         sustainable_peak_power_period: 10000,
     }
 }
@@ -133,8 +133,8 @@ pub(crate) fn compute_bpc<S: StaticBatteryData>(static_cache: &S) -> embedded_ba
     embedded_batteries_async::acpi::Bpc {
         revision: 1,
         power_threshold_support: static_cache.power_threshold_support,
-        max_instantaneous_peak_power_threshold: static_cache.max_instant_pwr_threshold,
-        max_sustainable_peak_power_threshold: static_cache.max_sus_pwr_threshold,
+        max_instantaneous_peak_power_threshold: static_cache.max_instant_pwr_threshold_mw,
+        max_sustainable_peak_power_threshold: static_cache.max_sus_pwr_threshold_mw,
     }
 }
 
@@ -148,8 +148,8 @@ pub(crate) fn compute_bmd<S: StaticBatteryData, D: DynamicBatteryData>(
         status_flags: dynamic_cache.bmd_status,
         capability_flags: static_cache.bmd_capability,
         recalibrate_count: static_cache.bmd_recalibrate_count,
-        quick_recalibrate_time: static_cache.bmd_quick_recalibrate_time,
-        slow_recalibrate_time: static_cache.bmd_slow_recalibrate_time,
+        quick_recalibrate_time: static_cache.bmd_quick_recalibrate_time_s,
+        slow_recalibrate_time: static_cache.bmd_slow_recalibrate_time_s,
     }
 }
 
@@ -479,7 +479,7 @@ mod tests {
         let bpc = compute_bpc(&oem_static);
         assert_eq!(
             bpc.max_instantaneous_peak_power_threshold,
-            oem_static.standard.max_instant_pwr_threshold
+            oem_static.standard.max_instant_pwr_threshold_mw
         );
         assert_eq!(oem_static.oem_part_number, 0xABCD);
     }

--- a/battery-service/src/acpi.rs
+++ b/battery-service/src/acpi.rs
@@ -72,7 +72,7 @@ pub(crate) fn compute_bix<S: StaticBatteryData, D: DynamicBatteryData>(
         design_cap_of_warning: capacity_raw(static_cache.design_cap_warning),
         design_cap_of_low: capacity_raw(static_cache.design_cap_low),
         cycle_count: dynamic_cache.cycle_count.into(),
-        measurement_accuracy: u32::from(100 - dynamic_cache.max_error) * 1000u32,
+        measurement_accuracy: static_cache.measurement_accuracy,
         max_sampling_time: static_cache.max_sample_time,
         min_sampling_time: static_cache.min_sample_time,
         max_averaging_interval: static_cache.max_averaging_interval,

--- a/battery-service/src/acpi.rs
+++ b/battery-service/src/acpi.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
 use battery_service_interface::BatteryError;
-use battery_service_interface::fuel_gauge::{DynamicBatteryMsgs, FuelGauge, StaticBatteryMsgs};
+use battery_service_interface::fuel_gauge::{DynamicBatteryData, FuelGauge, StaticBatteryData};
 use embedded_batteries_async::acpi::{PowerSourceState, PowerUnit};
+use embedded_batteries_async::smart_battery::CapacityModeValue;
 use embedded_services::sync::Lockable;
 use embedded_services::{info, trace};
 
@@ -25,7 +26,17 @@ pub(crate) struct PsuState {
     pub power_capability: Option<PowerCapability>,
 }
 
-pub(crate) fn compute_bst(cache: &DynamicBatteryMsgs) -> embedded_batteries_async::acpi::BstReturn {
+/// Extract the raw numeric value from a [`CapacityModeValue`], discarding the unit
+/// tag. The unit (mA/mAh vs centiWatt) is conveyed to ACPI separately via the BIX
+/// `power_unit` field, which is derived from the battery's capacity mode.
+fn capacity_raw(value: CapacityModeValue) -> u32 {
+    match value {
+        CapacityModeValue::MilliAmpUnsigned(v) | CapacityModeValue::CentiWattUnsigned(v) => u32::from(v),
+    }
+}
+
+pub(crate) fn compute_bst<D: DynamicBatteryData>(cache: &D) -> embedded_batteries_async::acpi::BstReturn {
+    let cache = cache.standard();
     let charging = if cache.battery_status & (1 << 6) == 0 {
         embedded_batteries_async::acpi::BatteryState::CHARGING
     } else {
@@ -35,16 +46,18 @@ pub(crate) fn compute_bst(cache: &DynamicBatteryMsgs) -> embedded_batteries_asyn
     // TODO: add critical energy state and charge limiting state
     embedded_batteries_async::acpi::BstReturn {
         battery_state: charging,
-        battery_remaining_capacity: cache.remaining_capacity_mwh,
-        battery_present_rate: cache.current_ma.unsigned_abs().into(),
-        battery_present_voltage: cache.voltage_mv.into(),
+        battery_remaining_capacity: capacity_raw(cache.remaining_capacity),
+        battery_present_rate: cache.current.unsigned_abs().into(),
+        battery_present_voltage: cache.voltage.into(),
     }
 }
 
-pub(crate) fn compute_bix<'a>(
-    static_cache: &'a StaticBatteryMsgs,
-    dynamic_cache: &'a DynamicBatteryMsgs,
+pub(crate) fn compute_bix<S: StaticBatteryData, D: DynamicBatteryData>(
+    static_cache: &S,
+    dynamic_cache: &D,
 ) -> Result<BixFixedStrings, ()> {
+    let static_cache = static_cache.standard();
+    let dynamic_cache = dynamic_cache.standard();
     let mut bix_return = BixFixedStrings {
         revision: 1,
         power_unit: if static_cache.battery_mode.capacity_mode() {
@@ -52,20 +65,20 @@ pub(crate) fn compute_bix<'a>(
         } else {
             PowerUnit::MilliAmps
         },
-        design_capacity: static_cache.design_capacity_mwh,
-        last_full_charge_capacity: dynamic_cache.full_charge_capacity_mwh,
+        design_capacity: capacity_raw(static_cache.design_capacity),
+        last_full_charge_capacity: capacity_raw(dynamic_cache.full_charge_capacity),
         battery_technology: embedded_batteries_async::acpi::BatteryTechnology::Secondary,
-        design_voltage: static_cache.design_voltage_mv.into(),
-        design_cap_of_warning: static_cache.design_cap_warning,
-        design_cap_of_low: static_cache.design_cap_low,
+        design_voltage: static_cache.design_voltage.into(),
+        design_cap_of_warning: capacity_raw(static_cache.design_cap_warning),
+        design_cap_of_low: capacity_raw(static_cache.design_cap_low),
         cycle_count: dynamic_cache.cycle_count.into(),
-        measurement_accuracy: u32::from(100 - dynamic_cache.max_error_pct) * 1000u32,
+        measurement_accuracy: u32::from(100 - dynamic_cache.max_error) * 1000u32,
         max_sampling_time: static_cache.max_sample_time,
         min_sampling_time: static_cache.min_sample_time,
         max_averaging_interval: static_cache.max_averaging_interval,
         min_averaging_interval: static_cache.min_averaging_interval,
-        battery_capacity_granularity_1: static_cache.cap_granularity_1,
-        battery_capacity_granularity_2: static_cache.cap_granularity_2,
+        battery_capacity_granularity_1: capacity_raw(static_cache.cap_granularity_1),
+        battery_capacity_granularity_2: capacity_raw(static_cache.cap_granularity_2),
         model_number: [0u8; STD_BIX_MODEL_SIZE],
         serial_number: [0u8; STD_BIX_SERIAL_SIZE],
         battery_type: [0u8; STD_BIX_BATTERY_SIZE],
@@ -103,18 +116,20 @@ pub(crate) fn compute_bix<'a>(
     Ok(bix_return)
 }
 
-pub(crate) fn compute_bps(dynamic_cache: &DynamicBatteryMsgs) -> embedded_batteries_async::acpi::Bps {
+pub(crate) fn compute_bps<D: DynamicBatteryData>(dynamic_cache: &D) -> embedded_batteries_async::acpi::Bps {
+    let dynamic_cache = dynamic_cache.standard();
     // TODO: period values are correct for bq40z50, add to config to support other fuel gauges
     embedded_batteries_async::acpi::Bps {
         revision: 1,
-        instantaneous_peak_power_level: dynamic_cache.max_power_mw,
+        instantaneous_peak_power_level: dynamic_cache.max_power,
         instantaneous_peak_power_period: 10,
-        sustainable_peak_power_level: dynamic_cache.sus_power_mw,
+        sustainable_peak_power_level: dynamic_cache.sus_power,
         sustainable_peak_power_period: 10000,
     }
 }
 
-pub(crate) fn compute_bpc(static_cache: &StaticBatteryMsgs) -> embedded_batteries_async::acpi::Bpc {
+pub(crate) fn compute_bpc<S: StaticBatteryData>(static_cache: &S) -> embedded_batteries_async::acpi::Bpc {
+    let static_cache = static_cache.standard();
     embedded_batteries_async::acpi::Bpc {
         revision: 1,
         power_threshold_support: static_cache.power_threshold_support,
@@ -123,10 +138,12 @@ pub(crate) fn compute_bpc(static_cache: &StaticBatteryMsgs) -> embedded_batterie
     }
 }
 
-pub(crate) fn compute_bmd(
-    static_cache: &StaticBatteryMsgs,
-    dynamic_cache: &DynamicBatteryMsgs,
+pub(crate) fn compute_bmd<S: StaticBatteryData, D: DynamicBatteryData>(
+    static_cache: &S,
+    dynamic_cache: &D,
 ) -> embedded_batteries_async::acpi::Bmd {
+    let static_cache = static_cache.standard();
+    let dynamic_cache = dynamic_cache.standard();
     embedded_batteries_async::acpi::Bmd {
         status_flags: dynamic_cache.bmd_status,
         capability_flags: static_cache.bmd_capability,
@@ -136,18 +153,18 @@ pub(crate) fn compute_bmd(
     }
 }
 
-pub(crate) fn compute_bct(
+pub(crate) fn compute_bct<D: DynamicBatteryData>(
     payload: &embedded_batteries_async::acpi::Bct,
-    _dynamic_cache: &DynamicBatteryMsgs,
+    _dynamic_cache: &D,
 ) -> embedded_batteries_async::acpi::BctReturnResult {
     // Just echo back charge level for now
     // TODO: Actually compute time from charge level
     embedded_batteries_async::acpi::BctReturnResult::from(payload.charge_level_percent)
 }
 
-pub(crate) fn compute_btm(
+pub(crate) fn compute_btm<D: DynamicBatteryData>(
     payload: &embedded_batteries_async::acpi::Btm,
-    _dynamic_cache: &DynamicBatteryMsgs,
+    _dynamic_cache: &D,
 ) -> embedded_batteries_async::acpi::BtmReturnResult {
     // Just echo back charge level for now
     // TODO: Actually compute time from charge level
@@ -368,5 +385,102 @@ impl<'hw, Reg: crate::registration::Registration<'hw>> crate::Service<'hw, Reg> 
     ) -> Result<StaReturn, BatteryError> {
         trace!("Battery service: got STA command!");
         Ok(compute_sta())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use embedded_batteries_async::smart_battery::CapacityModeValue;
+
+    use super::{compute_bix, compute_bpc, compute_bst};
+    use battery_service_interface::fuel_gauge::{
+        DynamicBatteryData, DynamicBatteryMsgs, StaticBatteryData, StaticBatteryMsgs,
+    };
+
+    /// An OEM dynamic data type that embeds the standard messages and extends
+    /// them with extra fields.
+    struct OemDynamic {
+        standard: DynamicBatteryMsgs,
+        oem_cell_imbalance_mv: u16,
+    }
+
+    impl DynamicBatteryData for OemDynamic {
+        fn standard(&self) -> &DynamicBatteryMsgs {
+            &self.standard
+        }
+    }
+
+    /// An OEM static data type that embeds the standard messages and extends them.
+    struct OemStatic {
+        standard: StaticBatteryMsgs,
+        oem_part_number: u32,
+    }
+
+    impl StaticBatteryData for OemStatic {
+        fn standard(&self) -> &StaticBatteryMsgs {
+            &self.standard
+        }
+    }
+
+    /// The service must compute standard ACPI values from the embedded standard
+    /// data of an OEM-extended type, identically to using the standard type directly.
+    #[test]
+    fn compute_from_extended_type_matches_standard() {
+        let standard = DynamicBatteryMsgs {
+            remaining_capacity: CapacityModeValue::MilliAmpUnsigned(5000),
+            voltage: 12000,
+            current: -1500,
+            battery_status: 0,
+            ..Default::default()
+        };
+        let oem = OemDynamic {
+            standard,
+            oem_cell_imbalance_mv: 42,
+        };
+
+        let from_standard = compute_bst(&standard);
+        let from_oem = compute_bst(&oem);
+
+        assert_eq!(
+            from_oem.battery_remaining_capacity,
+            from_standard.battery_remaining_capacity
+        );
+        assert_eq!(from_oem.battery_present_voltage, from_standard.battery_present_voltage);
+        assert_eq!(from_oem.battery_present_rate, from_standard.battery_present_rate);
+        // The extended field is still readable from the concrete type.
+        assert_eq!(oem.oem_cell_imbalance_mv, 42);
+    }
+
+    /// `compute_*` functions taking both caches accept OEM-extended types for each.
+    #[test]
+    fn compute_bix_and_bpc_accept_extended_types() {
+        let oem_static = OemStatic {
+            standard: StaticBatteryMsgs {
+                design_capacity: CapacityModeValue::MilliAmpUnsigned(9000),
+                design_voltage: 12000,
+                ..Default::default()
+            },
+            oem_part_number: 0xABCD,
+        };
+        let oem_dynamic = OemDynamic {
+            standard: DynamicBatteryMsgs {
+                full_charge_capacity: CapacityModeValue::MilliAmpUnsigned(8500),
+                ..Default::default()
+            },
+            oem_cell_imbalance_mv: 7,
+        };
+
+        let bix = compute_bix(&oem_static, &oem_dynamic).expect("bix should compute");
+        assert_eq!(bix.design_capacity, 9000);
+        assert_eq!(bix.last_full_charge_capacity, 8500);
+
+        let bpc = compute_bpc(&oem_static);
+        assert_eq!(
+            bpc.max_instantaneous_peak_power_threshold,
+            oem_static.standard.max_instant_pwr_threshold
+        );
+        assert_eq!(oem_static.oem_part_number, 0xABCD);
     }
 }

--- a/battery-service/src/lib.rs
+++ b/battery-service/src/lib.rs
@@ -18,8 +18,8 @@ pub use registration::{ArrayRegistration, Registration};
 // Re-export the fuel gauge interface so that OEM drivers and integrators can
 // implement and use the battery service without depending on the interface crate directly.
 pub use battery_service_interface::fuel_gauge::{
-    DynamicBatteryMsgs, FuelGauge, FuelGaugeError, InternalState, OperationalSubstate, PresentSubstate, State,
-    StaticBatteryMsgs,
+    DynamicBatteryData, DynamicBatteryMsgs, FuelGauge, FuelGaugeError, InternalState, OperationalSubstate,
+    PresentSubstate, State, StaticBatteryData, StaticBatteryMsgs,
 };
 pub use battery_service_interface::{BatteryService, DeviceId};
 

--- a/battery-service/src/mock.rs
+++ b/battery-service/src/mock.rs
@@ -99,7 +99,7 @@ impl MockFuelGauge {
     /// cutoff per cell); the 3000 mAh cell capacity and discharge currents are the
     /// same across topologies, so the reported power quantities scale with the pack
     /// voltage. Capacity and rate are reported in current units (mA/mAh).
-    fn with_series_cells(cells: u16, device_name: [u8; 21]) -> Self {
+    fn with_series_cells(cells: u16, device_name: [u8; DEVICE_NAME_SIZE]) -> Self {
         // Per-cell Li-ion voltages.
         const NOMINAL_MV_PER_CELL: u16 = 3_700;
         const FULL_MV_PER_CELL: u16 = 4_200;
@@ -110,11 +110,45 @@ impl MockFuelGauge {
         const SUS_DISCHARGE_MA: u32 = 2_700;
         const INSTANT_THRESHOLD_MA: u32 = 5_400;
         const SUS_THRESHOLD_MA: u32 = 3_150;
+        // Design charge capacity (mAh) and the capacity thresholds / granularity derived from it.
+        const DESIGN_CAPACITY_MAH: u16 = 3_000;
+        const DESIGN_CAP_WARNING_MAH: u16 = 300; // 10% of design
+        const DESIGN_CAP_LOW_MAH: u16 = 150; // 5% of design
+        const CAP_GRANULARITY_MAH: u16 = 10; // reporting granularity
+        const REMAINING_CAP_ALARM_MAH: u16 = 300; // 10% of design
+        const FULL_CHARGE_CAPACITY_MAH: u16 = 2_880; // ~96% of design after wear
+        const REMAINING_CAPACITY_MAH: u16 = 2_304; // 80% of full charge
+        // Measurement accuracy (thousandths of a percent) and sampling characteristics (ms).
+        const MEASUREMENT_ACCURACY: u32 = 99_000; // 99.000%, consistent with 1% max error
+        const MAX_SAMPLE_TIME_MS: u32 = 1_000;
+        const MIN_SAMPLE_TIME_MS: u32 = 31;
+        const MAX_AVERAGING_INTERVAL_MS: u32 = 4_250;
+        const MIN_AVERAGING_INTERVAL_MS: u32 = 25;
+        // Battery-maintenance (recalibration) characteristics.
+        const BMD_RECALIBRATE_COUNT: u32 = 2;
+        const BMD_QUICK_RECALIBRATE_TIME_S: u32 = 120;
+        const BMD_SLOW_RECALIBRATE_TIME_S: u32 = 600;
+        // Dynamic operating point: ~80% SoC discharging under a moderate load.
+        const TURBO_RHF_EFFECTIVE_MOHM: u32 = 150; // pack effective resistance
+        const RELATIVE_SOC_PCT: smart_battery::Percent = 80;
+        const ABSOLUTE_SOC_PCT: smart_battery::Percent = 77; // REMAINING_CAPACITY_MAH / DESIGN_CAPACITY_MAH
+        const CYCLE_COUNT: smart_battery::Cycles = 150;
+        const MAX_ERROR_PCT: smart_battery::Percent = 1;
+        const CHARGING_CURRENT_MA: charger::MilliAmps = 1_500; // desired 0.5C charge current
+        const BATTERY_TEMP_DK: smart_battery::DeciKelvin = 3_031; // 30.0 degC
+        const DISCHARGE_CURRENT_MA: smart_battery::MilliAmpsSigned = -1_500;
+        const AVERAGE_DISCHARGE_CURRENT_MA: smart_battery::MilliAmpsSigned = -1_450;
+        const AT_RATE_MA: i16 = -1_500;
+        // Runtime predictions, in minutes, at the emulated discharge rate.
+        const AT_RATE_TIME_TO_EMPTY_MIN: smart_battery::Minutes = 86;
+        const RUN_TIME_TO_EMPTY_MIN: smart_battery::Minutes = 86;
+        const AVERAGE_TIME_TO_EMPTY_MIN: smart_battery::Minutes = 88;
+        const REMAINING_TIME_ALARM_MIN: smart_battery::Minutes = 10;
 
         let design_voltage = cells * NOMINAL_MV_PER_CELL;
         let full_charge_voltage = cells * FULL_MV_PER_CELL;
         let terminal_voltage = cells * SOC80_MV_PER_CELL; // ~80% SoC
-        let cutoff_voltage = u32::from(cells) * u32::from(CUTOFF_MV_PER_CELL);
+        let cutoff_voltage = cells * CUTOFF_MV_PER_CELL;
         // Power (mW) at the pack's nominal voltage for a given current draw.
         let power_mw = |current_ma: u32| current_ma * u32::from(design_voltage) / 1_000;
 
@@ -123,32 +157,32 @@ impl MockFuelGauge {
         s.manufacturer_name = padded(b"ODP Batteries");
         s.device_name = device_name;
         s.device_chemistry = padded(b"LION");
-        s.design_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(3_000); // 3000 mAh design charge
+        s.design_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(DESIGN_CAPACITY_MAH);
         s.design_voltage = design_voltage;
         s.device_chemistry_id = *b"LI";
         s.serial_num = [0x34, 0x12, 0x00, 0x00]; // serial 0x1234
         // Report capacity/rate in current units (mA/mAh) to match the fields here;
         // alarm and charger-broadcast modes left enabled (the SBS defaults).
         s.battery_mode = smart_battery::BatteryModeFields::new().with_capacity_mode(false);
-        s.design_cap_warning = smart_battery::CapacityModeValue::MilliAmpUnsigned(300); // 10% of design (300 mAh)
-        s.design_cap_low = smart_battery::CapacityModeValue::MilliAmpUnsigned(150); // 5% of design (150 mAh)
-        s.measurement_accuracy = 99_000; // 99.000%, consistent with 1% max error
-        s.max_sample_time = 1_000;
-        s.min_sample_time = 31;
-        s.max_averaging_interval = 4_250;
-        s.min_averaging_interval = 25;
-        s.cap_granularity_1 = smart_battery::CapacityModeValue::MilliAmpUnsigned(10); // 10 mAh reporting granularity
-        s.cap_granularity_2 = smart_battery::CapacityModeValue::MilliAmpUnsigned(10);
+        s.design_cap_warning = smart_battery::CapacityModeValue::MilliAmpUnsigned(DESIGN_CAP_WARNING_MAH);
+        s.design_cap_low = smart_battery::CapacityModeValue::MilliAmpUnsigned(DESIGN_CAP_LOW_MAH);
+        s.measurement_accuracy = MEASUREMENT_ACCURACY;
+        s.max_sample_time_ms = MAX_SAMPLE_TIME_MS;
+        s.min_sample_time_ms = MIN_SAMPLE_TIME_MS;
+        s.max_averaging_interval_ms = MAX_AVERAGING_INTERVAL_MS;
+        s.min_averaging_interval_ms = MIN_AVERAGING_INTERVAL_MS;
+        s.cap_granularity_1 = smart_battery::CapacityModeValue::MilliAmpUnsigned(CAP_GRANULARITY_MAH);
+        s.cap_granularity_2 = smart_battery::CapacityModeValue::MilliAmpUnsigned(CAP_GRANULARITY_MAH);
         s.power_threshold_support =
             acpi::PowerThresholdSupport::INSTANTANEOUS | acpi::PowerThresholdSupport::SUSTAINABLE;
-        s.max_instant_pwr_threshold = power_mw(INSTANT_THRESHOLD_MA);
-        s.max_sus_pwr_threshold = power_mw(SUS_THRESHOLD_MA);
+        s.max_instant_pwr_threshold_mw = power_mw(INSTANT_THRESHOLD_MA);
+        s.max_sus_pwr_threshold_mw = power_mw(SUS_THRESHOLD_MA);
         s.bmc_flags = acpi::BmcControlFlags::empty();
         s.bmd_capability =
             acpi::BmdCapabilityFlags::AML_CALIBRATION_SUPPORTED | acpi::BmdCapabilityFlags::CHARGER_DISABLE_SUPPORTED;
-        s.bmd_recalibrate_count = 2;
-        s.bmd_quick_recalibrate_time = 120;
-        s.bmd_slow_recalibrate_time = 600;
+        s.bmd_recalibrate_count = BMD_RECALIBRATE_COUNT;
+        s.bmd_quick_recalibrate_time_s = BMD_QUICK_RECALIBRATE_TIME_S;
+        s.bmd_slow_recalibrate_time_s = BMD_SLOW_RECALIBRATE_TIME_S;
         s.manufacture_date = smart_battery::ManufactureDate::new()
             .with_day(16)
             .with_month(10)
@@ -158,38 +192,38 @@ impl MockFuelGauge {
             .with_revision(smart_battery::Revision::Version1And1Dot1)
             .with_version(smart_battery::Version::Version1Dot1)
             .into();
-        s.remaining_capacity_alarm = smart_battery::CapacityModeValue::MilliAmpUnsigned(300); // 10% of design (300 mAh)
-        s.remaining_time_alarm = 10;
+        s.remaining_capacity_alarm = smart_battery::CapacityModeValue::MilliAmpUnsigned(REMAINING_CAP_ALARM_MAH);
+        s.remaining_time_alarm = REMAINING_TIME_ALARM_MIN;
 
         let d = state.dynamic_cache_mut();
-        d.max_power = power_mw(PEAK_DISCHARGE_MA);
-        d.sus_power = power_mw(SUS_DISCHARGE_MA);
+        d.max_power_mw = power_mw(PEAK_DISCHARGE_MA);
+        d.sus_power_mw = power_mw(SUS_DISCHARGE_MA);
         d.turbo_vload = cutoff_voltage;
-        d.turbo_rhf_effective = 150; // pack effective resistance
-        d.full_charge_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(2_880); // ~96% of design after wear (mAh)
-        d.remaining_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(2_304); // 80% of full charge (mAh)
-        d.relative_soc = 80;
-        d.cycle_count = 150;
+        d.turbo_rhf_effective_mohm = TURBO_RHF_EFFECTIVE_MOHM;
+        d.full_charge_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(FULL_CHARGE_CAPACITY_MAH);
+        d.remaining_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(REMAINING_CAPACITY_MAH);
+        d.relative_soc = RELATIVE_SOC_PCT;
+        d.cycle_count = CYCLE_COUNT;
         d.voltage = terminal_voltage;
-        d.max_error = 1;
+        d.max_error = MAX_ERROR_PCT;
         // Initialized and discharging; the discharging bit drives the ACPI BST state.
         d.battery_status = smart_battery::BatteryStatusFields::new()
             .with_initialized(true)
             .with_discharging(true)
             .into();
         d.charging_voltage = full_charge_voltage; // desired full-charge voltage
-        d.charging_current = 1_500; // desired 0.5C charge current
-        d.battery_temp = 3_031; // 30.0 degC
-        d.current = -1_500; // discharging
-        d.average_current = -1_450;
+        d.charging_current = CHARGING_CURRENT_MA;
+        d.battery_temp = BATTERY_TEMP_DK;
+        d.current = DISCHARGE_CURRENT_MA;
+        d.average_current = AVERAGE_DISCHARGE_CURRENT_MA;
         d.bmd_status = acpi::BmdStatusFlags::empty();
-        d.absolute_soc = 77; // 2_304 / 3_000
-        d.at_rate = smart_battery::CapacityModeSignedValue::MilliAmpSigned(-1_500);
+        d.absolute_soc = ABSOLUTE_SOC_PCT;
+        d.at_rate = smart_battery::CapacityModeSignedValue::MilliAmpSigned(AT_RATE_MA);
         d.at_rate_ok = true;
         d.at_rate_time_to_full = u16::MAX; // over-range: not charging at this rate
-        d.at_rate_time_to_empty = 86;
-        d.run_time_to_empty = 86;
-        d.average_time_to_empty = 88;
+        d.at_rate_time_to_empty = AT_RATE_TIME_TO_EMPTY_MIN;
+        d.run_time_to_empty = RUN_TIME_TO_EMPTY_MIN;
+        d.average_time_to_empty = AVERAGE_TIME_TO_EMPTY_MIN;
         d.average_time_to_full = u16::MAX; // over-range: not charging
         MockFuelGauge { state }
     }
@@ -270,9 +304,9 @@ impl FuelGauge for MockFuelGauge {
         self.state_mut().on_dynamic_data(|d| {
             d.average_current = average_current;
             d.battery_status = battery_status;
-            d.max_power = 100;
+            d.max_power_mw = 100;
             d.battery_temp = battery_temp;
-            d.sus_power = 42;
+            d.sus_power_mw = 42;
             d.charging_current = charging_current;
             d.charging_voltage = charging_voltage;
             d.voltage = voltage;
@@ -284,7 +318,7 @@ impl FuelGauge for MockFuelGauge {
             d.max_error = max_error;
             d.bmd_status = acpi::BmdStatusFlags::default();
             d.turbo_vload = 0;
-            d.turbo_rhf_effective = 0;
+            d.turbo_rhf_effective_mohm = 0;
             d.absolute_soc = absolute_soc;
             d.at_rate = at_rate;
             d.at_rate_ok = at_rate_ok;
@@ -314,15 +348,21 @@ impl FuelGauge for MockFuelGauge {
         let remaining_capacity_alarm = self.remaining_capacity_alarm().await?;
         let remaining_time_alarm = self.remaining_time_alarm().await?;
 
-        let mut manufacturer_name = [0u8; 21];
+        let mut manufacturer_name = [0u8; MANUFACTURER_NAME_SIZE];
         self.manufacturer_name(&mut manufacturer_name).await?;
-        let mut device_name = [0u8; 21];
+        let mut device_name = [0u8; DEVICE_NAME_SIZE];
         self.device_name(&mut device_name).await?;
-        let mut device_chemistry = [0u8; 5];
+        let mut device_chemistry = [0u8; DEVICE_CHEMISTRY_SIZE];
         self.device_chemistry(&mut device_chemistry).await?;
-        let mut device_chemistry_id = [0u8; 2];
+        let mut device_chemistry_id = [0u8; DEVICE_CHEMISTRY_ID_SIZE];
         self.device_chemistry(&mut device_chemistry_id).await?;
         let [serial_lsb, serial_msb] = self.serial_number().await?.to_le_bytes();
+
+        // Warning threshold at ~1/4 (25%) and low threshold at ~1/10 (10%) of design capacity.
+        const DESIGN_CAP_WARNING_DIVISOR: u32 = 4;
+        const DESIGN_CAP_LOW_DIVISOR: u32 = 10;
+        let design_cap_warning = (design_capacity_value / DESIGN_CAP_WARNING_DIVISOR) as u16;
+        let design_cap_low = (design_capacity_value / DESIGN_CAP_LOW_DIVISOR) as u16;
 
         self.state_mut().on_static_data(|s| {
             s.manufacturer_name = manufacturer_name;
@@ -333,24 +373,23 @@ impl FuelGauge for MockFuelGauge {
             s.device_chemistry_id = device_chemistry_id;
             s.serial_num = [serial_lsb, serial_msb, 0, 0];
             s.battery_mode = battery_mode;
-            s.design_cap_warning =
-                smart_battery::CapacityModeValue::MilliAmpUnsigned((design_capacity_value / 4) as u16);
-            s.design_cap_low = smart_battery::CapacityModeValue::MilliAmpUnsigned((design_capacity_value / 10) as u16);
+            s.design_cap_warning = smart_battery::CapacityModeValue::MilliAmpUnsigned(design_cap_warning);
+            s.design_cap_low = smart_battery::CapacityModeValue::MilliAmpUnsigned(design_cap_low);
             s.measurement_accuracy = measurement_accuracy;
-            s.max_sample_time = Default::default();
-            s.min_sample_time = Default::default();
-            s.max_averaging_interval = Default::default();
-            s.min_averaging_interval = Default::default();
+            s.max_sample_time_ms = Default::default();
+            s.min_sample_time_ms = Default::default();
+            s.max_averaging_interval_ms = Default::default();
+            s.min_averaging_interval_ms = Default::default();
             s.cap_granularity_1 = smart_battery::CapacityModeValue::MilliAmpUnsigned(0);
             s.cap_granularity_2 = smart_battery::CapacityModeValue::MilliAmpUnsigned(0);
             s.power_threshold_support = battery_service_interface::PowerThresholdSupport::empty();
-            s.max_instant_pwr_threshold = Default::default();
-            s.max_sus_pwr_threshold = Default::default();
+            s.max_instant_pwr_threshold_mw = Default::default();
+            s.max_sus_pwr_threshold_mw = Default::default();
             s.bmc_flags = battery_service_interface::BmcControlFlags::empty();
             s.bmd_capability = battery_service_interface::BmdCapabilityFlags::empty();
             s.bmd_recalibrate_count = Default::default();
-            s.bmd_quick_recalibrate_time = Default::default();
-            s.bmd_slow_recalibrate_time = Default::default();
+            s.bmd_quick_recalibrate_time_s = Default::default();
+            s.bmd_slow_recalibrate_time_s = Default::default();
             s.manufacture_date = manufacture_date;
             s.specification_info = specification_info;
             s.remaining_capacity_alarm = remaining_capacity_alarm;

--- a/battery-service/src/mock.rs
+++ b/battery-service/src/mock.rs
@@ -54,24 +54,149 @@ where
     }
 }
 
+/// Helper method to build a zero-padded fixed-size byte array from a byte slice, truncating the
+/// slice if it is longer than `N`.
+fn padded<const N: usize>(bytes: &[u8]) -> [u8; N] {
+    let mut arr = [0u8; N];
+    for (dst, src) in arr.iter_mut().zip(bytes.iter()) {
+        *dst = *src;
+    }
+    arr
+}
+
 /// A mock fuel gauge that manages its own state and produces static, arbitrary data.
 pub struct MockFuelGauge {
     state: State,
-    capacity_mode_bit: bool,
 }
 
 impl MockFuelGauge {
+    /// Construct a [`MockFuelGauge`] emulating a 3S (three-cell-series) Li-ion
+    /// pack at roughly 80% charge under a moderate discharge load, with a
+    /// 3000 mAh design capacity (nominal 11.1 V, full charge 12.6 V).
     pub fn new() -> Self {
-        MockFuelGauge {
-            state: State::default(),
-            capacity_mode_bit: false,
-        }
+        Self::with_series_cells(3, padded(b"ODP-3S-3000"))
+    }
+
+    /// Construct a [`MockFuelGauge`] emulating a 2S (two-cell-series) Li-ion
+    /// pack at roughly 80% charge under a moderate discharge load, with a
+    /// 3000 mAh design capacity (nominal 7.4 V, full charge 8.4 V).
+    pub fn new_2s() -> Self {
+        Self::with_series_cells(2, padded(b"ODP-2S-3000"))
+    }
+
+    /// Construct a [`MockFuelGauge`] emulating a 4S (four-cell-series) Li-ion
+    /// pack at roughly 80% charge under a moderate discharge load, with a
+    /// 3000 mAh design capacity (nominal 14.8 V, full charge 16.8 V).
+    pub fn new_4s() -> Self {
+        Self::with_series_cells(4, padded(b"ODP-4S-3000"))
+    }
+
+    /// Build a [`MockFuelGauge`] preloaded with coherent data for a `cells`-cell
+    /// series Li-ion pack reporting `device_name` as its model string.
+    ///
+    /// Every static and dynamic cache field is populated. Pack voltages scale with
+    /// the series cell count (3.7 V nominal, 4.2 V full charge and 3.0 V load
+    /// cutoff per cell); the 3000 mAh cell capacity and discharge currents are the
+    /// same across topologies, so the reported power quantities scale with the pack
+    /// voltage. Capacity and rate are reported in current units (mA/mAh).
+    fn with_series_cells(cells: u16, device_name: [u8; 21]) -> Self {
+        // Per-cell Li-ion voltages.
+        const NOMINAL_MV_PER_CELL: u16 = 3_700;
+        const FULL_MV_PER_CELL: u16 = 4_200;
+        const CUTOFF_MV_PER_CELL: u16 = 3_000;
+        const SOC80_MV_PER_CELL: u16 = 3_950;
+        // Pack-independent discharge / threshold currents (mA); power = current * voltage.
+        const PEAK_DISCHARGE_MA: u32 = 4_500;
+        const SUS_DISCHARGE_MA: u32 = 2_700;
+        const INSTANT_THRESHOLD_MA: u32 = 5_400;
+        const SUS_THRESHOLD_MA: u32 = 3_150;
+
+        let design_voltage = cells * NOMINAL_MV_PER_CELL;
+        let full_charge_voltage = cells * FULL_MV_PER_CELL;
+        let terminal_voltage = cells * SOC80_MV_PER_CELL; // ~80% SoC
+        let cutoff_voltage = u32::from(cells) * u32::from(CUTOFF_MV_PER_CELL);
+        // Power (mW) at the pack's nominal voltage for a given current draw.
+        let power_mw = |current_ma: u32| current_ma * u32::from(design_voltage) / 1_000;
+
+        let mut state: State = State::default();
+        let s = state.static_cache_mut();
+        s.manufacturer_name = padded(b"ODP Batteries");
+        s.device_name = device_name;
+        s.device_chemistry = padded(b"LION");
+        s.design_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(3_000); // 3000 mAh design charge
+        s.design_voltage = design_voltage;
+        s.device_chemistry_id = *b"LI";
+        s.serial_num = [0x34, 0x12, 0x00, 0x00]; // serial 0x1234
+        // Report capacity/rate in current units (mA/mAh) to match the fields here;
+        // alarm and charger-broadcast modes left enabled (the SBS defaults).
+        s.battery_mode = smart_battery::BatteryModeFields::new().with_capacity_mode(false);
+        s.design_cap_warning = smart_battery::CapacityModeValue::MilliAmpUnsigned(300); // 10% of design (300 mAh)
+        s.design_cap_low = smart_battery::CapacityModeValue::MilliAmpUnsigned(150); // 5% of design (150 mAh)
+        s.measurement_accuracy = 99_000; // 99.000%, consistent with 1% max error
+        s.max_sample_time = 1_000;
+        s.min_sample_time = 31;
+        s.max_averaging_interval = 4_250;
+        s.min_averaging_interval = 25;
+        s.cap_granularity_1 = smart_battery::CapacityModeValue::MilliAmpUnsigned(10); // 10 mAh reporting granularity
+        s.cap_granularity_2 = smart_battery::CapacityModeValue::MilliAmpUnsigned(10);
+        s.power_threshold_support =
+            acpi::PowerThresholdSupport::INSTANTANEOUS | acpi::PowerThresholdSupport::SUSTAINABLE;
+        s.max_instant_pwr_threshold = power_mw(INSTANT_THRESHOLD_MA);
+        s.max_sus_pwr_threshold = power_mw(SUS_THRESHOLD_MA);
+        s.bmc_flags = acpi::BmcControlFlags::empty();
+        s.bmd_capability =
+            acpi::BmdCapabilityFlags::AML_CALIBRATION_SUPPORTED | acpi::BmdCapabilityFlags::CHARGER_DISABLE_SUPPORTED;
+        s.bmd_recalibrate_count = 2;
+        s.bmd_quick_recalibrate_time = 120;
+        s.bmd_slow_recalibrate_time = 600;
+        s.manufacture_date = smart_battery::ManufactureDate::new()
+            .with_day(16)
+            .with_month(10)
+            .with_year(45); // 1980 + 45 = 2025
+        // Stored as raw u16 (see `StaticBatteryMsgs`); revision 1.1 / version 1.1.
+        s.specification_info = smart_battery::SpecificationInfoFields::from(0u16)
+            .with_revision(smart_battery::Revision::Version1And1Dot1)
+            .with_version(smart_battery::Version::Version1Dot1)
+            .into();
+        s.remaining_capacity_alarm = smart_battery::CapacityModeValue::MilliAmpUnsigned(300); // 10% of design (300 mAh)
+        s.remaining_time_alarm = 10;
+
+        let d = state.dynamic_cache_mut();
+        d.max_power = power_mw(PEAK_DISCHARGE_MA);
+        d.sus_power = power_mw(SUS_DISCHARGE_MA);
+        d.turbo_vload = cutoff_voltage;
+        d.turbo_rhf_effective = 150; // pack effective resistance
+        d.full_charge_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(2_880); // ~96% of design after wear (mAh)
+        d.remaining_capacity = smart_battery::CapacityModeValue::MilliAmpUnsigned(2_304); // 80% of full charge (mAh)
+        d.relative_soc = 80;
+        d.cycle_count = 150;
+        d.voltage = terminal_voltage;
+        d.max_error = 1;
+        // Initialized and discharging; the discharging bit drives the ACPI BST state.
+        d.battery_status = smart_battery::BatteryStatusFields::new()
+            .with_initialized(true)
+            .with_discharging(true)
+            .into();
+        d.charging_voltage = full_charge_voltage; // desired full-charge voltage
+        d.charging_current = 1_500; // desired 0.5C charge current
+        d.battery_temp = 3_031; // 30.0 degC
+        d.current = -1_500; // discharging
+        d.average_current = -1_450;
+        d.bmd_status = acpi::BmdStatusFlags::empty();
+        d.absolute_soc = 77; // 2_304 / 3_000
+        d.at_rate = smart_battery::CapacityModeSignedValue::MilliAmpSigned(-1_500);
+        d.at_rate_ok = true;
+        d.at_rate_time_to_full = u16::MAX; // over-range: not charging at this rate
+        d.at_rate_time_to_empty = 86;
+        d.run_time_to_empty = 86;
+        d.average_time_to_empty = 88;
+        d.average_time_to_full = u16::MAX; // over-range: not charging
+        MockFuelGauge { state }
     }
 
     async fn set_capacity_bit(&mut self, mwh: bool) -> Result<(), MockBatteryError> {
         let battery_mode = self.battery_mode().await?;
         SmartBattery::set_battery_mode(self, battery_mode.with_capacity_mode(mwh)).await?;
-        self.capacity_mode_bit = mwh;
 
         Ok(())
     }
@@ -94,6 +219,8 @@ impl From<MockBatteryError> for FuelGaugeError {
 
 impl FuelGauge for MockFuelGauge {
     type FuelGaugeError = MockBatteryError;
+    type StaticData = StaticBatteryMsgs;
+    type DynamicData = DynamicBatteryMsgs;
 
     async fn initialize(&mut self) -> Result<(), Self::FuelGaugeError> {
         // Milliamps
@@ -119,107 +246,113 @@ impl FuelGauge for MockFuelGauge {
     }
 
     async fn update_dynamic_data(&mut self) -> Result<(), Self::FuelGaugeError> {
-        let new_msgs = DynamicBatteryMsgs {
-            average_current_ma: self.average_current().await?,
-            battery_status: self.battery_status().await?.into(),
-            max_power_mw: 100,
-            battery_temp_dk: self.temperature().await?,
-            sus_power_mw: 42,
-            charging_current_ma: self.charging_current().await?,
-            charging_voltage_mv: self.charging_voltage().await?,
-            voltage_mv: self.voltage().await?,
-            current_ma: self.current().await?,
-            full_charge_capacity_mwh: match self.full_charge_capacity().await? {
-                smart_battery::CapacityModeValue::CentiWattUnsigned(_) => 0xDEADBEEF,
-                smart_battery::CapacityModeValue::MilliAmpUnsigned(capacity) => capacity.into(),
-            },
-            remaining_capacity_mwh: match self.remaining_capacity().await? {
-                smart_battery::CapacityModeValue::CentiWattUnsigned(_) => 0xDEADBEEF,
-                smart_battery::CapacityModeValue::MilliAmpUnsigned(capacity) => capacity.into(),
-            },
-            relative_soc_pct: self.relative_state_of_charge().await?.into(),
-            cycle_count: self.cycle_count().await?,
-            max_error_pct: self.max_error().await?.into(),
-            bmd_status: acpi::BmdStatusFlags::default(),
-            turbo_vload_mv: 0,
-            turbo_rhf_effective_mohm: 0,
-        };
-        self.state_mut().on_dynamic_data(new_msgs);
+        let average_current = self.average_current().await?;
+        let battery_status: u16 = self.battery_status().await?.into();
+        let battery_temp = self.temperature().await?;
+        let charging_current = self.charging_current().await?;
+        let charging_voltage = self.charging_voltage().await?;
+        let voltage = self.voltage().await?;
+        let current = self.current().await?;
+        let full_charge_capacity = self.full_charge_capacity().await?;
+        let remaining_capacity = self.remaining_capacity().await?;
+        let relative_soc = self.relative_state_of_charge().await?;
+        let cycle_count = self.cycle_count().await?;
+        let max_error = self.max_error().await?;
+        let absolute_soc = self.absolute_state_of_charge().await?;
+        let at_rate = self.at_rate().await?;
+        let at_rate_ok = self.at_rate_ok().await?;
+        let at_rate_time_to_full = self.at_rate_time_to_full().await?;
+        let at_rate_time_to_empty = self.at_rate_time_to_empty().await?;
+        let run_time_to_empty = self.run_time_to_empty().await?;
+        let average_time_to_empty = self.average_time_to_empty().await?;
+        let average_time_to_full = self.average_time_to_full().await?;
+
+        self.state_mut().on_dynamic_data(|d| {
+            d.average_current = average_current;
+            d.battery_status = battery_status;
+            d.max_power = 100;
+            d.battery_temp = battery_temp;
+            d.sus_power = 42;
+            d.charging_current = charging_current;
+            d.charging_voltage = charging_voltage;
+            d.voltage = voltage;
+            d.current = current;
+            d.full_charge_capacity = full_charge_capacity;
+            d.remaining_capacity = remaining_capacity;
+            d.relative_soc = relative_soc;
+            d.cycle_count = cycle_count;
+            d.max_error = max_error;
+            d.bmd_status = acpi::BmdStatusFlags::default();
+            d.turbo_vload = 0;
+            d.turbo_rhf_effective = 0;
+            d.absolute_soc = absolute_soc;
+            d.at_rate = at_rate;
+            d.at_rate_ok = at_rate_ok;
+            d.at_rate_time_to_full = at_rate_time_to_full;
+            d.at_rate_time_to_empty = at_rate_time_to_empty;
+            d.run_time_to_empty = run_time_to_empty;
+            d.average_time_to_empty = average_time_to_empty;
+            d.average_time_to_full = average_time_to_full;
+        });
         Ok(())
     }
 
-    // No index/slice below can panic: `buf` is sized to the largest static string field,
-    // every `buf_len` is a field's own `.len()` (<= that size), and `serial` is a `[u8; 2]`
-    // from `u16::to_le_bytes()`.
-    #[allow(clippy::indexing_slicing)]
     async fn update_static_data(&mut self) -> Result<(), Self::FuelGaugeError> {
-        let design_capacity: u32 = match self.design_capacity().await? {
-            smart_battery::CapacityModeValue::CentiWattUnsigned(design_capacity) => design_capacity.into(),
-            smart_battery::CapacityModeValue::MilliAmpUnsigned(design_capacity) => design_capacity.into(),
+        let design_capacity = self.design_capacity().await?;
+        let design_capacity_value: u32 = match design_capacity {
+            smart_battery::CapacityModeValue::CentiWattUnsigned(v) => v.into(),
+            smart_battery::CapacityModeValue::MilliAmpUnsigned(v) => v.into(),
         };
+        let design_voltage = self.design_voltage().await?;
+        let battery_mode = self.battery_mode().await?;
+        let measurement_accuracy: u32 = self.max_error().await?.into();
+        let manufacture_date = self.manufacture_date().await?;
+        let specification_info: u16 = self.specification_info().await?.into();
+        let remaining_capacity_alarm = self.remaining_capacity_alarm().await?;
+        let remaining_time_alarm = self.remaining_time_alarm().await?;
 
-        let mut new_msgs = StaticBatteryMsgs {
-            manufacturer_name: Default::default(),
-            device_name: Default::default(),
-            device_chemistry: Default::default(),
-            design_capacity_mwh: match self.design_capacity().await? {
-                smart_battery::CapacityModeValue::CentiWattUnsigned(design_capacity) => design_capacity.into(),
-                smart_battery::CapacityModeValue::MilliAmpUnsigned(design_capacity) => design_capacity.into(),
-            },
-            design_voltage_mv: self.design_voltage().await?,
-            device_chemistry_id: Default::default(),
-            serial_num: Default::default(),
-            battery_mode: self.battery_mode().await?,
-            design_cap_warning: design_capacity / 4,
-            design_cap_low: design_capacity / 10,
-            measurement_accuracy: self.max_error().await?.into(),
-            max_sample_time: Default::default(),
-            min_sample_time: Default::default(),
-            max_averaging_interval: Default::default(),
-            min_averaging_interval: Default::default(),
-            cap_granularity_1: Default::default(),
-            cap_granularity_2: Default::default(),
-            power_threshold_support: battery_service_interface::PowerThresholdSupport::empty(),
-            max_instant_pwr_threshold: Default::default(),
-            max_sus_pwr_threshold: Default::default(),
-            bmc_flags: battery_service_interface::BmcControlFlags::empty(),
-            bmd_capability: battery_service_interface::BmdCapabilityFlags::empty(),
-            bmd_recalibrate_count: Default::default(),
-            bmd_quick_recalibrate_time: Default::default(),
-            bmd_slow_recalibrate_time: Default::default(),
-        };
-        // `BUF_SIZE` is the compile time maximum of the static string field lengths read below,
-        // so `buf` is always large enough for each.
-        const fn max_usize(a: usize, b: usize) -> usize {
-            if a > b { a } else { b }
-        }
-        const BUF_SIZE: usize = max_usize(
-            max_usize(MANUFACTURER_NAME_SIZE, DEVICE_NAME_SIZE),
-            max_usize(DEVICE_CHEMISTRY_SIZE, DEVICE_CHEMISTRY_ID_SIZE),
-        );
-        let mut buf = [0u8; BUF_SIZE];
+        let mut manufacturer_name = [0u8; 21];
+        self.manufacturer_name(&mut manufacturer_name).await?;
+        let mut device_name = [0u8; 21];
+        self.device_name(&mut device_name).await?;
+        let mut device_chemistry = [0u8; 5];
+        self.device_chemistry(&mut device_chemistry).await?;
+        let mut device_chemistry_id = [0u8; 2];
+        self.device_chemistry(&mut device_chemistry_id).await?;
+        let [serial_lsb, serial_msb] = self.serial_number().await?.to_le_bytes();
 
-        let buf_len = new_msgs.manufacturer_name.len();
-        self.manufacturer_name(&mut buf[..buf_len]).await?;
-        new_msgs.manufacturer_name.copy_from_slice(&buf[..buf_len]);
-
-        let buf_len = new_msgs.device_name.len();
-        self.device_name(&mut buf[..buf_len]).await?;
-        new_msgs.device_name.copy_from_slice(&buf[..buf_len]);
-
-        let buf_len = new_msgs.device_chemistry.len();
-        self.device_chemistry(&mut buf[..buf_len]).await?;
-        new_msgs.device_chemistry.copy_from_slice(&buf[..buf_len]);
-
-        let buf_len = new_msgs.device_chemistry_id.len();
-        self.device_chemistry(&mut buf[..buf_len]).await?;
-        new_msgs.device_chemistry_id.copy_from_slice(&buf[..buf_len]);
-
-        let serial = self.serial_number().await?;
-        let serial = serial.to_le_bytes();
-        new_msgs.serial_num = [serial[0], serial[1], 0, 0];
-
-        self.state_mut().on_static_data(new_msgs);
+        self.state_mut().on_static_data(|s| {
+            s.manufacturer_name = manufacturer_name;
+            s.device_name = device_name;
+            s.device_chemistry = device_chemistry;
+            s.design_capacity = design_capacity;
+            s.design_voltage = design_voltage;
+            s.device_chemistry_id = device_chemistry_id;
+            s.serial_num = [serial_lsb, serial_msb, 0, 0];
+            s.battery_mode = battery_mode;
+            s.design_cap_warning =
+                smart_battery::CapacityModeValue::MilliAmpUnsigned((design_capacity_value / 4) as u16);
+            s.design_cap_low = smart_battery::CapacityModeValue::MilliAmpUnsigned((design_capacity_value / 10) as u16);
+            s.measurement_accuracy = measurement_accuracy;
+            s.max_sample_time = Default::default();
+            s.min_sample_time = Default::default();
+            s.max_averaging_interval = Default::default();
+            s.min_averaging_interval = Default::default();
+            s.cap_granularity_1 = smart_battery::CapacityModeValue::MilliAmpUnsigned(0);
+            s.cap_granularity_2 = smart_battery::CapacityModeValue::MilliAmpUnsigned(0);
+            s.power_threshold_support = battery_service_interface::PowerThresholdSupport::empty();
+            s.max_instant_pwr_threshold = Default::default();
+            s.max_sus_pwr_threshold = Default::default();
+            s.bmc_flags = battery_service_interface::BmcControlFlags::empty();
+            s.bmd_capability = battery_service_interface::BmdCapabilityFlags::empty();
+            s.bmd_recalibrate_count = Default::default();
+            s.bmd_quick_recalibrate_time = Default::default();
+            s.bmd_slow_recalibrate_time = Default::default();
+            s.manufacture_date = manufacture_date;
+            s.specification_info = specification_info;
+            s.remaining_capacity_alarm = remaining_capacity_alarm;
+            s.remaining_time_alarm = remaining_time_alarm;
+        });
         Ok(())
     }
 
@@ -245,72 +378,72 @@ impl smart_battery::ErrorType for MockFuelGauge {
 // Revisit: Have this generate realistic data dynamically (right now just static arbitrary values)
 impl smart_battery::SmartBattery for MockFuelGauge {
     async fn absolute_state_of_charge(&mut self) -> Result<smart_battery::Percent, Self::Error> {
-        Ok(77)
+        Ok(self.state.dynamic_cache().absolute_soc)
     }
 
     async fn at_rate(&mut self) -> Result<smart_battery::CapacityModeSignedValue, Self::Error> {
-        Ok(smart_battery::CapacityModeSignedValue::MilliAmpSigned(100))
+        Ok(self.state.dynamic_cache().at_rate)
     }
 
     async fn at_rate_ok(&mut self) -> Result<bool, Self::Error> {
-        Ok(true)
+        Ok(self.state.dynamic_cache().at_rate_ok)
     }
 
     async fn at_rate_time_to_empty(&mut self) -> Result<smart_battery::Minutes, Self::Error> {
-        Ok(2600)
+        Ok(self.state.dynamic_cache().at_rate_time_to_empty)
     }
 
     async fn at_rate_time_to_full(&mut self) -> Result<smart_battery::Minutes, Self::Error> {
-        Ok(1337)
+        Ok(self.state.dynamic_cache().at_rate_time_to_full)
     }
 
     async fn average_current(&mut self) -> Result<smart_battery::MilliAmpsSigned, Self::Error> {
-        Ok(42)
+        Ok(self.state.dynamic_cache().average_current)
     }
 
     async fn average_time_to_empty(&mut self) -> Result<smart_battery::Minutes, Self::Error> {
-        Ok(100)
+        Ok(self.state.dynamic_cache().average_time_to_empty)
     }
 
     async fn average_time_to_full(&mut self) -> Result<smart_battery::Minutes, Self::Error> {
-        Ok(120)
+        Ok(self.state.dynamic_cache().average_time_to_full)
     }
 
     async fn battery_mode(&mut self) -> Result<smart_battery::BatteryModeFields, Self::Error> {
-        Ok(smart_battery::BatteryModeFields::new())
+        Ok(self.state.static_cache().battery_mode)
     }
 
     async fn battery_status(&mut self) -> Result<smart_battery::BatteryStatusFields, Self::Error> {
-        Ok(smart_battery::BatteryStatusFields::new())
+        Ok(self.state.dynamic_cache().battery_status.into())
     }
 
     async fn charging_current(&mut self) -> Result<charger::MilliAmps, Self::Error> {
-        Ok(50)
+        Ok(self.state.dynamic_cache().charging_current)
     }
 
     async fn charging_voltage(&mut self) -> Result<charger::MilliVolts, Self::Error> {
-        Ok(4242)
+        Ok(self.state.dynamic_cache().charging_voltage)
     }
 
     async fn current(&mut self) -> Result<smart_battery::MilliAmpsSigned, Self::Error> {
-        Ok(500)
+        Ok(self.state.dynamic_cache().current)
     }
 
     async fn cycle_count(&mut self) -> Result<smart_battery::Cycles, Self::Error> {
-        Ok(10000)
+        Ok(self.state.dynamic_cache().cycle_count)
     }
 
     async fn design_capacity(&mut self) -> Result<smart_battery::CapacityModeValue, Self::Error> {
-        Ok(smart_battery::CapacityModeValue::CentiWattUnsigned(0))
+        Ok(self.state.static_cache().design_capacity)
     }
 
     async fn design_voltage(&mut self) -> Result<charger::MilliVolts, Self::Error> {
-        Ok(12000)
+        Ok(self.state.static_cache().design_voltage)
     }
 
     #[allow(clippy::indexing_slicing)]
     async fn device_chemistry(&mut self, chemistry: &mut [u8]) -> Result<(), Self::Error> {
-        let bytes = [b'L', b'i', b'P', b'o', 0];
+        let bytes = self.state.static_cache().device_chemistry;
         let bytes_to_copy = core::cmp::min(bytes.len(), chemistry.len());
         chemistry[..bytes_to_copy].copy_from_slice(&bytes[..bytes_to_copy]);
         Ok(())
@@ -318,84 +451,89 @@ impl smart_battery::SmartBattery for MockFuelGauge {
 
     #[allow(clippy::indexing_slicing)]
     async fn device_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-        let bytes = [b'O', b'd', b'p', b'B', b'a', b't', b't', 0];
+        let bytes = self.state.static_cache().device_name;
         let bytes_to_copy = core::cmp::min(bytes.len(), name.len());
         name[..bytes_to_copy].copy_from_slice(&bytes[..bytes_to_copy]);
         Ok(())
     }
 
     async fn full_charge_capacity(&mut self) -> Result<smart_battery::CapacityModeValue, Self::Error> {
-        Ok(smart_battery::CapacityModeValue::CentiWattUnsigned(0))
+        Ok(self.state.dynamic_cache().full_charge_capacity)
     }
 
     async fn manufacture_date(&mut self) -> Result<smart_battery::ManufactureDate, Self::Error> {
-        Ok(smart_battery::ManufactureDate::new())
+        Ok(self.state.static_cache().manufacture_date)
     }
 
     #[allow(clippy::indexing_slicing)]
     async fn manufacturer_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-        let bytes = [b'B', b'a', b't', b'B', b'r', b'o', b's', 0];
+        let bytes = self.state.static_cache().manufacturer_name;
         let bytes_to_copy = core::cmp::min(bytes.len(), name.len());
         name[..bytes_to_copy].copy_from_slice(&bytes[..bytes_to_copy]);
         Ok(())
     }
 
     async fn max_error(&mut self) -> Result<smart_battery::Percent, Self::Error> {
-        Ok(2)
+        Ok(self.state.dynamic_cache().max_error)
     }
 
     async fn relative_state_of_charge(&mut self) -> Result<smart_battery::Percent, Self::Error> {
-        Ok(10)
+        Ok(self.state.dynamic_cache().relative_soc)
     }
 
     async fn remaining_capacity(&mut self) -> Result<smart_battery::CapacityModeValue, Self::Error> {
-        Ok(smart_battery::CapacityModeValue::CentiWattUnsigned(0))
+        Ok(self.state.dynamic_cache().remaining_capacity)
     }
 
     async fn remaining_capacity_alarm(&mut self) -> Result<smart_battery::CapacityModeValue, Self::Error> {
-        Ok(smart_battery::CapacityModeValue::CentiWattUnsigned(0))
+        Ok(self.state.static_cache().remaining_capacity_alarm)
     }
 
     async fn remaining_time_alarm(&mut self) -> Result<smart_battery::Minutes, Self::Error> {
-        Ok(85)
+        Ok(self.state.static_cache().remaining_time_alarm)
     }
 
     async fn run_time_to_empty(&mut self) -> Result<smart_battery::Minutes, Self::Error> {
-        Ok(110)
+        Ok(self.state.dynamic_cache().run_time_to_empty)
     }
 
     async fn serial_number(&mut self) -> Result<u16, Self::Error> {
-        Ok(0x4544)
+        let [lsb, msb, _, _] = self.state.static_cache().serial_num;
+        Ok(u16::from_le_bytes([lsb, msb]))
     }
 
-    async fn set_at_rate(&mut self, _rate: smart_battery::CapacityModeSignedValue) -> Result<(), Self::Error> {
+    async fn set_at_rate(&mut self, rate: smart_battery::CapacityModeSignedValue) -> Result<(), Self::Error> {
+        self.state_mut().dynamic_cache_mut().at_rate = rate;
         Ok(())
     }
 
-    async fn set_battery_mode(&mut self, _flags: smart_battery::BatteryModeFields) -> Result<(), Self::Error> {
+    async fn set_battery_mode(&mut self, flags: smart_battery::BatteryModeFields) -> Result<(), Self::Error> {
+        self.state_mut().static_cache_mut().battery_mode = flags;
         Ok(())
     }
 
     async fn set_remaining_capacity_alarm(
         &mut self,
-        _capacity: smart_battery::CapacityModeValue,
+        capacity: smart_battery::CapacityModeValue,
     ) -> Result<(), Self::Error> {
+        self.state_mut().static_cache_mut().remaining_capacity_alarm = capacity;
         Ok(())
     }
 
-    async fn set_remaining_time_alarm(&mut self, _time: smart_battery::Minutes) -> Result<(), Self::Error> {
+    async fn set_remaining_time_alarm(&mut self, time: smart_battery::Minutes) -> Result<(), Self::Error> {
+        self.state_mut().static_cache_mut().remaining_time_alarm = time;
         Ok(())
     }
 
     async fn specification_info(&mut self) -> Result<smart_battery::SpecificationInfoFields, Self::Error> {
-        Ok(smart_battery::SpecificationInfoFields::new())
+        Ok(self.state.static_cache().specification_info.into())
     }
 
     async fn temperature(&mut self) -> Result<smart_battery::DeciKelvin, Self::Error> {
-        Ok(2981)
+        Ok(self.state.dynamic_cache().battery_temp)
     }
 
     async fn voltage(&mut self) -> Result<smart_battery::MilliVolts, Self::Error> {
-        Ok(12600)
+        Ok(self.state.dynamic_cache().voltage)
     }
 }

--- a/battery-service/src/mock.rs
+++ b/battery-service/src/mock.rs
@@ -305,7 +305,10 @@ impl FuelGauge for MockFuelGauge {
         };
         let design_voltage = self.design_voltage().await?;
         let battery_mode = self.battery_mode().await?;
-        let measurement_accuracy: u32 = self.max_error().await?.into();
+        // ACPI BIX measurement accuracy is in thousandths of a percent; derive it
+        // from the Smart Battery MaxError (in %): accuracy = (100 - max_error)%.
+        // Saturate so an out-of-range MaxError (> 100%) can't underflow.
+        let measurement_accuracy: u32 = 100u32.saturating_sub(u32::from(self.max_error().await?)) * 1_000;
         let manufacture_date = self.manufacture_date().await?;
         let specification_info: u16 = self.specification_info().await?.into();
         let remaining_capacity_alarm = self.remaining_capacity_alarm().await?;

--- a/examples/pico-de-gallo/src/bin/battery.rs
+++ b/examples/pico-de-gallo/src/bin/battery.rs
@@ -133,9 +133,9 @@ impl bs::FuelGauge for Battery {
         self.state_mut().on_dynamic_data(|d| {
             d.average_current = average_current;
             d.battery_status = battery_status;
-            d.max_power = max_power;
+            d.max_power_mw = max_power;
             d.battery_temp = battery_temp;
-            d.sus_power = sus_power;
+            d.sus_power_mw = sus_power;
             d.charging_current = charging_current;
             d.charging_voltage = charging_voltage;
             d.voltage = voltage;
@@ -147,7 +147,7 @@ impl bs::FuelGauge for Battery {
             d.max_error = max_error;
             d.bmd_status = embedded_batteries_async::acpi::BmdStatusFlags::default();
             d.turbo_vload = 0;
-            d.turbo_rhf_effective = 0;
+            d.turbo_rhf_effective_mohm = 0;
         });
         Ok(())
     }

--- a/examples/pico-de-gallo/src/bin/battery.rs
+++ b/examples/pico-de-gallo/src/bin/battery.rs
@@ -58,6 +58,8 @@ embedded_batteries_async::impl_smart_battery_for_wrapper_type!(Battery, driver, 
 
 impl bs::FuelGauge for Battery {
     type FuelGaugeError = BatteryError;
+    type StaticData = bs::StaticBatteryMsgs;
+    type DynamicData = bs::DynamicBatteryMsgs;
 
     async fn initialize(&mut self) -> Result<(), Self::FuelGaugeError> {
         self.driver
@@ -83,73 +85,70 @@ impl bs::FuelGauge for Battery {
     }
 
     async fn update_static_data(&mut self) -> Result<(), Self::FuelGaugeError> {
-        let mut buf = [0u8; 21];
-        let mut new_msgs = bs::StaticBatteryMsgs {
-            design_capacity_mwh: match self.design_capacity().await? {
-                embedded_batteries_async::smart_battery::CapacityModeValue::CentiWattUnsigned(_) => 0xDEADBEEF,
-                embedded_batteries_async::smart_battery::CapacityModeValue::MilliAmpUnsigned(design_capacity) => {
-                    design_capacity.into()
-                }
-            },
-            design_voltage_mv: self.design_voltage().await?,
-            ..Default::default()
-        };
+        let design_capacity = self.design_capacity().await?;
+        let design_voltage = self.design_voltage().await?;
+        let mut device_chemistry = [0u8; 5];
+        self.device_chemistry(&mut device_chemistry).await?;
 
-        let buf_len = new_msgs.device_chemistry.len();
-        self.device_chemistry(&mut buf[..buf_len]).await?;
-        new_msgs.device_chemistry.copy_from_slice(&buf[..buf_len]);
-
-        self.state_mut().on_static_data(new_msgs);
+        self.state_mut().on_static_data(|s| {
+            s.design_capacity = design_capacity;
+            s.design_voltage = design_voltage;
+            s.device_chemistry = device_chemistry;
+        });
         Ok(())
     }
 
     async fn update_dynamic_data(&mut self) -> Result<(), Self::FuelGaugeError> {
-        let new_msgs = bs::DynamicBatteryMsgs {
-            average_current_ma: self.average_current().await?,
-            battery_status: self.battery_status().await?.into(),
-            max_power_mw: self
-                .driver
-                .device
-                .max_turbo_power()
-                .read_async()
-                .await?
-                .max_turbo_power()
-                .unsigned_abs()
-                .into(),
-            battery_temp_dk: self.temperature().await?,
-            sus_power_mw: self
-                .driver
-                .device
-                .sus_turbo_power()
-                .read_async()
-                .await?
-                .sus_turbo_power()
-                .unsigned_abs()
-                .into(),
-            charging_current_ma: self.charging_current().await?,
-            charging_voltage_mv: self.charging_voltage().await?,
-            voltage_mv: self.voltage().await?,
-            current_ma: self.current().await?,
-            full_charge_capacity_mwh: match self.full_charge_capacity().await? {
-                embedded_batteries_async::smart_battery::CapacityModeValue::CentiWattUnsigned(_) => 0xDEADBEEF,
-                embedded_batteries_async::smart_battery::CapacityModeValue::MilliAmpUnsigned(capacity) => {
-                    capacity.into()
-                }
-            },
-            remaining_capacity_mwh: match self.remaining_capacity().await? {
-                embedded_batteries_async::smart_battery::CapacityModeValue::CentiWattUnsigned(_) => 0xDEADBEEF,
-                embedded_batteries_async::smart_battery::CapacityModeValue::MilliAmpUnsigned(capacity) => {
-                    capacity.into()
-                }
-            },
-            relative_soc_pct: self.relative_state_of_charge().await?.into(),
-            cycle_count: self.cycle_count().await?,
-            max_error_pct: self.max_error().await?.into(),
-            bmd_status: embedded_batteries_async::acpi::BmdStatusFlags::default(),
-            turbo_vload_mv: 0,
-            turbo_rhf_effective_mohm: 0,
-        };
-        self.state_mut().on_dynamic_data(new_msgs);
+        let average_current = self.average_current().await?;
+        let battery_status: u16 = self.battery_status().await?.into();
+        let max_power: u32 = self
+            .driver
+            .device
+            .max_turbo_power()
+            .read_async()
+            .await?
+            .max_turbo_power()
+            .unsigned_abs()
+            .into();
+        let battery_temp = self.temperature().await?;
+        let sus_power: u32 = self
+            .driver
+            .device
+            .sus_turbo_power()
+            .read_async()
+            .await?
+            .sus_turbo_power()
+            .unsigned_abs()
+            .into();
+        let charging_current = self.charging_current().await?;
+        let charging_voltage = self.charging_voltage().await?;
+        let voltage = self.voltage().await?;
+        let current = self.current().await?;
+        let full_charge_capacity = self.full_charge_capacity().await?;
+        let remaining_capacity = self.remaining_capacity().await?;
+        let relative_soc = self.relative_state_of_charge().await?;
+        let cycle_count = self.cycle_count().await?;
+        let max_error = self.max_error().await?;
+
+        self.state_mut().on_dynamic_data(|d| {
+            d.average_current = average_current;
+            d.battery_status = battery_status;
+            d.max_power = max_power;
+            d.battery_temp = battery_temp;
+            d.sus_power = sus_power;
+            d.charging_current = charging_current;
+            d.charging_voltage = charging_voltage;
+            d.voltage = voltage;
+            d.current = current;
+            d.full_charge_capacity = full_charge_capacity;
+            d.remaining_capacity = remaining_capacity;
+            d.relative_soc = relative_soc;
+            d.cycle_count = cycle_count;
+            d.max_error = max_error;
+            d.bmd_status = embedded_batteries_async::acpi::BmdStatusFlags::default();
+            d.turbo_vload = 0;
+            d.turbo_rhf_effective = 0;
+        });
         Ok(())
     }
 


### PR DESCRIPTION
- Introduce StaticBatteryData and DynamicBatteryData traits and make the
fuel-gauge State generic over them (State<S, D>) so OEM drivers can cache
a custom type that embeds the standard StaticBatteryMsgs / Dynamic
BatteryMsgs and adds extra fields, while the battery service still reads
the standard fields needed to answer ACPI queries.

Rework the cache data model in the process:

- Encode capacity and rate quantities with the Smart Battery
  CapacityModeValue / CapacityModeSignedValue enums so each value
  self-describes its unit (mA/mAh vs centiWatt) instead of assuming a
  fixed encoding.
- Drop unit-suffixed field names in favor of the embedded-batteries
  typed aliases (MilliVolts, MilliAmps, Percent, Cycles, DeciKelvin,
  Minutes), keeping units in the types and docs.
- Add the previously missing ACPI/SBS fields (manufacture_date,
  specification_info, remaining_capacity_alarm, at_rate and its
  predictions, run_time_to_empty, average_time_to_*), and document
  every field.

Since the capacity enums have no Default, replace the derived Default on
both cache structs with manual impls that default to the mA-zero variant.

Update the mock fuel gauge to source every SmartBattery getter from the
cached State and add coherent emulated-pack constructors (new, new_2s,
new_4s) that scale pack voltage and power with the series cell count.

Change State::on_static_data / on_dynamic_data to take an in-place
updater closure (FnOnce(&mut S/D)) instead of consuming the data by
value. The closure writes freshly read values directly into the cache
storage, so a (potentially large or OEM-extended) S/D is never moved or
copied through the call.

Assisted-by: GitHub Copilot:claude-opus-4.8

Depends on #893 