### PR TITLE
type-c-interface-mocks: Create initial port mock structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,6 +2155,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-c-interface-mocks"
+version = "0.1.0"
+dependencies = [
+ "critical-section",
+ "defmt 0.3.100",
+ "embassy-sync",
+ "embedded-services",
+ "embedded-usb-pd",
+ "log",
+ "power-policy-interface",
+ "tokio",
+ "type-c-interface",
+]
+
+[[package]]
 name = "type-c-interface-test-mocks"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "fw-update-interface",
     "fw-update-interface-test-mocks",
     "mctp-rs",
+    "type-c-interface-mocks",
     "type-c-interface-test-mocks",
     "power-policy-interface-test-mocks",
 ]
@@ -117,6 +118,7 @@ thermal-service-relay = { path = "./thermal-service-relay" }
 time-alarm-service-interface = { path = "./time-alarm-service-interface" }
 time-alarm-service-relay = { path = "./time-alarm-service-relay" }
 type-c-interface = { path = "./type-c-interface" }
+type-c-interface-mocks = { path = "./type-c-interface-mocks" }
 type-c-interface-test-mocks = { path = "./type-c-interface-test-mocks" }
 syn = "2.0"
 tokio = { version = "1.42.0" }

--- a/type-c-interface-mocks/Cargo.toml
+++ b/type-c-interface-mocks/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "type-c-interface-mocks"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+embedded-services = { workspace = true }
+embedded-usb-pd = { workspace = true }
+power-policy-interface = { workspace = true }
+type-c-interface = { workspace = true }
+defmt = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+
+[features]
+default = []
+defmt = [
+    "dep:defmt",
+    "embedded-services/defmt",
+    "embedded-usb-pd/defmt",
+    "power-policy-interface/defmt",
+    "type-c-interface/defmt",
+]
+log = [
+    "dep:log",
+    "embedded-services/log",
+    "power-policy-interface/log",
+    "type-c-interface/log",
+]
+
+[dev-dependencies]
+embassy-sync = { workspace = true, features = ["std"] }
+critical-section = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["defmt", "log"]

--- a/type-c-interface-mocks/src/lib.rs
+++ b/type-c-interface-mocks/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+//! Mock implementations of the per-port `type-c-interface` traits for testing.
+
+pub mod port;

