### PR TITLE
Manually cast `heapless::Vec` to slice for `select_slice`

### DIFF
--- a/power-policy-service/src/charger.rs
+++ b/power-policy-service/src/charger.rs
@@ -35,7 +35,10 @@ where
                 // Push will never fail since the number of receivers is the same as the capacity of the vector
                 let _ = futures.push(async move { (receiver.wait_next().await, psu) });
             }
-            select_slice(pin!(&mut futures)).await
+            // Pin the futures and deference to a slice
+            let pinned = pin!(futures);
+            // Safety: The backing buffer is contained within the heapless::Vec so it won't be moved either.
+            select_slice(unsafe { pinned.map_unchecked_mut(|f| f.as_mut()) }).await
         };
 
         Event { charger, event }

--- a/power-policy-service/src/psu.rs
+++ b/power-policy-service/src/psu.rs
@@ -32,7 +32,10 @@ where
                 // Push will never fail since the number of receivers is the same as the capacity of the vector
                 let _ = futures.push(async move { (receiver.wait_next().await, psu) });
             }
-            select_slice(pin!(&mut futures)).await
+            // Pin the futures and deference to a slice
+            let pinned = pin!(futures);
+            // Safety: The backing buffer is contained within the heapless::Vec so it won't be moved either.
+            select_slice(unsafe { pinned.map_unchecked_mut(|f| f.as_mut()) }).await
         };
 
         Event { psu, event }

--- a/type-c-service/src/service/event_receiver.rs
+++ b/type-c-service/src/service/event_receiver.rs
@@ -42,7 +42,10 @@ impl<
                 // Push will never fail since the number of receivers is the same as the capacity of the vector
                 let _ = futures.push(async move { (receiver.wait_next().await, psu) });
             }
-            select_slice(pin!(&mut futures)).await
+            // Pin the futures and deference to a slice
+            let pinned = pin!(futures);
+            // Safety: The backing buffer is contained within the heapless::Vec so it won't be moved either.
+            select_slice(unsafe { pinned.map_unchecked_mut(|f| f.as_mut()) }).await
         };
 
         Event::PortEvent(PortEvent { port: *port, event })


### PR DESCRIPTION
The current implementation of `pin!` automatically does type coercion with references. We rely on this when using `select_slice`. However, this behavior is unsound because there's no guarantee that the result of this coercion is actually pinned. Pre-emptively Use `map_unchecked_mut` to manually perform this cast since it is safe in our case and because this fix will eventually land on main (currently present on nightly 1.97).

See https://github.com/rust-lang/rust/issues/153438 and https://github.com/rust-lang/rust/pull/153457.