### PR TITLE
Add software sink-ready timeout test coverage

### DIFF
--- a/type-c-service/src/controller/state.rs
+++ b/type-c-service/src/controller/state.rs
@@ -14,6 +14,11 @@ impl SharedState {
             sink_ready_timeout: None,
         }
     }
+
+    /// Get the current sink ready timeout deadline, if one is pending
+    pub fn sink_ready_timeout(&self) -> Option<Instant> {
+        self.sink_ready_timeout
+    }
 }
 
 impl Default for SharedState {

--- a/type-c-service/tests/common/mod.rs
+++ b/type-c-service/tests/common/mod.rs
@@ -41,6 +41,12 @@ pub type PortPowerSender<'a> = DynamicSender<'a, power_policy_interface::psu::ev
 pub type PortPowerReceiver<'a> = DynamicReceiver<'a, power_policy_interface::psu::event::EventData>;
 /// [`type_c_service::controller::Port`] sender for loopback events
 pub type PortLoopbackSender<'a> = DynamicSender<'a, type_c_service::controller::event::Loopback>;
+/// Corresponding receiver for [`PortLoopbackSender`]
+pub type PortLoopbackReceiver<'a> = DynamicReceiver<'a, type_c_service::controller::event::Loopback>;
+/// Interrupt sender into a [`type_c_service::controller::Port`]'s event receiver
+pub type PortInterruptSender<'a> = DynamicSender<'a, type_c_interface::port::event::PortEventBitfield>;
+/// Corresponding receiver for [`PortInterruptSender`]
+pub type PortInterruptReceiver<'a> = DynamicReceiver<'a, type_c_interface::port::event::PortEventBitfield>;
 /// Shared port state type
 pub type PortSharedState = Mutex<GlobalRawMutex, type_c_service::controller::state::SharedState>;
 /// Port type
@@ -59,6 +65,14 @@ pub type PortMutexType<'port, 'ch> = Mutex<
         // Loopback sender
         PortLoopbackSender<'ch>,
     >,
+>;
+
+/// Controller-side event receiver that drives software sink-ready timeouts
+pub type PortEventReceiverType<'port, 'ch> = type_c_service::controller::event_receiver::EventReceiver<
+    'port,
+    PortSharedState,
+    PortInterruptReceiver<'ch>,
+    PortLoopbackReceiver<'ch>,
 >;
 
 /// Sender for events broadcast by the power policy service
@@ -117,6 +131,12 @@ pub struct TestPort<'port, 'ch> {
     pub port: &'port PortMutexType<'port, 'ch>,
     /// Underlying controller mock
     pub mock: &'port ControllerMockMutexType,
+    /// State shared between the port and its event receiver
+    pub shared_state: &'port PortSharedState,
+    /// Interrupt sender into the port's event receiver
+    pub interrupt_sender: PortInterruptSender<'ch>,
+    /// Controller-side event receiver, drives software sink-ready timeouts
+    pub event_receiver: PortEventReceiverType<'port, 'ch>,
 }
 
 /// Integration test trait
@@ -138,6 +158,9 @@ pub trait Test {
 struct PortComponents<'port, 'ch> {
     port: PortMutexType<'port, 'ch>,
     mock: &'port ControllerMockMutexType,
+    shared_state: &'port PortSharedState,
+    interrupt_sender: PortInterruptSender<'ch>,
+    event_receiver: PortEventReceiverType<'port, 'ch>,
     type_c_receiver: PortTypeCReceiver<'ch>,
     power_policy_receiver: PortPowerReceiver<'ch>,
 }
@@ -166,10 +189,24 @@ macro_rules! define_port {
             CHANNEL_SIZE,
         > = Channel::new(); }
         paste! { let [<$name _loopback_sender>] = [<$name _loopback_channel>].dyn_sender(); }
+        paste! { let [<$name _loopback_receiver>] = [<$name _loopback_channel>].dyn_receiver(); }
+
+        paste! { let [<$name _interrupt_channel>]: Channel<
+            GlobalRawMutex,
+            type_c_interface::port::event::PortEventBitfield,
+            CHANNEL_SIZE,
+        > = Channel::new(); }
+        paste! { let [<$name _interrupt_sender>] = [<$name _interrupt_channel>].dyn_sender(); }
+        paste! { let [<$name _interrupt_receiver>] = [<$name _interrupt_channel>].dyn_receiver(); }
 
         paste! { let [<$name _mock>] = Mutex::new(type_c_interface_mocks::controller::Mock::new($mock_name)); }
         paste! { let [<$name _shared_state>] =
         PortSharedState::new(type_c_service::controller::state::SharedState::new()); }
+        paste! { let [<$name _event_receiver>] = type_c_service::controller::event_receiver::EventReceiver::new(
+            &[<$name _shared_state>],
+            [<$name _interrupt_receiver>],
+            [<$name _loopback_receiver>],
+        ); }
         paste! { let $name = PortComponents {
                 port: Mutex::new(type_c_service::controller::Port::new(
                     $port_name,
@@ -182,6 +219,9 @@ macro_rules! define_port {
                     paste! { [<$name _loopback_sender>] },
             )),
             mock: &paste! { [<$name _mock>] },
+            shared_state: &paste! { [<$name _shared_state>] },
+            interrupt_sender: paste! { [<$name _interrupt_sender>] },
+            event_receiver: paste! { [<$name _event_receiver>] },
             type_c_receiver: paste! { [<$name _type_c_receiver>] },
             power_policy_receiver: paste! { [<$name _power_policy_receiver>] },
         };
@@ -264,6 +304,9 @@ pub async fn run_test(
         type_c_receiver: port0_type_c_receiver,
         power_policy_receiver: port0_power_policy_receiver,
         mock: port0_mock,
+        shared_state: port0_shared_state,
+        interrupt_sender: port0_interrupt_sender,
+        event_receiver: port0_event_receiver,
     } = port0;
 
     define_port!(port1, "mock1", "port1", port_config[1], LocalPortId(0));
@@ -272,6 +315,9 @@ pub async fn run_test(
         type_c_receiver: port1_type_c_receiver,
         power_policy_receiver: port1_power_policy_receiver,
         mock: port1_mock,
+        shared_state: port1_shared_state,
+        interrupt_sender: port1_interrupt_sender,
+        event_receiver: port1_event_receiver,
     } = port1;
 
     define_port!(port2, "mock2", "port2", port_config[2], LocalPortId(0));
@@ -280,6 +326,9 @@ pub async fn run_test(
         type_c_receiver: port2_type_c_receiver,
         power_policy_receiver: port2_power_policy_receiver,
         mock: port2_mock,
+        shared_state: port2_shared_state,
+        interrupt_sender: port2_interrupt_sender,
+        event_receiver: port2_event_receiver,
     } = port2;
 
     // Channel to broadcast events from the type-C service
@@ -375,14 +424,23 @@ pub async fn run_test(
                     TestPort {
                         port: &port0,
                         mock: port0_mock,
+                        shared_state: port0_shared_state,
+                        interrupt_sender: port0_interrupt_sender,
+                        event_receiver: port0_event_receiver,
                     },
                     TestPort {
                         port: &port1,
                         mock: port1_mock,
+                        shared_state: port1_shared_state,
+                        interrupt_sender: port1_interrupt_sender,
+                        event_receiver: port1_event_receiver,
                     },
                     TestPort {
                         port: &port2,
                         mock: port2_mock,
+                        shared_state: port2_shared_state,
+                        interrupt_sender: port2_interrupt_sender,
+                        event_receiver: port2_event_receiver,
                     },
                 )
                 .await;

--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -3,15 +3,16 @@
 use std::ptr;
 
 use embassy_futures::join::join;
-use embassy_time::{TimeoutError, with_timeout};
-use embedded_usb_pd::{PowerRole, type_c::ConnectionState};
+use embassy_time::{Duration, Instant, TimeoutError, with_timeout};
+use embedded_usb_pd::{PowerRole, constants::T_PS_TRANSITION_SPR_MS, type_c::ConnectionState};
 use power_policy_interface::{
     capability::{ConsumerDisconnect, ConsumerFlags, ConsumerPowerCapability, PsuType},
+    psu::{Psu, PsuState},
     service::event::Event as PowerPolicyEvent,
 };
 use type_c_interface::{
     control::pd::PortStatus,
-    port::event::{PortEvent, PortStatusEventBitfield},
+    port::event::{PortEvent, PortEventBitfield, PortStatusEventBitfield},
     port::max_sink_voltage::MaxSinkVoltage,
     util::POWER_CAPABILITY_5V_1A5,
 };
@@ -89,6 +90,12 @@ impl Test for TestBasicConsumerFlow {
             _ => panic!("Did not receive consumer connected event"),
         }
 
+        // The port should now be tracking a connected consumer internally
+        assert!(matches!(
+            port0.port.lock().await.state().psu_state,
+            PsuState::ConnectedConsumer(_)
+        ));
+
         {
             // Set up the mock to report an unplug
             let mut mock0 = port0.mock.lock().await;
@@ -123,6 +130,151 @@ impl Test for TestBasicConsumerFlow {
             }
             _ => panic!("Did not receive consumer disconnected event"),
         }
+
+        // The port should be detached again after unplug
+        assert_eq!(port0.port.lock().await.state().psu_state, PsuState::Detached);
+    }
+}
+
+/// End-to-end test of the software sink-ready timeout that drives the real `EventReceiver` and
+/// exercises every internal state transition along with the power-policy broadcasts.
+///
+/// The controller never raises a hardware sink-ready event, so a real `embassy_time::Timer` inside
+/// a live [`type_c_service::controller::event_receiver::EventReceiver`] must elapse and synthesize
+/// the sink-ready event that completes the consumer contract. The event receiver is driven
+/// manually, one event at a time, so the port's internal state can be asserted deterministically
+/// between transitions:
+///
+/// * `Detached` with no armed timeout initially,
+/// * `Idle` with the sink-ready timeout armed after the plug (no consumer broadcast yet),
+/// * `ConnectedConsumer` with the timeout cleared once the timer fires (`ConsumerConnected`),
+/// * `Detached` with no armed timeout after the unplug (`ConsumerDisconnected`).
+struct TestConsumerFlowTimerSinkReady;
+
+impl Test for TestConsumerFlowTimerSinkReady {
+    async fn run<'port, 'ch>(
+        &mut self,
+        _type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        _port1: TestPort<'port, 'ch>,
+        _port2: TestPort<'port, 'ch>,
+    ) {
+        let TestPort {
+            port,
+            mock,
+            shared_state,
+            interrupt_sender,
+            mut event_receiver,
+        } = port0;
+
+        {
+            // Queue the controller's status responses in call order. No hardware sink-ready event
+            // is ever raised, so the sink-ready poll below is driven entirely by the software timer.
+            let mut mock0 = mock.lock().await;
+            // Plug: report a connected sink so the port begins the consumer-attach flow.
+            mock0.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_sink_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Sink,
+                ..Default::default()
+            }));
+            // Timer-driven sink-ready poll: still a connected sink, which completes the contract.
+            mock0.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_sink_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Sink,
+                ..Default::default()
+            }));
+            // Unplug: report a detached/default status so the consumer disconnects.
+            mock0.next_result_get_port_status.push_back(Ok(Default::default()));
+            // Sink path is enabled when the power policy connects the consumer.
+            mock0.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        // Initially detached with no pending sink-ready timeout.
+        assert_eq!(port.lock().await.state().psu_state, PsuState::Detached);
+        assert!(shared_state.lock().await.sink_ready_timeout().is_none());
+
+        let start = Instant::now();
+
+        // Plug in with a new consumer contract but WITHOUT a hardware sink-ready event.
+        let mut interrupt = PortEventBitfield::none();
+        interrupt.status.set_plug_inserted_or_removed(true);
+        interrupt.status.set_new_power_contract_as_consumer(true);
+        interrupt_sender.send(interrupt).await;
+
+        // Drive the receiver manually so the intermediate state is observable before the timer
+        // fires. This first event is the plug interrupt that was just sent.
+        let event = event_receiver.wait_event().await;
+        port.lock().await.process_event(event).await.unwrap();
+
+        // The port is attached but not consuming yet, the sink-ready timeout is armed, and no
+        // consumer connection has been broadcast to the power policy.
+        assert_eq!(port.lock().await.state().psu_state, PsuState::Idle);
+        assert!(shared_state.lock().await.sink_ready_timeout().is_some());
+        assert!(power_policy_receiver.try_receive().is_err());
+
+        // The next event is synthesized *inside* `wait_event` by a real timer; nothing in this test
+        // injects a sink-ready event. This call blocks until that timer elapses.
+        let event = event_receiver.wait_event().await;
+        let elapsed = start.elapsed();
+        port.lock().await.process_event(event).await.unwrap();
+
+        // The connect must have waited for the sink-ready timer to elapse, proving it was
+        // timer-driven rather than an immediate hardware sink-ready event.
+        assert!(
+            elapsed >= Duration::from_millis(T_PS_TRANSITION_SPR_MS.maximum.0 as u64),
+            "consumer connected before the sink-ready timer could elapse: {}ms",
+            elapsed.as_millis()
+        );
+
+        // The timer cleared the sink-ready timeout when it synthesized the sink-ready event. The
+        // port is not a connected consumer yet: it has only forwarded the updated consumer
+        // capability to the power policy, which still has to connect it.
+        assert!(shared_state.lock().await.sink_ready_timeout().is_none());
+
+        // The power policy should now broadcast a consumer connect event.
+        match with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()).await {
+            Ok(PowerPolicyEvent::ConsumerConnected(psu, capability)) => {
+                assert_eq!(
+                    capability,
+                    ConsumerPowerCapability {
+                        capability: POWER_CAPABILITY_5V_1A5,
+                        flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
+                    }
+                );
+                assert!(ptr::eq(psu, port));
+            }
+            _ => panic!("Did not receive consumer connected event from software sink-ready timeout"),
+        }
+
+        // Connecting the consumer is what moves the port into the connected-consumer state.
+        assert!(matches!(
+            port.lock().await.state().psu_state,
+            PsuState::ConnectedConsumer(_)
+        ));
+
+        // Unplug.
+        let mut interrupt = PortEventBitfield::none();
+        interrupt.status.set_plug_inserted_or_removed(true);
+        interrupt_sender.send(interrupt).await;
+
+        // Process the unplug event.
+        let event = event_receiver.wait_event().await;
+        port.lock().await.process_event(event).await.unwrap();
+
+        // The power policy should broadcast a consumer disconnect event.
+        match with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()).await {
+            Ok(PowerPolicyEvent::ConsumerDisconnected(psu, _)) => {
+                assert!(ptr::eq(psu, port));
+            }
+            _ => panic!("Did not receive consumer disconnected event"),
+        }
+
+        // Back to detached with no pending sink-ready timeout.
+        assert_eq!(port.lock().await.state().psu_state, PsuState::Detached);
+        assert!(shared_state.lock().await.sink_ready_timeout().is_none());
     }
 }
 
@@ -252,6 +404,17 @@ async fn test_basic_consumer_flow() {
         Default::default(),
         Default::default(),
         TestBasicConsumerFlow,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_consumer_flow_timer_sink_ready() {
+    common::run_test(
+        Duration::from_secs(10),
+        Default::default(),
+        Default::default(),
+        TestConsumerFlowTimerSinkReady,
     )
     .await;
 }


### PR DESCRIPTION
The Type-C port arms a software timer after accepting a consumer contract so controllers that never raise a hardware sink-ready event still complete the contract once tPSTransition elapses..

- Add an end-to-end test that drives the real EventReceiver so a real embassy_time::Timer synthesizes the sink-ready event.
- Assert every internal state transition: Detached -> Idle with the timeout armed -> ConnectedConsumer with it cleared -> Detached.
- Assert the matching ConsumerConnected/ConsumerDisconnected power-policy broadcasts.
- Add a sink_ready_timeout() accessor on SharedState and expose each port's shared state, interrupt sender, and event receiver through the TestPort harness.
- Assert the internal psu_state in the basic consumer flow.

Resolves #829 