### PR TITLE
Type c service/port provider flow test

### DIFF
--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -6,7 +6,9 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, TimeoutError, with_timeout};
 use embedded_usb_pd::{PowerRole, constants::T_PS_TRANSITION_SPR_MS, type_c::ConnectionState};
 use power_policy_interface::{
-    capability::{ConsumerDisconnect, ConsumerFlags, ConsumerPowerCapability, PsuType},
+    capability::{
+        ConsumerDisconnect, ConsumerFlags, ConsumerPowerCapability, ProviderFlags, ProviderPowerCapability, PsuType,
+    },
     psu::{Psu, PsuState},
     service::event::Event as PowerPolicyEvent,
 };
@@ -129,6 +131,120 @@ impl Test for TestBasicConsumerFlow {
                 assert!(ptr::eq(psu, port0.port));
             }
             _ => panic!("Did not receive consumer disconnected event"),
+        }
+
+        // The port should be detached again after unplug
+        assert_eq!(port0.port.lock().await.state().psu_state, PsuState::Detached);
+    }
+}
+
+/// Test basic provider attach flow: plug -> new provider contract -> unplug.
+///
+/// Validates the internal `psu_state` transitions (`Detached` -> `ConnectedProvider` -> `Detached`)
+/// and that the matching `ProviderConnected`/`ProviderDisconnected` events are broadcast to the
+/// power policy service.
+struct TestBasicProviderFlow;
+
+impl Test for TestBasicProviderFlow {
+    async fn run<'port, 'ch>(
+        &mut self,
+        type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        _port1: TestPort<'port, 'ch>,
+        _port2: TestPort<'port, 'ch>,
+    ) {
+        // The port should start out detached.
+        assert_eq!(port0.port.lock().await.state().psu_state, PsuState::Detached);
+
+        {
+            // Set up the mock to report a source connection
+            let mut mock0 = port0.mock.lock().await;
+
+            mock0.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_source_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Source,
+                ..Default::default()
+            }));
+        }
+
+        // Simulate a plug event and a new provider contract
+        let mut port_event = PortStatusEventBitfield::none();
+        port_event.set_plug_inserted_or_removed(true);
+        port_event.set_new_power_contract_as_provider(true);
+
+        port0
+            .port
+            .lock()
+            .await
+            .process_event(Event::PortEvent(PortEvent::StatusChanged(port_event)))
+            .await
+            .unwrap();
+
+        let (type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+
+        // Shouldn't get any Type-C service events in this flow
+        assert_eq!(type_c_result.err(), Some(TimeoutError));
+
+        // Power policy service should broadcast a provider connect event
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ProviderConnected(psu, capability)) => {
+                assert_eq!(
+                    capability,
+                    ProviderPowerCapability {
+                        capability: POWER_CAPABILITY_5V_1A5,
+                        flags: ProviderFlags::none().with_psu_type(PsuType::TypeC),
+                    }
+                );
+                assert!(ptr::eq(psu, port0.port));
+            }
+            _ => panic!("Did not receive provider connected event"),
+        }
+
+        // The port should now be tracking a connected provider internally
+        assert!(matches!(
+            port0.port.lock().await.state().psu_state,
+            PsuState::ConnectedProvider(_)
+        ));
+
+        {
+            // Set up the mock to report an unplug
+            let mut mock0 = port0.mock.lock().await;
+            let port_status = Ok(Default::default());
+            mock0.next_result_get_port_status.push_back(port_status);
+        }
+
+        // Simulate an unplug event
+        let mut port_event = PortStatusEventBitfield::none();
+        port_event.set_plug_inserted_or_removed(true);
+
+        port0
+            .port
+            .lock()
+            .await
+            .process_event(Event::PortEvent(PortEvent::StatusChanged(port_event)))
+            .await
+            .unwrap();
+
+        let (type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+
+        // Type-C service currently shouldn't broadcast any events in this flow
+        assert_eq!(type_c_result.err(), Some(TimeoutError));
+        // Power policy service should broadcast a provider disconnect event
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ProviderDisconnected(psu)) => {
+                assert!(ptr::eq(psu, port0.port));
+            }
+            _ => panic!("Did not receive provider disconnected event"),
         }
 
         // The port should be detached again after unplug
@@ -404,6 +520,17 @@ async fn test_basic_consumer_flow() {
         Default::default(),
         Default::default(),
         TestBasicConsumerFlow,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_basic_provider_flow() {
+    common::run_test(
+        DEFAULT_TEST_DURATION,
+        Default::default(),
+        Default::default(),
+        TestBasicProviderFlow,
     )
     .await;
 }


### PR DESCRIPTION
Add basic provider contract flow test coverage.

Cover the Type-C port's plug -> new provider contract -> unplug flow to mirror the existing basic consumer coverage.

- Add an integration test that drives the port through a source attach and asserts every internal psu_state transition: Detached -> ConnectedProvider -> Detached.
- Assert the matching ProviderConnected/ProviderDisconnected power-policy broadcasts, including the negotiated provider capability.

Assisted-by: GitHub Copilot:claude-opus-4.8

Resolves #830 