### PR TITLE
type-c-service/wrapper: Add recovery logic to `set_max_sink_voltage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aquamarine"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1107,7 +1107,7 @@ end = "2026-09-03"
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-10-05"
-end = "2026-04-16"
+end = "2027-07-06"
 
 [[trusted.cc]]
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,8 +9,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.anyhow]]
-version = "1.0.99"
-when = "2025-08-11"
+version = "1.0.103"
+when = "2026-06-25"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -368,7 +368,10 @@ aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embas
 who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.5.0"
-aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/tps6699x/refs/heads/main/supply-chain/audits.toml"
+aggregated-from = [
+    "https://raw.githubusercontent.com/OpenDevicePartnership/tps6699x/refs/heads/main/supply-chain/audits.toml",
+    "https://raw.githubusercontent.com/OpenDevicePartnership/tps6699x/refs/heads/main/supply-chain/audits.toml",
+]
 
 [[audits.OpenDevicePartnership.audits.embassy-time-queue-utils]]
 who = "Felipe Balbi <febalbi@microsoft.com>"

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -7,6 +7,8 @@ use embedded_services::type_c::controller::{InternalResponseData, Response};
 use embedded_usb_pd::constants::{T_PS_TRANSITION_EPR_MS, T_PS_TRANSITION_SPR_MS};
 use embedded_usb_pd::ucsi::{self, lpm};
 
+use crate::wrapper::backing::PortState;
+
 use super::*;
 
 impl<'device, M: RawMutex, C: Lockable, V: FwOfferValidator> ControllerWrapper<'device, M, C, V>
@@ -36,6 +38,20 @@ where
                 }
             }
         }
+    }
+
+    /// Returns the timeout duration for the sink ready check.
+    fn check_sink_ready_timeout_duration(is_epr: bool) -> Duration {
+        Duration::from_millis(
+            (if is_epr {
+                T_PS_TRANSITION_EPR_MS
+            } else {
+                T_PS_TRANSITION_SPR_MS
+            }
+            .maximum
+            .0 * 2)
+                .into(),
+        )
     }
 
     /// Check the sink ready timeout
@@ -72,16 +88,9 @@ where
         if new_contract && !sink_ready && contract_changed {
             // Start the timeout
             // Double the spec maximum transition time to provide a safety margin for hardware/controller delays or out-of-spec controllers.
-            let timeout_ms = if status.epr {
-                T_PS_TRANSITION_EPR_MS
-            } else {
-                T_PS_TRANSITION_SPR_MS
-            }
-            .maximum
-            .0 * 2;
-
-            debug!("Port{}: Sink ready timeout started for {}ms", port.0, timeout_ms);
-            *deadline = Some(Instant::now() + Duration::from_millis(timeout_ms as u64));
+            let timeout = Self::check_sink_ready_timeout_duration(status.epr);
+            debug!("Port{}: Sink ready timeout started for {:?}", port.0, timeout);
+            *deadline = Some(Instant::now() + timeout);
         } else if deadline.is_some()
             && (!status.is_connected() || status.available_sink_contract.is_none() || sink_ready)
         {
@@ -125,8 +134,13 @@ where
     /// Set the maximum sink voltage for a port
     pub async fn set_max_sink_voltage(&self, local_port: LocalPortId, voltage_mv: Option<u16>) -> Result<(), PdError> {
         let mut controller = self.controller.lock().await;
+        let mut state = self.state.lock().await;
+        let port_state = state
+            .port_states_mut()
+            .get_mut(local_port.0 as usize)
+            .ok_or(PdError::InvalidPort)?;
         let _ = self
-            .process_set_max_sink_voltage(&mut controller, local_port, voltage_mv)
+            .process_set_max_sink_voltage(&mut controller, port_state, local_port, voltage_mv)
             .await?;
         Ok(())
     }
@@ -135,13 +149,14 @@ where
     async fn process_set_max_sink_voltage(
         &self,
         controller: &mut C::Inner,
+        port_state: &mut PortState<'_>,
         local_port: LocalPortId,
         voltage_mv: Option<u16>,
     ) -> Result<controller::PortResponseData, PdError> {
         let power_device = self.get_power_device(local_port).ok_or(PdError::InvalidPort)?;
 
-        let state = power_device.state().await;
-        debug!("Port{}: Current state: {:#?}", local_port.0, state);
+        let power_state = power_device.state().await;
+        debug!("Port{}: Current state: {:#?}", local_port.0, power_state);
         if let Ok(connected_consumer) = power_device.try_device_action::<action::ConnectedConsumer>().await {
             debug!("Port{}: Set max sink voltage, connected consumer found", local_port.0);
 
@@ -166,6 +181,16 @@ where
                         Error::Pd(e) => Err(e),
                     },
                 }?;
+
+                // In general it's not possible know if setting the max sink voltage will trigger a renegotiation
+                // because the logic to select a particular contract is specific to the PD controller.
+                // Enable the sink ready timeout as a recovery mechanism. If there's no renegotiation, then the timeout
+                // will result in us broadcasting the existing contract back to the power policy.
+                if port_state.sink_ready_deadline.is_none() {
+                    port_state.sink_ready_deadline =
+                        Some(Instant::now() + Self::check_sink_ready_timeout_duration(port_state.status.epr));
+                }
+
                 let _ = connected_consumer
                     .disconnect(flags::ConsumerDisconnect::default().with_renegotiation(true))
                     .await;
@@ -288,13 +313,11 @@ where
                 Err(e) => Err(e),
             },
             controller::PortCommandData::SetMaxSinkVoltage(voltage_mv) => {
-                match self.registration.pd_controller.lookup_local_port(command.port) {
-                    Ok(local_port) => {
-                        self.process_set_max_sink_voltage(controller, local_port, voltage_mv)
-                            .await
-                    }
-                    Err(e) => Err(e),
-                }
+                // Panic Safety: Local port is verified above
+                #[allow(clippy::unwrap_used)]
+                let port_state = state.port_states_mut().get_mut(local_port.0 as usize).unwrap();
+                self.process_set_max_sink_voltage(controller, port_state, local_port, voltage_mv)
+                    .await
             }
             controller::PortCommandData::SetUnconstrainedPower(unconstrained) => {
                 match controller.set_unconstrained_power(local_port, unconstrained).await {


### PR DESCRIPTION
Since the PD controller is responsible for picking a contract, we can't determine if a renegotiation will actually happen. The current behavior can cause a failure to consume power if no renegotiation happens. Start a sink ready timeout when limiting the maximum sink voltage to allow us to recover in cases where no renegotiation happens.