### PR TITLE
Disable sink path during voltage transition

### DIFF
--- a/power-policy-interface/src/capability.rs
+++ b/power-policy-interface/src/capability.rs
@@ -203,6 +203,72 @@ impl ProviderFlags {
     }
 }
 
+bitfield! {
+    /// Flags for disconnect events
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    struct ConsumerDisconnectRaw(u32);
+    impl Debug;
+    /// Renegotiation
+    ///
+    /// When set this flag indicates that the current consumer is attempting to negotiate a new power capability.
+    pub bool, renegotiation, set_renegotiation: 0;
+    /// Switching
+    ///
+    /// When set this flag indicates that the service is switching to a different PSU.
+    pub bool, switching, set_switching: 1;
+}
+
+/// Type safe wrapper for consumer disconnect flags
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ConsumerDisconnect(ConsumerDisconnectRaw);
+
+impl ConsumerDisconnect {
+    /// Create new consumer disconnect flags with no flags set
+    pub const fn none() -> Self {
+        Self(ConsumerDisconnectRaw(0))
+    }
+
+    /// Builder method to set the renegotiation flag
+    pub fn with_renegotiation(mut self, value: bool) -> Self {
+        self.set_renegotiation(value);
+        self
+    }
+
+    /// Set the value of the renegotiation flag
+    pub fn set_renegotiation(&mut self, value: bool) {
+        self.0.set_renegotiation(value);
+    }
+
+    /// Get the value of the renegotiation flag
+    pub fn renegotiation(&self) -> bool {
+        self.0.renegotiation()
+    }
+
+    /// Builder method to set the switching flag
+    pub fn with_switching(mut self, value: bool) -> Self {
+        self.set_switching(value);
+        self
+    }
+
+    /// Set the value of the switching flag
+    pub fn set_switching(&mut self, value: bool) {
+        self.0.set_switching(value);
+    }
+
+    /// Get the value of the switching flag
+    pub fn switching(&self) -> bool {
+        self.0.switching()
+    }
+}
+
+impl Default for ConsumerDisconnect {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,5 +321,35 @@ mod tests {
         assert_eq!(provider.0.0, 0x100);
         provider.set_psu_type(PsuType::Unknown);
         assert_eq!(provider.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_consumer_disconnect_renegotiation() {
+        let mut disconnect = ConsumerDisconnect::none().with_renegotiation(true);
+        assert_eq!(disconnect.0.0, 0x1);
+        assert!(disconnect.renegotiation());
+        assert!(!disconnect.switching());
+        disconnect.set_renegotiation(false);
+        assert_eq!(disconnect.0.0, 0x0);
+        assert!(!disconnect.renegotiation());
+    }
+
+    #[test]
+    fn test_consumer_disconnect_switching() {
+        let mut disconnect = ConsumerDisconnect::none().with_switching(true);
+        assert_eq!(disconnect.0.0, 0x2);
+        assert!(disconnect.switching());
+        assert!(!disconnect.renegotiation());
+        disconnect.set_switching(false);
+        assert_eq!(disconnect.0.0, 0x0);
+        assert!(!disconnect.switching());
+    }
+
+    #[test]
+    fn test_consumer_disconnect_default() {
+        let disconnect = ConsumerDisconnect::default();
+        assert_eq!(disconnect.0.0, 0x0);
+        assert!(!disconnect.renegotiation());
+        assert!(!disconnect.switching());
     }
 }

--- a/power-policy-interface/src/psu/event.rs
+++ b/power-policy-interface/src/psu/event.rs
@@ -2,7 +2,7 @@
 use embedded_services::sync::Lockable;
 
 use crate::{
-    capability::{ConsumerPowerCapability, ProviderPowerCapability},
+    capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
     psu,
 };
 
@@ -18,7 +18,7 @@ pub enum EventData {
     /// Request the given amount of power to provider
     RequestedProviderCapability(Option<ProviderPowerCapability>),
     /// Notify that a device cannot consume or provide power anymore
-    Disconnected,
+    Disconnected(ConsumerDisconnect),
     /// Notify that a device has detached
     Detached,
 }

--- a/power-policy-interface/src/service/event.rs
+++ b/power-policy-interface/src/service/event.rs
@@ -1,7 +1,7 @@
 use embedded_services::sync::Lockable;
 
 use crate::{
-    capability::{ConsumerPowerCapability, ProviderPowerCapability},
+    capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
     psu::Psu,
     service::UnconstrainedState,
 };
@@ -16,7 +16,7 @@ use crate::{
 #[non_exhaustive]
 pub enum EventData {
     /// Consumer disconnected
-    ConsumerDisconnected,
+    ConsumerDisconnected(ConsumerDisconnect),
     /// Consumer connected
     ConsumerConnected(ConsumerPowerCapability),
     /// Provider disconnected
@@ -33,7 +33,7 @@ where
 {
     fn from(value: Event<'device, PSU>) -> Self {
         match value {
-            Event::ConsumerDisconnected(_) => EventData::ConsumerDisconnected,
+            Event::ConsumerDisconnected(_, flags) => EventData::ConsumerDisconnected(flags),
             Event::ConsumerConnected(_, capability) => EventData::ConsumerConnected(capability),
             Event::ProviderDisconnected(_) => EventData::ProviderDisconnected,
             Event::ProviderConnected(_, capability) => EventData::ProviderConnected(capability),
@@ -51,7 +51,7 @@ where
     PSU::Inner: Psu,
 {
     /// Consumer disconnected
-    ConsumerDisconnected(&'device PSU),
+    ConsumerDisconnected(&'device PSU, ConsumerDisconnect),
     /// Consumer connected
     ConsumerConnected(&'device PSU, ConsumerPowerCapability),
     /// Provider disconnected

--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -249,7 +249,12 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
     }
 
     /// Determines and connects the best external power
-    pub(super) async fn update_current_consumer(&mut self) -> Result<(), Error> {
+    ///
+    /// `disconnect_flags` describes the reason for a disconnect and is applied to the
+    /// [`ServiceEvent::ConsumerDisconnected`] event when the current consumer is removed and not
+    /// replaced by another one. When switching between consumers the flags are derived from the
+    /// switch itself (see [`Self::connect_new_consumer`]).
+    pub(super) async fn update_current_consumer(&mut self, disconnect_flags: ConsumerDisconnect) -> Result<(), Error> {
         let current_consumer_name = if let Some(current_consumer) = self.state.current_consumer_state {
             current_consumer.psu.lock().await.name()
         } else {
@@ -275,7 +280,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
                 self.disconnect_chargers().await?;
                 self.broadcast_event(ServiceEvent::ConsumerDisconnected(
                     current_consumer.psu,
-                    ConsumerDisconnect::none(),
+                    disconnect_flags,
                 ));
             }
             // No new consumer available

--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -8,7 +8,10 @@ use super::*;
 
 use power_policy_interface::psu;
 use power_policy_interface::service::event::Event as ServiceEvent;
-use power_policy_interface::{capability::ConsumerPowerCapability, psu::PsuState};
+use power_policy_interface::{
+    capability::{ConsumerDisconnect, ConsumerPowerCapability},
+    psu::PsuState,
+};
 
 /// State of the current consumer
 #[derive(Debug, PartialEq, Eq)]
@@ -216,7 +219,15 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
             // so just continue execution.
             self.disconnect_chargers().await?;
 
-            self.broadcast_event(ServiceEvent::ConsumerDisconnected(current_consumer.psu));
+            // Indicate why the current consumer is being disconnected. If we are reconnecting
+            // the same device, it is renegotiating a new power capability. Otherwise, the service
+            // is switching to a different PSU.
+            let flags = if ptr::eq(current_consumer.psu, new_consumer.psu) {
+                ConsumerDisconnect::none().with_renegotiation(true)
+            } else {
+                ConsumerDisconnect::none().with_switching(true)
+            };
+            self.broadcast_event(ServiceEvent::ConsumerDisconnected(current_consumer.psu, flags));
 
             // Don't update the unconstrained here because this is a transitional state
         }
@@ -262,7 +273,10 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
             // Notify disconnect if recently detached consumer was previously attached.
             if let Some(current_consumer) = self.state.current_consumer_state {
                 self.disconnect_chargers().await?;
-                self.broadcast_event(ServiceEvent::ConsumerDisconnected(current_consumer.psu));
+                self.broadcast_event(ServiceEvent::ConsumerDisconnected(
+                    current_consumer.psu,
+                    ConsumerDisconnect::none(),
+                ));
             }
             // No new consumer available
             self.state.current_consumer_state = None;

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -14,7 +14,7 @@ use embedded_services::{event::NonBlockingSender, info, sync::Lockable, trace};
 
 use power_policy_interface::charger::{Charger, PsuState};
 use power_policy_interface::{
-    capability::{ConsumerPowerCapability, ProviderPowerCapability},
+    capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
     charger::{Event as ChargerEvent, EventData as ChargerEventData},
     psu::{
         Error, Psu,
@@ -117,7 +117,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
     async fn process_notify_detach(&mut self, device: &'device Reg::Psu) -> Result<(), Error> {
         info!("({}): Received notify detached", device.lock().await.name());
         self.post_provider_removed(device).await;
-        self.update_current_consumer().await?;
+        self.update_current_consumer(ConsumerDisconnect::none()).await?;
         Ok(())
     }
 
@@ -132,7 +132,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
             capability,
         );
 
-        self.update_current_consumer().await
+        self.update_current_consumer(ConsumerDisconnect::none()).await
     }
 
     async fn process_request_provider_power_capabilities(
@@ -149,10 +149,14 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
         self.connect_provider(requester).await
     }
 
-    async fn process_notify_disconnect(&mut self, device: &'device Reg::Psu) -> Result<(), Error> {
+    async fn process_notify_disconnect(
+        &mut self,
+        device: &'device Reg::Psu,
+        flags: ConsumerDisconnect,
+    ) -> Result<(), Error> {
         info!("({}): Received notify disconnect", device.lock().await.name());
         self.post_provider_removed(device).await;
-        self.update_current_consumer().await?;
+        self.update_current_consumer(flags).await?;
         Ok(())
     }
 
@@ -180,7 +184,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
                 self.process_request_provider_power_capabilities(device, capability)
                     .await
             }
-            PsuEventData::Disconnected => self.process_notify_disconnect(device).await,
+            PsuEventData::Disconnected(flags) => self.process_notify_disconnect(device, flags).await,
             _ => {
                 info!(
                     "Received unknown PSU event from ({}): {:?}",

--- a/power-policy-service/tests/common/mock.rs
+++ b/power-policy-service/tests/common/mock.rs
@@ -54,6 +54,14 @@ impl<'a, S: NonBlockingSender<EventData>> Mock<'a, S> {
             .unwrap();
     }
 
+    /// Simulate an already-attached consumer renegotiating a new power capability.
+    pub async fn simulate_update_consumer_power_capability(&mut self, capability: Option<ConsumerPowerCapability>) {
+        self.state.update_consumer_power_capability(capability).unwrap();
+        self.sender
+            .try_send(EventData::UpdatedConsumerCapability(capability))
+            .unwrap();
+    }
+
     pub async fn simulate_detach(&mut self) {
         self.state.detach();
         self.sender.try_send(EventData::Detached).unwrap();

--- a/power-policy-service/tests/common/mock.rs
+++ b/power-policy-service/tests/common/mock.rs
@@ -4,7 +4,9 @@ use embassy_sync::{channel, mutex::Mutex, signal::Signal};
 use embedded_batteries_async::charger::{MilliAmps, MilliVolts};
 use embedded_services::{GlobalRawMutex, event::NonBlockingSender, info, named::Named};
 use power_policy_interface::{
-    capability::{ConsumerPowerCapability, PowerCapability, ProviderFlags, ProviderPowerCapability},
+    capability::{
+        ConsumerDisconnect, ConsumerPowerCapability, PowerCapability, ProviderFlags, ProviderPowerCapability,
+    },
     charger,
     psu::{Error, Psu, State, event::EventData},
 };
@@ -85,7 +87,9 @@ impl<'a, S: NonBlockingSender<EventData>> Mock<'a, S> {
 
     pub async fn simulate_disconnect(&mut self) {
         self.state.disconnect(true).unwrap();
-        self.sender.try_send(EventData::Disconnected).unwrap();
+        self.sender
+            .try_send(EventData::Disconnected(ConsumerDisconnect::none()))
+            .unwrap();
     }
 
     pub async fn simulate_update_requested_provider_power_capability(

--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -17,7 +17,7 @@ use embassy_time::{Duration, with_timeout};
 use embedded_services::GlobalRawMutex;
 use power_policy_interface::psu::event::EventData;
 use power_policy_interface::{
-    capability::{ConsumerPowerCapability, PowerCapability, ProviderPowerCapability},
+    capability::{ConsumerDisconnect, ConsumerPowerCapability, PowerCapability, ProviderPowerCapability},
     service::{UnconstrainedState, event::Event as ServiceEvent},
 };
 use power_policy_service::service::{Service, config::Config, customization};
@@ -168,10 +168,22 @@ pub async fn assert_consumer_disconnected<'a>(
     receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
     expected_device: &DeviceType<'a>,
 ) {
-    let ServiceEvent::ConsumerDisconnected(device) = receiver.receive().await else {
+    let ServiceEvent::ConsumerDisconnected(device, _) = receiver.receive().await else {
         panic!("Expected ConsumerDisconnected event");
     };
     assert_eq!(device as *const _, expected_device as *const _);
+}
+
+pub async fn assert_consumer_disconnected_with_flags<'a>(
+    receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+    expected_device: &DeviceType<'a>,
+    expected_flags: ConsumerDisconnect,
+) {
+    let ServiceEvent::ConsumerDisconnected(device, flags) = receiver.receive().await else {
+        panic!("Expected ConsumerDisconnected event");
+    };
+    assert_eq!(device as *const _, expected_device as *const _);
+    assert_eq!(flags, expected_flags);
 }
 
 pub async fn assert_consumer_connected<'a>(

--- a/power-policy-service/tests/consumer.rs
+++ b/power-policy-service/tests/consumer.rs
@@ -7,7 +7,7 @@ use embedded_services::info;
 use embedded_services::sync::Lockable;
 use power_policy_interface::capability::ProviderFlags;
 use power_policy_interface::capability::ProviderPowerCapability;
-use power_policy_interface::capability::{ConsumerFlags, ConsumerPowerCapability};
+use power_policy_interface::capability::{ConsumerDisconnect, ConsumerFlags, ConsumerPowerCapability};
 
 mod common;
 
@@ -30,7 +30,8 @@ use crate::common::assert_no_event;
 use crate::common::assert_provider_connected;
 use crate::common::assert_provider_disconnected;
 use crate::common::{
-    DEFAULT_TIMEOUT, HIGH_POWER, assert_consumer_connected, assert_consumer_disconnected, mock::FnCall, run_test,
+    DEFAULT_TIMEOUT, HIGH_POWER, assert_consumer_connected, assert_consumer_disconnected,
+    assert_consumer_disconnected_with_flags, mock::FnCall, run_test,
 };
 
 const PER_CALL_TIMEOUT: Duration = Duration::from_millis(1000);
@@ -791,6 +792,167 @@ impl Test for TestFindBestConsumerCustomization {
     }
 }
 
+/// Test that disconnecting the current consumer to switch to a different PSU sets the
+/// `switching` flag on the [`ServiceEvent::ConsumerDisconnected`] event.
+struct TestConsumerDisconnectSwitchingFlag;
+
+impl Test for TestConsumerDisconnectSwitchingFlag {
+    type Customization = DefaultCustomization;
+
+    async fn run<'a>(
+        &mut self,
+        _service: &ServiceMutex<'a, 'a, Self::Customization>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        device1: &DeviceType<'a>,
+        device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_consumer_disconnect_switching_flag");
+        // Connect device0 at low power.
+        device0
+            .lock()
+            .await
+            .simulate_consumer_connection(LOW_POWER.into())
+            .await;
+        assert_eq!(
+            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+            (
+                1,
+                FnCall::ConnectConsumer(ConsumerPowerCapability {
+                    capability: LOW_POWER,
+                    flags: ConsumerFlags::none(),
+                })
+            )
+        );
+        device0_signal.reset();
+        assert_consumer_connected(
+            service_receiver,
+            device0,
+            ConsumerPowerCapability {
+                capability: LOW_POWER,
+                flags: ConsumerFlags::none(),
+            },
+        )
+        .await;
+
+        // Connect device1 at high power, the service should switch to it.
+        device1
+            .lock()
+            .await
+            .simulate_consumer_connection(HIGH_POWER.into())
+            .await;
+        assert_eq!(
+            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+            (1, FnCall::Disconnect)
+        );
+        device0_signal.reset();
+        assert_eq!(
+            with_timeout(PER_CALL_TIMEOUT, device1_signal.wait()).await.unwrap(),
+            (
+                1,
+                FnCall::ConnectConsumer(ConsumerPowerCapability {
+                    capability: HIGH_POWER,
+                    flags: ConsumerFlags::none(),
+                })
+            )
+        );
+        device1_signal.reset();
+
+        // device0 should be disconnected with the switching flag set since we're switching to device1.
+        assert_consumer_disconnected_with_flags(
+            service_receiver,
+            device0,
+            ConsumerDisconnect::none().with_switching(true),
+        )
+        .await;
+        assert_consumer_connected(
+            service_receiver,
+            device1,
+            ConsumerPowerCapability {
+                capability: HIGH_POWER,
+                flags: ConsumerFlags::none(),
+            },
+        )
+        .await;
+
+        assert_no_event(service_receiver);
+    }
+}
+
+/// Test that disconnecting the current consumer because it renegotiated a new power capability
+/// sets the `renegotiation` flag on the [`ServiceEvent::ConsumerDisconnected`] event.
+struct TestConsumerDisconnectRenegotiationFlag;
+
+impl Test for TestConsumerDisconnectRenegotiationFlag {
+    type Customization = DefaultCustomization;
+
+    async fn run<'a>(
+        &mut self,
+        _service: &ServiceMutex<'a, 'a, Self::Customization>,
+        service_receiver: DynamicReceiver<'a, ServiceEvent<'a, DeviceType<'a>>>,
+        device0: &DeviceType<'a>,
+        device0_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+        _device1: &DeviceType<'a>,
+        _device1_signal: &Signal<GlobalRawMutex, (usize, FnCall)>,
+    ) {
+        info!("Running test_consumer_disconnect_renegotiation_flag");
+        // Connect device0 at low power.
+        device0
+            .lock()
+            .await
+            .simulate_consumer_connection(LOW_POWER.into())
+            .await;
+        assert_eq!(
+            with_timeout(PER_CALL_TIMEOUT, device0_signal.wait()).await.unwrap(),
+            (
+                1,
+                FnCall::ConnectConsumer(ConsumerPowerCapability {
+                    capability: LOW_POWER,
+                    flags: ConsumerFlags::none(),
+                })
+            )
+        );
+        device0_signal.reset();
+        assert_consumer_connected(
+            service_receiver,
+            device0,
+            ConsumerPowerCapability {
+                capability: LOW_POWER,
+                flags: ConsumerFlags::none(),
+            },
+        )
+        .await;
+
+        // The same device renegotiates a new (higher) power capability. Since the best consumer is
+        // still the same device but with a different capability, the service disconnects and
+        // reconnects it. The disconnect event should carry the renegotiation flag.
+        device0
+            .lock()
+            .await
+            .simulate_update_consumer_power_capability(Some(HIGH_POWER.into()))
+            .await;
+
+        assert_consumer_disconnected_with_flags(
+            service_receiver,
+            device0,
+            ConsumerDisconnect::none().with_renegotiation(true),
+        )
+        .await;
+        assert_consumer_connected(
+            service_receiver,
+            device0,
+            ConsumerPowerCapability {
+                capability: HIGH_POWER,
+                flags: ConsumerFlags::none(),
+            },
+        )
+        .await;
+
+        assert_no_event(service_receiver);
+    }
+}
+
 #[tokio::test]
 async fn run_test_swap_higher() {
     run_test(
@@ -860,6 +1022,28 @@ async fn run_test_find_best_consumer_hook() {
         TestFindBestConsumerCustomization,
         Default::default(),
         AlwaysFirstConsumerCustomization,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn run_test_consumer_disconnect_switching_flag() {
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestConsumerDisconnectSwitchingFlag,
+        Default::default(),
+        DefaultCustomization,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn run_test_consumer_disconnect_renegotiation_flag() {
+    run_test(
+        DEFAULT_TIMEOUT,
+        TestConsumerDisconnectRenegotiationFlag,
+        Default::default(),
+        DefaultCustomization,
     )
     .await;
 }

--- a/type-c-interface-mocks/src/controller/max_sink_voltage.rs
+++ b/type-c-interface-mocks/src/controller/max_sink_voltage.rs
@@ -1,0 +1,25 @@
+//! Mock implementation of [`type_c_interface::controller::max_sink_voltage::MaxSinkVoltage`]
+
+use embedded_usb_pd::{LocalPortId, PdError};
+use type_c_interface::controller::max_sink_voltage::MaxSinkVoltage;
+
+use super::FnCall as ControllerFnCall;
+use super::Mock;
+
+/// Contains a [`MaxSinkVoltage`] function call and its arguments
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FnCall {
+    SetMaxSinkVoltage(LocalPortId, Option<u16>),
+}
+
+impl MaxSinkVoltage for Mock {
+    async fn set_max_sink_voltage(&mut self, port: LocalPortId, voltage_mv: Option<u16>) -> Result<(), PdError> {
+        self.fn_calls
+            .push_back(ControllerFnCall::MaxSinkVoltage(FnCall::SetMaxSinkVoltage(
+                port, voltage_mv,
+            )));
+        self.next_result_set_max_sink_voltage
+            .pop_front()
+            .expect("next_result_set_max_sink_voltage not set")
+    }
+}

--- a/type-c-interface-mocks/src/controller/mod.rs
+++ b/type-c-interface-mocks/src/controller/mod.rs
@@ -10,6 +10,7 @@ use type_c_interface::control::{
     vdm::{AttnVdm, OtherVdm},
 };
 
+pub mod max_sink_voltage;
 pub mod pd;
 pub mod ucsi;
 
@@ -17,6 +18,7 @@ pub mod ucsi;
 pub enum FnCall {
     Pd(pd::FnCall),
     Ucsi(ucsi::FnCall),
+    MaxSinkVoltage(max_sink_voltage::FnCall),
 }
 
 /// Mock PD controller for use in tests
@@ -30,6 +32,8 @@ pub struct Mock {
     pub next_result_clear_dead_battery_flag: VecDeque<Result<(), PdError>>,
     /// Next results to return for [`type_c_interface::controller::pd::Pd::enable_sink_path`]
     pub next_result_enable_sink_path: VecDeque<Result<(), PdError>>,
+    /// Next results to return for [`type_c_interface::controller::max_sink_voltage::MaxSinkVoltage::set_max_sink_voltage`]
+    pub next_result_set_max_sink_voltage: VecDeque<Result<(), PdError>>,
     /// Next results to return for [`type_c_interface::controller::pd::Pd::get_pd_alert`]
     pub next_result_get_pd_alert: VecDeque<Result<Option<Ado>, PdError>>,
     /// Next results to return for [`type_c_interface::controller::pd::Pd::set_unconstrained_power`]
@@ -74,6 +78,7 @@ impl Mock {
             next_result_get_port_status: VecDeque::new(),
             next_result_clear_dead_battery_flag: VecDeque::new(),
             next_result_enable_sink_path: VecDeque::new(),
+            next_result_set_max_sink_voltage: VecDeque::new(),
             next_result_get_pd_alert: VecDeque::new(),
             next_result_set_unconstrained_power: VecDeque::new(),
             next_result_get_other_vdm: VecDeque::new(),

--- a/type-c-service/src/controller/max_sink_voltage.rs
+++ b/type-c-service/src/controller/max_sink_voltage.rs
@@ -17,10 +17,24 @@ impl<
     for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
 {
     async fn set_max_sink_voltage(&mut self, voltage_mv: Option<u16>) -> Result<(), PdError> {
-        self.controller
-            .lock()
-            .await
-            .set_max_sink_voltage(self.port, voltage_mv)
-            .await
+        // A change in the maximum sink voltage can trigger a PD renegotiation. During that transition the
+        // source may briefly output a voltage that does not match the active contract, which can cause an
+        // overcurrent/overvoltage condition on the sink path. If we currently have a connected consumer and
+        // the limit is actually changing (or being removed), disable the sink path before the renegotiation
+        // to protect the system. The power policy re-enables the sink path when it connects the consumer to
+        // the renegotiated contract.
+        let disable_sink_path = match self.psu_state.psu_state {
+            PsuState::ConnectedConsumer(capability) => {
+                voltage_mv.is_none() || voltage_mv != Some(capability.capability.voltage_mv)
+            }
+            _ => false,
+        };
+
+        let mut controller = self.controller.lock().await;
+        if disable_sink_path {
+            debug!("({}): Disabling sink path before max sink voltage change", self.name);
+            controller.enable_sink_path(self.port, false).await?;
+        }
+        controller.set_max_sink_voltage(self.port, voltage_mv).await
     }
 }

--- a/type-c-service/src/controller/max_sink_voltage.rs
+++ b/type-c-service/src/controller/max_sink_voltage.rs
@@ -1,6 +1,7 @@
 //! Max sink voltage port trait implementation
 use embedded_services::{event::NonBlockingSender, sync::Lockable};
 use embedded_usb_pd::PdError;
+use power_policy_interface::capability::ConsumerDisconnect;
 use type_c_interface::controller::max_sink_voltage::MaxSinkVoltage;
 
 use super::*;
@@ -20,9 +21,9 @@ impl<
         // A change in the maximum sink voltage can trigger a PD renegotiation. During that transition the
         // source may briefly output a voltage that does not match the active contract, which can cause an
         // overcurrent/overvoltage condition on the sink path. If we currently have a connected consumer and
-        // the limit is actually changing (or being removed), disable the sink path before the renegotiation
-        // to protect the system. The power policy re-enables the sink path when it connects the consumer to
-        // the renegotiated contract.
+        // the limit is actually changing (or being removed), disable the sink path and notify the power
+        // policy that we have disconnected before applying the new limit. The power policy re-enables the
+        // sink path when it reconnects the consumer to the renegotiated contract.
         let disable_sink_path = match self.psu_state.psu_state {
             PsuState::ConnectedConsumer(capability) => {
                 voltage_mv.is_none() || voltage_mv != Some(capability.capability.voltage_mv)
@@ -30,11 +31,31 @@ impl<
             _ => false,
         };
 
-        let mut controller = self.controller.lock().await;
         if disable_sink_path {
             debug!("({}): Disabling sink path before max sink voltage change", self.name);
-            controller.enable_sink_path(self.port, false).await?;
+            self.controller.lock().await.enable_sink_path(self.port, false).await?;
+
+            // Move our local state out of the consumer state and notify the power policy so it stops
+            // tracking us as the active consumer and broadcasts a ConsumerDisconnected event. The
+            // renegotiation flag marks this as a temporary disconnect for a recontract.
+            if let Err(e) = self.psu_state.disconnect(true) {
+                error!("({}): Error updating PSU state on disconnect: {:?}", self.name, e);
+            }
+            if self
+                .power_policy_sender
+                .try_send(power_policy_interface::psu::event::EventData::Disconnected(
+                    ConsumerDisconnect::none().with_renegotiation(true),
+                ))
+                .is_none()
+            {
+                error!("({}): Failed to notify power policy of disconnect", self.name);
+            }
         }
-        controller.set_max_sink_voltage(self.port, voltage_mv).await
+
+        self.controller
+            .lock()
+            .await
+            .set_max_sink_voltage(self.port, voltage_mv)
+            .await
     }
 }

--- a/type-c-service/src/service/power.rs
+++ b/type-c-service/src/service/power.rs
@@ -74,7 +74,7 @@ impl<'a, Reg: Registration<'a>> Service<'a, Reg> {
     pub(super) async fn process_power_policy_event(&mut self, message: &PowerPolicyEventData) -> Result<(), Error> {
         match message {
             PowerPolicyEventData::Unconstrained(state) => self.process_unconstrained_state_change(state).await,
-            PowerPolicyEventData::ConsumerDisconnected => {
+            PowerPolicyEventData::ConsumerDisconnected(_) => {
                 self.ucsi.psu_connected = false;
                 // Notify OPM because this can affect battery charging capability status
                 if self.ucsi.notifications_enabled.battery_charge_change() {

--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -12,7 +12,11 @@ use power_policy_interface::{
 use type_c_interface::{
     control::pd::PortStatus,
     port::event::{PortEvent, PortStatusEventBitfield},
+    port::max_sink_voltage::MaxSinkVoltage,
     util::POWER_CAPABILITY_5V_1A5,
+};
+use type_c_interface_mocks::controller::{
+    FnCall as ControllerFnCall, max_sink_voltage::FnCall as MaxSinkVoltageFnCall, pd::FnCall as PdFnCall,
 };
 use type_c_service::controller::event::Event;
 
@@ -114,10 +118,134 @@ impl Test for TestBasicConsumerFlow {
         assert_eq!(type_c_result.err(), Some(TimeoutError));
         // Power policy service should broadcast a consumer disconnect event
         match power_policy_result {
-            Ok(PowerPolicyEvent::ConsumerDisconnected(psu)) => {
+            Ok(PowerPolicyEvent::ConsumerDisconnected(psu, _)) => {
                 assert!(ptr::eq(psu, port0.port));
             }
             _ => panic!("Did not receive consumer disconnected event"),
+        }
+    }
+}
+
+/// Test that changing the max sink voltage while a consumer is connected disables the sink path
+/// before the renegotiation, while setting the same voltage does not.
+struct TestSinkDisableOnVoltageChange;
+
+impl Test for TestSinkDisableOnVoltageChange {
+    async fn run<'port, 'ch>(
+        &mut self,
+        type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        _port1: TestPort<'port, 'ch>,
+        _port2: TestPort<'port, 'ch>,
+    ) {
+        // Bring up a connected consumer at 5V.
+        {
+            let mut mock0 = port0.mock.lock().await;
+            mock0.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_sink_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Sink,
+                ..Default::default()
+            }));
+            // Sink path is enabled when the power policy connects the consumer.
+            mock0.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        let mut port_event = PortStatusEventBitfield::none();
+        port_event.set_plug_inserted_or_removed(true);
+        port_event.set_new_power_contract_as_consumer(true);
+        port_event.set_sink_ready(true);
+        port0
+            .port
+            .lock()
+            .await
+            .process_event(Event::PortEvent(PortEvent::StatusChanged(port_event)))
+            .await
+            .unwrap();
+
+        // Wait for the power policy to connect the consumer so the port is in the connected state.
+        let (_type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ConsumerConnected(psu, _)) => assert!(ptr::eq(psu, port0.port)),
+            _ => panic!("Did not receive consumer connected event"),
+        }
+
+        // Changing the max sink voltage should disable the sink path before the renegotiation.
+        {
+            let mut mock0 = port0.mock.lock().await;
+            mock0.fn_calls.clear();
+            mock0.next_result_enable_sink_path.push_back(Ok(()));
+            mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
+        }
+        port0.port.lock().await.set_max_sink_voltage(Some(9000)).await.unwrap();
+        {
+            let mut mock0 = port0.mock.lock().await;
+            assert!(
+                matches!(
+                    mock0.fn_calls.pop_front(),
+                    Some(ControllerFnCall::Pd(PdFnCall::EnableSinkPath(_, false)))
+                ),
+                "expected the sink path to be disabled before the voltage change"
+            );
+            assert!(
+                matches!(
+                    mock0.fn_calls.pop_front(),
+                    Some(ControllerFnCall::MaxSinkVoltage(
+                        MaxSinkVoltageFnCall::SetMaxSinkVoltage(_, Some(9000))
+                    ))
+                ),
+                "expected the max sink voltage to be set"
+            );
+            assert!(mock0.fn_calls.is_empty());
+        }
+
+        // Removing the voltage limit (None) also requires a renegotiation, so the sink path is disabled.
+        {
+            let mut mock0 = port0.mock.lock().await;
+            mock0.fn_calls.clear();
+            mock0.next_result_enable_sink_path.push_back(Ok(()));
+            mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
+        }
+        port0.port.lock().await.set_max_sink_voltage(None).await.unwrap();
+        {
+            let mut mock0 = port0.mock.lock().await;
+            assert!(matches!(
+                mock0.fn_calls.pop_front(),
+                Some(ControllerFnCall::Pd(PdFnCall::EnableSinkPath(_, false)))
+            ));
+            assert!(matches!(
+                mock0.fn_calls.pop_front(),
+                Some(ControllerFnCall::MaxSinkVoltage(
+                    MaxSinkVoltageFnCall::SetMaxSinkVoltage(_, None)
+                ))
+            ));
+            assert!(mock0.fn_calls.is_empty());
+        }
+
+        // Setting the same voltage as the active contract must not disable the sink path.
+        {
+            let mut mock0 = port0.mock.lock().await;
+            mock0.fn_calls.clear();
+            mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
+        }
+        port0.port.lock().await.set_max_sink_voltage(Some(5000)).await.unwrap();
+        {
+            let mut mock0 = port0.mock.lock().await;
+            assert!(
+                matches!(
+                    mock0.fn_calls.pop_front(),
+                    Some(ControllerFnCall::MaxSinkVoltage(
+                        MaxSinkVoltageFnCall::SetMaxSinkVoltage(_, Some(5000))
+                    ))
+                ),
+                "expected only the max sink voltage to be set without disabling the sink path"
+            );
+            assert!(mock0.fn_calls.is_empty());
         }
     }
 }
@@ -129,6 +257,17 @@ async fn test_basic_consumer_flow() {
         Default::default(),
         Default::default(),
         TestBasicConsumerFlow,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_sink_disable_on_voltage_change() {
+    common::run_test(
+        DEFAULT_TEST_DURATION,
+        Default::default(),
+        Default::default(),
+        TestSinkDisableOnVoltageChange,
     )
     .await;
 }

--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -6,7 +6,7 @@ use embassy_futures::join::join;
 use embassy_time::{TimeoutError, with_timeout};
 use embedded_usb_pd::{PowerRole, type_c::ConnectionState};
 use power_policy_interface::{
-    capability::{ConsumerFlags, ConsumerPowerCapability, PsuType},
+    capability::{ConsumerDisconnect, ConsumerFlags, ConsumerPowerCapability, PsuType},
     service::event::Event as PowerPolicyEvent,
 };
 use type_c_interface::{
@@ -126,8 +126,9 @@ impl Test for TestBasicConsumerFlow {
     }
 }
 
-/// Test that changing the max sink voltage while a consumer is connected disables the sink path
-/// before the renegotiation, while setting the same voltage does not.
+/// Test that changing the max sink voltage while a consumer is connected disables the sink path and
+/// notifies the power policy, which broadcasts a `ConsumerDisconnected` event with the renegotiation
+/// flag set. Setting the same voltage should do neither.
 struct TestSinkDisableOnVoltageChange;
 
 impl Test for TestSinkDisableOnVoltageChange {
@@ -170,12 +171,39 @@ impl Test for TestSinkDisableOnVoltageChange {
             with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
         )
         .await;
+
         match power_policy_result {
             Ok(PowerPolicyEvent::ConsumerConnected(psu, _)) => assert!(ptr::eq(psu, port0.port)),
             _ => panic!("Did not receive consumer connected event"),
         }
 
-        // Changing the max sink voltage should disable the sink path before the renegotiation.
+        // Setting the same voltage as the active contract must not disable the sink path or disconnect.
+        {
+            let mut mock0 = port0.mock.lock().await;
+            mock0.fn_calls.clear();
+            mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
+        }
+        port0.port.lock().await.set_max_sink_voltage(Some(5000)).await.unwrap();
+        {
+            let mut mock0 = port0.mock.lock().await;
+            assert!(
+                matches!(
+                    mock0.fn_calls.pop_front(),
+                    Some(ControllerFnCall::MaxSinkVoltage(
+                        MaxSinkVoltageFnCall::SetMaxSinkVoltage(_, Some(5000))
+                    ))
+                ),
+                "expected only the max sink voltage to be set without disabling the sink path"
+            );
+            assert!(mock0.fn_calls.is_empty());
+        }
+        // No disconnect should have been broadcast.
+        assert!(matches!(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()).await,
+            Err(TimeoutError)
+        ));
+
+        // Changing the max sink voltage should disable the sink path and notify the power policy.
         {
             let mut mock0 = port0.mock.lock().await;
             mock0.fn_calls.clear();
@@ -183,6 +211,17 @@ impl Test for TestSinkDisableOnVoltageChange {
             mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
         }
         port0.port.lock().await.set_max_sink_voltage(Some(9000)).await.unwrap();
+
+        // The power policy should broadcast a consumer disconnect with the renegotiation flag set.
+        match with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()).await {
+            Ok(PowerPolicyEvent::ConsumerDisconnected(psu, flags)) => {
+                assert!(ptr::eq(psu, port0.port));
+                assert_eq!(flags, ConsumerDisconnect::none().with_renegotiation(true));
+            }
+            _ => panic!("Did not receive consumer disconnected event"),
+        }
+
+        // The sink path should have been disabled before the new voltage was applied.
         {
             let mut mock0 = port0.mock.lock().await;
             assert!(
@@ -200,50 +239,6 @@ impl Test for TestSinkDisableOnVoltageChange {
                     ))
                 ),
                 "expected the max sink voltage to be set"
-            );
-            assert!(mock0.fn_calls.is_empty());
-        }
-
-        // Removing the voltage limit (None) also requires a renegotiation, so the sink path is disabled.
-        {
-            let mut mock0 = port0.mock.lock().await;
-            mock0.fn_calls.clear();
-            mock0.next_result_enable_sink_path.push_back(Ok(()));
-            mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
-        }
-        port0.port.lock().await.set_max_sink_voltage(None).await.unwrap();
-        {
-            let mut mock0 = port0.mock.lock().await;
-            assert!(matches!(
-                mock0.fn_calls.pop_front(),
-                Some(ControllerFnCall::Pd(PdFnCall::EnableSinkPath(_, false)))
-            ));
-            assert!(matches!(
-                mock0.fn_calls.pop_front(),
-                Some(ControllerFnCall::MaxSinkVoltage(
-                    MaxSinkVoltageFnCall::SetMaxSinkVoltage(_, None)
-                ))
-            ));
-            assert!(mock0.fn_calls.is_empty());
-        }
-
-        // Setting the same voltage as the active contract must not disable the sink path.
-        {
-            let mut mock0 = port0.mock.lock().await;
-            mock0.fn_calls.clear();
-            mock0.next_result_set_max_sink_voltage.push_back(Ok(()));
-        }
-        port0.port.lock().await.set_max_sink_voltage(Some(5000)).await.unwrap();
-        {
-            let mut mock0 = port0.mock.lock().await;
-            assert!(
-                matches!(
-                    mock0.fn_calls.pop_front(),
-                    Some(ControllerFnCall::MaxSinkVoltage(
-                        MaxSinkVoltageFnCall::SetMaxSinkVoltage(_, Some(5000))
-                    ))
-                ),
-                "expected only the max sink voltage to be set without disabling the sink path"
             );
             assert!(mock0.fn_calls.is_empty());
         }


### PR DESCRIPTION
- Disable the sink path before a max sink voltage change when a consumer is connected and the limit is changing or being removed, to avoid overcurrent/overvoltage during renegotiation.
- Add a ConsumerDisconnect flags argument to the power policy consumer disconnected event: renegotiation when the consumer is recontracting, switching when moving to a different PSU.
- Add tests for the sink disable logic and the new flags.

Assisted-by: GitHub Copilot:claude-opus-4.8

Resolves #874 and is a port of #861 