--- a/type-c-interface-mocks/src/port/mod.rs
+++ b/type-c-interface-mocks/src/port/mod.rs
@@ -1,0 +1,312 @@
+//! Mock implementation of the per-port [`type_c_interface::port::pd::Pd`] and
+//! [`power_policy_interface::psu::Psu`] traits.
+
+use core::future::ready;
+
+use embedded_services::error;
+use embedded_services::event::NonBlockingSender;
+use embedded_services::named::Named;
+use embedded_usb_pd::vdm::structured::command::discover_identity::{sop, sop_prime};
+use embedded_usb_pd::{PdError, PlugOrientation, PowerRole, ado::Ado, type_c::ConnectionState};
+use power_policy_interface::capability::{
+    ConsumerFlags, ConsumerPowerCapability, PowerCapability, ProviderFlags, ProviderPowerCapability, PsuType,
+};
+use power_policy_interface::psu::{Error as PsuError, Psu, State};
+use type_c_interface::control::{
+    dp::{DpConfig, DpStatus},
+    pd::PortStatus,
+    svid::DiscoveredSvids,
+    tbt::TbtConfig,
+    usb::UsbControlConfig,
+    vdm::{AttnVdm, OtherVdm, SendVdm},
+};
+use type_c_interface::port::event::PortStatusEventBitfield;
+use type_c_interface::port::pd::Pd;
+use type_c_interface::service::event::StatusChangedData;
+
+/// Error type for [`PortMock`] control operations
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PortMockError {
+    /// A disconnect was requested but the port was not connected
+    NotConnected,
+}
+
+/// Additional connection parameters for [`PortMock::plug`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ConnectionConfig {
+    /// Port partner supports dual-power roles
+    pub dual_power: bool,
+    /// Plug orientation
+    pub plug_orientation: PlugOrientation,
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            dual_power: false,
+            plug_orientation: PlugOrientation::CC1,
+        }
+    }
+}
+
+/// Mock implementation of a single Type-C port for use in tests
+pub struct PortMock<
+    TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
+    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+> {
+    name: &'static str,
+    /// Current port status returned by [`Pd::get_port_status`]
+    status: PortStatus,
+    /// Current power-policy PSU state
+    psu_state: State,
+    /// Type-C event sender
+    type_c_sender: TypeCSender,
+    /// Power policy event sender
+    power_sender: PowerSender,
+}
+
+impl<TypeCSender, PowerSender> PortMock<TypeCSender, PowerSender>
+where
+    TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
+    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+{
+    /// Create a new mock with the given name
+    pub fn new(name: &'static str, type_c_sender: TypeCSender, power_sender: PowerSender) -> Self {
+        Self {
+            name,
+            status: PortStatus::new(),
+            psu_state: State::default(),
+            type_c_sender,
+            power_sender,
+        }
+    }
+
+    /// Returns the current port status
+    pub fn status(&self) -> &PortStatus {
+        &self.status
+    }
+
+    /// Simulate a plug on this port.
+    ///
+    /// Rebuilds the stored [`PortStatus`] to reflect an attached connection in
+    /// the given [`PowerRole`] with the provided [`PowerCapability`].
+    pub fn plug(
+        &mut self,
+        role: PowerRole,
+        capability: PowerCapability,
+        config: ConnectionConfig,
+    ) -> Result<(), PsuError> {
+        let mut status = PortStatus::new();
+        status.connection_state = Some(ConnectionState::Attached);
+        status.dual_power = config.dual_power;
+        status.plug_orientation = config.plug_orientation;
+        status.power_role = role;
+        self.psu_state.attach()?;
+
+        // Notify services
+        if self
+            .power_sender
+            .try_send(power_policy_interface::psu::event::EventData::Attached)
+            .is_none()
+        {
+            error!("Failed to send attached to power policy");
+        }
+
+        let mut status_event = PortStatusEventBitfield::none();
+        status_event.set_plug_inserted_or_removed(true);
+
+        match role {
+            PowerRole::Sink => {
+                status_event.set_new_power_contract_as_consumer(true);
+                status_event.set_sink_ready(true);
+                status.available_sink_contract = Some(capability);
+                self.psu_state
+                    .update_consumer_power_capability(Some(ConsumerPowerCapability {
+                        capability,
+                        flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
+                    }))?;
+            }
+            PowerRole::Source => {
+                status_event.set_new_power_contract_as_provider(true);
+                status.available_source_contract = Some(capability);
+                self.psu_state
+                    .update_requested_provider_power_capability(Some(ProviderPowerCapability {
+                        capability,
+                        flags: ProviderFlags::none().with_psu_type(PsuType::TypeC),
+                    }))?;
+            }
+        }
+
+        let previous_status = self.status;
+        self.status = status;
+
+        if self
+            .type_c_sender
+            .try_send(type_c_interface::service::event::PortEventData::StatusChanged(
+                StatusChangedData {
+                    status_event,
+                    previous_status,
+                    current_status: self.status,
+                },
+            ))
+            .is_none()
+        {
+            error!("Failed to send Type-C status changed event");
+        }
+        Ok(())
+    }
+
+    /// Simulate an unplug on this port.
+    ///
+    /// Returns [`PortMockError::NotConnected`] if the port was not connected.
+    pub fn unplug(&mut self) -> Result<(), PortMockError> {
+        if !self.status.is_connected() {
+            return Err(PortMockError::NotConnected);
+        }
+        self.psu_state.detach();
+
+        // Notify services
+        if self
+            .power_sender
+            .try_send(power_policy_interface::psu::event::EventData::Detached)
+            .is_none()
+        {
+            error!("Failed to send detached to power policy");
+        }
+
+        let mut status_event = PortStatusEventBitfield::none();
+        status_event.set_plug_inserted_or_removed(true);
+
+        let previous_status = self.status;
+        self.status = PortStatus::default();
+
+        if self
+            .type_c_sender
+            .try_send(type_c_interface::service::event::PortEventData::StatusChanged(
+                StatusChangedData {
+                    status_event,
+                    previous_status,
+                    current_status: self.status,
+                },
+            ))
+            .is_none()
+        {
+            error!("Failed to send Type-C status changed event");
+        }
+        Ok(())
+    }
+}
+
+impl<TypeCSender, PowerSender> Named for PortMock<TypeCSender, PowerSender>
+where
+    TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
+    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+{
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+impl<TypeCSender, PowerSender> Pd for PortMock<TypeCSender, PowerSender>
+where
+    TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
+    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+{
+    async fn get_port_status(&mut self) -> Result<PortStatus, PdError> {
+        Ok(self.status)
+    }
+
+    async fn clear_dead_battery_flag(&mut self) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn enable_sink_path(&mut self, _enable: bool) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn get_pd_alert(&mut self) -> Result<Option<Ado>, PdError> {
+        Ok(None)
+    }
+
+    async fn set_unconstrained_power(&mut self, _unconstrained: bool) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn get_other_vdm(&mut self) -> Result<OtherVdm, PdError> {
+        Ok(OtherVdm::default())
+    }
+
+    async fn get_attn_vdm(&mut self) -> Result<AttnVdm, PdError> {
+        Ok(AttnVdm::default())
+    }
+
+    async fn send_vdm(&mut self, _tx_vdm: SendVdm) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn execute_drst(&mut self) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn hard_reset(&mut self) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn get_dp_status(&mut self) -> Result<DpStatus, PdError> {
+        Ok(DpStatus::default())
+    }
+
+    async fn set_dp_config(&mut self, _config: DpConfig) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn set_tbt_config(&mut self, _config: TbtConfig) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn set_usb_control(&mut self, _config: UsbControlConfig) -> Result<(), PdError> {
+        Ok(())
+    }
+
+    async fn get_discovered_svids(&mut self) -> Result<DiscoveredSvids, PdError> {
+        Ok(DiscoveredSvids::default())
+    }
+
+    async fn get_discover_identity_sop_response(&mut self) -> Result<sop::ResponseVdos, PdError> {
+        Err(PdError::Failed)
+    }
+
+    async fn get_discover_identity_sop_prime_response(&mut self) -> Result<sop_prime::ResponseVdos, PdError> {
+        Err(PdError::Failed)
+    }
+}
+
+impl<TypeCSender, PowerSender> Psu for PortMock<TypeCSender, PowerSender>
+where
+    TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
+    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+{
+    async fn disconnect(&mut self) -> Result<(), PsuError> {
+        self.enable_sink_path(false).await.map_err(|_| PsuError::Failed)?;
+        self.psu_state.disconnect(false)
+    }
+
+    fn connect_provider(&mut self, capability: ProviderPowerCapability) -> impl Future<Output = Result<(), PsuError>> {
+        ready(self.psu_state.connect_provider(capability))
+    }
+
+    async fn connect_consumer(&mut self, capability: ConsumerPowerCapability) -> Result<(), PsuError> {
+        self.enable_sink_path(true).await.map_err(|_| PsuError::Failed)?;
+        self.psu_state.connect_consumer(capability)
+    }
+
+    fn state(&self) -> &State {
+        &self.psu_state
+    }
+
+    fn state_mut(&mut self) -> &mut State {
+        &mut self.psu_state
+    }
+}

--- a/type-c-interface-mocks/tests/connect_disconnect.rs
+++ b/type-c-interface-mocks/tests/connect_disconnect.rs
@@ -1,0 +1,152 @@
+//! Integration tests for [`PortMock`] `plug`/`unplug` control helpers,
+//! verifying that the appropriate Type-C and power-policy events are broadcast.
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use embassy_sync::channel::Channel;
+use embedded_services::GlobalRawMutex;
+use embedded_usb_pd::{PlugOrientation, PowerRole, type_c::ConnectionState};
+use power_policy_interface::capability::{
+    ConsumerFlags, ConsumerPowerCapability, PowerCapability, ProviderFlags, ProviderPowerCapability, PsuType,
+};
+use power_policy_interface::psu::event::EventData as PsuEventData;
+use power_policy_interface::psu::{Psu, PsuState};
+use type_c_interface::service::event::PortEventData;
+use type_c_interface_mocks::port::{ConnectionConfig, PortMock, PortMockError};
+
+const CHANNEL_SIZE: usize = 4;
+
+const TEST_CAPABILITY: PowerCapability = PowerCapability {
+    voltage_mv: 5000,
+    current_ma: 1500,
+};
+
+type TypeCChannel = Channel<GlobalRawMutex, PortEventData, CHANNEL_SIZE>;
+type PowerChannel = Channel<GlobalRawMutex, PsuEventData, CHANNEL_SIZE>;
+
+#[tokio::test]
+async fn test_plug_sink_broadcasts_events() {
+    let type_c_channel: TypeCChannel = Channel::new();
+    let power_channel: PowerChannel = Channel::new();
+
+    let mut mock = PortMock::new("test", type_c_channel.dyn_sender(), power_channel.dyn_sender());
+
+    let config = ConnectionConfig {
+        dual_power: true,
+        plug_orientation: PlugOrientation::CC2,
+    };
+    mock.plug(PowerRole::Sink, TEST_CAPABILITY, config).unwrap();
+
+    // Power policy should be notified of the attach
+    assert_eq!(power_channel.try_receive().unwrap(), PsuEventData::Attached);
+    assert!(power_channel.try_receive().is_err());
+
+    // Type-C service should receive a status changed event reflecting the connection
+    let PortEventData::StatusChanged(data) = type_c_channel.try_receive().unwrap() else {
+        panic!("expected StatusChanged event");
+    };
+    assert!(data.status_event.plug_inserted_or_removed());
+    assert!(!data.previous_status.is_connected());
+    assert!(data.current_status.is_connected());
+    assert_eq!(data.current_status.connection_state, Some(ConnectionState::Attached));
+    assert_eq!(data.current_status.available_sink_contract, Some(TEST_CAPABILITY));
+    assert_eq!(data.current_status.power_role, PowerRole::Sink);
+    assert!(data.current_status.dual_power);
+    assert_eq!(data.current_status.plug_orientation, PlugOrientation::CC2);
+    assert!(type_c_channel.try_receive().is_err());
+
+    // State should be Idle since power policy hasn't directed us to connect yet
+    // But the consumer capability should have been recorded
+    let expected_capability = ConsumerPowerCapability {
+        capability: TEST_CAPABILITY,
+        flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
+    };
+    assert_eq!(mock.state().consumer_capability, Some(expected_capability));
+    assert_eq!(mock.state().psu_state, PsuState::Idle);
+    assert!(mock.status().is_connected());
+
+    // Direct the mock to connect and verify state
+    mock.connect_consumer(expected_capability).await.unwrap();
+    assert_eq!(mock.state().psu_state, PsuState::ConnectedConsumer(expected_capability));
+}
+
+#[tokio::test]
+async fn test_plug_source_broadcasts_events() {
+    let type_c_channel: TypeCChannel = Channel::new();
+    let power_channel: PowerChannel = Channel::new();
+
+    let mut mock = PortMock::new("test", type_c_channel.dyn_sender(), power_channel.dyn_sender());
+
+    mock.plug(PowerRole::Source, TEST_CAPABILITY, ConnectionConfig::default())
+        .unwrap();
+
+    assert_eq!(power_channel.try_receive().unwrap(), PsuEventData::Attached);
+
+    let PortEventData::StatusChanged(data) = type_c_channel.try_receive().unwrap() else {
+        panic!("expected StatusChanged event");
+    };
+    assert!(data.status_event.plug_inserted_or_removed());
+    assert!(data.status_event.new_power_contract_as_provider());
+    assert_eq!(data.current_status.available_source_contract, Some(TEST_CAPABILITY));
+    assert_eq!(data.current_status.power_role, PowerRole::Source);
+
+    // State should be Idle since power policy hasn't directed us to connect yet
+    // But the requested provider capability should have been recorded
+    let expected_capability = ProviderPowerCapability {
+        capability: TEST_CAPABILITY,
+        flags: ProviderFlags::none().with_psu_type(PsuType::TypeC),
+    };
+    assert_eq!(mock.state().requested_provider_capability, Some(expected_capability));
+    assert_eq!(mock.state().psu_state, PsuState::Idle);
+    assert!(mock.status().is_connected());
+
+    // Direct the mock to connect and verify state
+    mock.connect_provider(expected_capability).await.unwrap();
+    assert_eq!(mock.state().psu_state, PsuState::ConnectedProvider(expected_capability));
+}
+
+#[tokio::test]
+async fn test_unplug_broadcasts_events() {
+    let type_c_channel: TypeCChannel = Channel::new();
+    let power_channel: PowerChannel = Channel::new();
+
+    let mut mock = PortMock::new("test", type_c_channel.dyn_sender(), power_channel.dyn_sender());
+
+    // Establish a connection, then drain its events
+    mock.plug(PowerRole::Sink, TEST_CAPABILITY, ConnectionConfig::default())
+        .unwrap();
+    while power_channel.try_receive().is_ok() {}
+    while type_c_channel.try_receive().is_ok() {}
+
+    mock.unplug().unwrap();
+
+    // Power policy should be notified of the detach
+    assert_eq!(power_channel.try_receive().unwrap(), PsuEventData::Detached);
+    assert!(power_channel.try_receive().is_err());
+
+    // Type-C service should receive a status changed event reflecting the removal
+    let PortEventData::StatusChanged(data) = type_c_channel.try_receive().unwrap() else {
+        panic!("expected StatusChanged event");
+    };
+    assert!(data.status_event.plug_inserted_or_removed());
+    assert!(data.previous_status.is_connected());
+    assert!(!data.current_status.is_connected());
+    assert!(type_c_channel.try_receive().is_err());
+
+    // Internal state should reflect the detached PSU
+    assert_eq!(mock.state().psu_state, PsuState::Detached);
+    assert!(!mock.status().is_connected());
+}
+
+#[tokio::test]
+async fn test_unplug_without_connection_errors() {
+    let type_c_channel: TypeCChannel = Channel::new();
+    let power_channel: PowerChannel = Channel::new();
+
+    let mut mock = PortMock::new("test", type_c_channel.dyn_sender(), power_channel.dyn_sender());
+
+    // Unplugging a port that was never connected should error and broadcast nothing
+    assert_eq!(mock.unplug(), Err(PortMockError::NotConnected));
+    assert!(power_channel.try_receive().is_err());
+    assert!(type_c_channel.try_receive().is_err());
+}


### PR DESCRIPTION
Create the initial structure for a type-C port mock that is intended to run in a `no_std` environment to mock hardware that isn't physically present. This will mostly be used for demonstration purposes.