### PR TITLE
type-c-service: Move most of `utils` into `type-c-interface`

### DIFF
--- a/examples/std/src/bin/type_c/service.rs
+++ b/examples/std/src/bin/type_c/service.rs
@@ -18,6 +18,7 @@ use std_examples::type_c::mock_controller::Port;
 use std_examples::type_c::mock_controller::{self, InterruptReceiver};
 use type_c_interface::port::event::PortEventBitfield;
 use type_c_interface::service::event::PortEventData as ServicePortEventData;
+use type_c_interface::util::power_capability_from_current;
 use type_c_service::controller::event_receiver::InterruptReceiver as _;
 use type_c_service::controller::event_receiver::{EventReceiver as PortEventReceiver, PortEventSplitter};
 use type_c_service::controller::macros::PortComponents;
@@ -25,7 +26,6 @@ use type_c_service::controller::state::SharedState;
 use type_c_service::define_controller_port_static_cell_channel;
 use type_c_service::service::Service;
 use type_c_service::service::config::Config;
-use type_c_service::util::power_capability_from_current;
 
 const DELAY_MS: u64 = 1000;
 

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -21,8 +21,8 @@ use type_c_interface::control::type_c::TypeCStateMachineState;
 use type_c_interface::control::usb::UsbControlConfig;
 use type_c_interface::control::vdm::{AttnVdm, OtherVdm, SendVdm};
 use type_c_interface::port::event::PortEventBitfield;
+use type_c_interface::util::power_capability_from_current;
 use type_c_service::controller::state::SharedState;
-use type_c_service::util::power_capability_from_current;
 
 pub struct ControllerState {
     events: Signal<GlobalRawMutex, PortEventBitfield>,

--- a/type-c-interface/src/lib.rs
+++ b/type-c-interface/src/lib.rs
@@ -5,3 +5,4 @@ pub mod controller;
 pub mod port;
 pub mod service;
 pub mod ucsi;
+pub mod util;

--- a/type-c-interface/src/util.rs
+++ b/type-c-interface/src/util.rs
@@ -1,0 +1,67 @@
+//! Type-C utility functions and constants.
+use embedded_usb_pd::pdo::{Common, Contract};
+use embedded_usb_pd::type_c;
+use embedded_usb_pd::{Error as PdBusError, PdError};
+use power_policy_interface::psu::Error as PowerPolicyError;
+
+pub fn power_capability_try_from_contract(
+    contract: Contract,
+) -> Option<power_policy_interface::capability::PowerCapability> {
+    Some(power_policy_interface::capability::PowerCapability {
+        voltage_mv: contract.pdo.max_voltage_mv(),
+        current_ma: contract.operating_current_ma()?,
+    })
+}
+
+pub fn power_capability_from_current(current: type_c::Current) -> power_policy_interface::capability::PowerCapability {
+    power_policy_interface::capability::PowerCapability {
+        voltage_mv: 5000,
+        // Assume higher power for now
+        current_ma: current.to_ma(false),
+    }
+}
+
+/// Type-C USB2 power capability 5V@500mA
+pub const POWER_CAPABILITY_USB_DEFAULT_USB2: power_policy_interface::capability::PowerCapability =
+    power_policy_interface::capability::PowerCapability {
+        voltage_mv: 5000,
+        current_ma: 500,
+    };
+
+/// Type-C USB3 power capability 5V@900mA
+pub const POWER_CAPABILITY_USB_DEFAULT_USB3: power_policy_interface::capability::PowerCapability =
+    power_policy_interface::capability::PowerCapability {
+        voltage_mv: 5000,
+        current_ma: 900,
+    };
+
+/// Type-C power capability 5V@1.5A
+pub const POWER_CAPABILITY_5V_1A5: power_policy_interface::capability::PowerCapability =
+    power_policy_interface::capability::PowerCapability {
+        voltage_mv: 5000,
+        current_ma: 1500,
+    };
+
+/// Type-C power capability 5V@3A
+pub const POWER_CAPABILITY_5V_3A0: power_policy_interface::capability::PowerCapability =
+    power_policy_interface::capability::PowerCapability {
+        voltage_mv: 5000,
+        current_ma: 3000,
+    };
+
+/// Converts a PD error into a power policy error
+pub fn power_policy_error_from_pd_error(pd_error: PdError) -> PowerPolicyError {
+    match pd_error {
+        PdError::Busy => PowerPolicyError::Busy,
+        PdError::Timeout => PowerPolicyError::Timeout,
+        _ => PowerPolicyError::Failed,
+    }
+}
+
+/// Converts a PD bus error into a power policy error
+pub fn power_policy_error_from_pd_bus_error<BE>(pd_error: PdBusError<BE>) -> PowerPolicyError {
+    match pd_error {
+        PdBusError::Pd(pd_error) => power_policy_error_from_pd_error(pd_error),
+        PdBusError::Bus(_) => PowerPolicyError::Bus,
+    }
+}

--- a/type-c-service/src/controller/power.rs
+++ b/type-c-service/src/controller/power.rs
@@ -11,7 +11,8 @@ use power_policy_interface::{
 };
 use type_c_interface::controller::power::SystemPowerStateStatus;
 
-use crate::{controller::config::UnconstrainedSink, util::power_policy_error_from_pd_error};
+use crate::controller::config::UnconstrainedSink;
+use type_c_interface::util::power_policy_error_from_pd_error;
 
 use super::*;
 

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -44,9 +44,8 @@ use type_c_interface::controller::pd::Pd;
 use type_c_interface::controller::retimer::Retimer;
 use type_c_interface::port::event::PortEventBitfield;
 
-use crate::util::{
-    basic_fw_update_error_from_pd_error, power_capability_from_current, power_capability_try_from_contract,
-};
+use crate::util::basic_fw_update_error_from_pd_error;
+use type_c_interface::util::{power_capability_from_current, power_capability_try_from_contract};
 
 type Updater<'a, M, B> = BorrowedUpdaterInProgress<tps6699x_drv::Tps6699x<'a, M, B>>;
 

--- a/type-c-service/src/util.rs
+++ b/type-c-service/src/util.rs
@@ -1,54 +1,6 @@
 //! Type-C service utility functions and constants.
-use embedded_usb_pd::pdo::{Common, Contract};
-use embedded_usb_pd::type_c;
 use embedded_usb_pd::{Error as PdBusError, PdError};
 use fw_update_interface::basic::Error as BasicFwError;
-use power_policy_interface::psu::Error as PowerPolicyError;
-
-pub fn power_capability_try_from_contract(
-    contract: Contract,
-) -> Option<power_policy_interface::capability::PowerCapability> {
-    Some(power_policy_interface::capability::PowerCapability {
-        voltage_mv: contract.pdo.max_voltage_mv(),
-        current_ma: contract.operating_current_ma()?,
-    })
-}
-
-pub fn power_capability_from_current(current: type_c::Current) -> power_policy_interface::capability::PowerCapability {
-    power_policy_interface::capability::PowerCapability {
-        voltage_mv: 5000,
-        // Assume higher power for now
-        current_ma: current.to_ma(false),
-    }
-}
-
-/// Type-C USB2 power capability 5V@500mA
-pub const POWER_CAPABILITY_USB_DEFAULT_USB2: power_policy_interface::capability::PowerCapability =
-    power_policy_interface::capability::PowerCapability {
-        voltage_mv: 5000,
-        current_ma: 500,
-    };
-
-/// Type-C USB3 power capability 5V@900mA
-pub const POWER_CAPABILITY_USB_DEFAULT_USB3: power_policy_interface::capability::PowerCapability =
-    power_policy_interface::capability::PowerCapability {
-        voltage_mv: 5000,
-        current_ma: 900,
-    };
-
-/// Type-C power capability 5V@1.5A
-pub const POWER_CAPABILITY_5V_1A5: power_policy_interface::capability::PowerCapability =
-    power_policy_interface::capability::PowerCapability {
-        voltage_mv: 5000,
-        current_ma: 1500,
-    };
-
-/// Type-C power capability 5V@3A
-pub const POWER_CAPABILITY_5V_3A0: power_policy_interface::capability::PowerCapability =
-    power_policy_interface::capability::PowerCapability {
-        voltage_mv: 5000,
-        current_ma: 3000,
-    };
 
 /// Converts a PD error into a basic FW update error
 pub fn basic_fw_update_error_from_pd_error(pd_error: PdError) -> BasicFwError {
@@ -63,22 +15,5 @@ pub fn basic_fw_update_error_from_pd_bus_error<BE>(pd_error: PdBusError<BE>) -> 
     match pd_error {
         PdBusError::Pd(pd_error) => basic_fw_update_error_from_pd_error(pd_error),
         PdBusError::Bus(_) => BasicFwError::Bus,
-    }
-}
-
-/// Converts a PD error into a power policy error
-pub fn power_policy_error_from_pd_error(pd_error: PdError) -> PowerPolicyError {
-    match pd_error {
-        PdError::Busy => PowerPolicyError::Busy,
-        PdError::Timeout => PowerPolicyError::Timeout,
-        _ => PowerPolicyError::Failed,
-    }
-}
-
-/// Converts a PD bus error into a power policy error
-pub fn power_policy_error_from_pd_bus_error<BE>(pd_error: PdBusError<BE>) -> PowerPolicyError {
-    match pd_error {
-        PdBusError::Pd(pd_error) => power_policy_error_from_pd_error(pd_error),
-        PdBusError::Bus(_) => PowerPolicyError::Bus,
     }
 }

--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -12,8 +12,9 @@ use power_policy_interface::{
 use type_c_interface::{
     control::pd::PortStatus,
     port::event::{PortEvent, PortStatusEventBitfield},
+    util::POWER_CAPABILITY_5V_1A5,
 };
-use type_c_service::{controller::event::Event, util::POWER_CAPABILITY_5V_1A5};
+use type_c_service::controller::event::Event;
 
 use crate::common::{
     DEFAULT_PER_CALL_TIMEOUT, DEFAULT_TEST_DURATION, PowerPolicyServiceReceiver, Test, TestPort, TypeCServiceReceiver,


### PR DESCRIPTION
Move these functions because they're generally useful and not specific to `type-c-service`.