### PR TITLE
power-policy-interface/psu: Introduce notification traits

### DIFF
--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -231,7 +231,7 @@ async fn main(spawner: Spawner) {
     let power_policy_registration = ArrayRegistration {
         psus: [port0, port1],
         chargers: [],
-        service_senders: [power_policy_sender.into()],
+        service_notifiers: [power_policy_sender.into()],
     };
 
     static POWER_SERVICE: StaticCell<PowerPolicyServiceType> = StaticCell::new();

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -38,6 +38,8 @@ bind_interrupts!(struct Irqs {
     FLEXCOMM2 => embassy_imxrt::i2c::InterruptHandler<peripherals::FLEXCOMM2>;
 });
 
+type PowerNotifier<'a> =
+    power_policy_interface::psu::event::NonBlockingSenderNotifier<DynamicSender<'a, psu::event::EventData>>;
 type SharedStateType = Mutex<GlobalRawMutex, SharedState>;
 type PortType = Mutex<
     GlobalRawMutex,
@@ -46,7 +48,7 @@ type PortType = Mutex<
         Tps6699xMutex<'static>,
         SharedStateType,
         DynamicSender<'static, type_c_interface::service::event::PortEventData>,
-        DynamicSender<'static, power_policy_interface::psu::event::EventData>,
+        PowerNotifier<'static>,
         DynamicSender<'static, type_c_service::controller::event::Loopback>,
     >,
 >;

--- a/examples/rt685s-evk/src/bin/type_c.rs
+++ b/examples/rt685s-evk/src/bin/type_c.rs
@@ -71,12 +71,13 @@ type PowerPolicySenderType = MapSender<
 >;
 
 type PowerPolicyReceiverType = DynSubscriber<'static, power_policy_interface::service::event::EventData>;
-
+type PowerPolicyNotifierType =
+    power_policy_interface::service::event::NonBlockingSenderNotifier<'static, PortType, PowerPolicySenderType>;
 type PowerPolicyServiceType = Mutex<
     GlobalRawMutex,
     power_policy_service::service::Service<
         'static,
-        ArrayRegistration<'static, PortType, 2, PowerPolicySenderType, 1, ChargerType, 0>,
+        ArrayRegistration<'static, PortType, 2, PowerPolicyNotifierType, 1, ChargerType, 0>,
     >,
 >;
 
@@ -230,7 +231,7 @@ async fn main(spawner: Spawner) {
     let power_policy_registration = ArrayRegistration {
         psus: [port0, port1],
         chargers: [],
-        service_senders: [power_policy_sender],
+        service_senders: [power_policy_sender.into()],
     };
 
     static POWER_SERVICE: StaticCell<PowerPolicyServiceType> = StaticCell::new();

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -54,6 +54,8 @@ impl cfu_service::customization::Customization for CfuCustomization {
     }
 }
 
+type PowerNotifier<'a> =
+    power_policy_interface::psu::event::NonBlockingSenderNotifier<DynamicSender<'a, psu::event::EventData>>;
 type PortSharedStateType = Mutex<GlobalRawMutex, PortSharedState>;
 type PortType = Mutex<
     GlobalRawMutex,
@@ -62,7 +64,7 @@ type PortType = Mutex<
         Tps6699xMutex<'static>,
         PortSharedStateType,
         DynamicSender<'static, type_c_interface::service::event::PortEventData>,
-        DynamicSender<'static, power_policy_interface::psu::event::EventData>,
+        PowerNotifier<'static>,
         DynamicSender<'static, type_c_service::controller::event::Loopback>,
     >,
 >;

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -369,7 +369,7 @@ async fn main(spawner: Spawner) {
     let power_policy_registration = ArrayRegistration {
         psus: [port0, port1],
         chargers: [],
-        service_senders: [power_policy_sender.into()],
+        service_notifiers: [power_policy_sender.into()],
     };
 
     static POWER_SERVICE: StaticCell<PowerPolicyServiceType> = StaticCell::new();

--- a/examples/rt685s-evk/src/bin/type_c_cfu.rs
+++ b/examples/rt685s-evk/src/bin/type_c_cfu.rs
@@ -87,12 +87,13 @@ type PowerPolicySenderType = MapSender<
 >;
 
 type PowerPolicyReceiverType = DynSubscriber<'static, power_policy_interface::service::event::EventData>;
-
+type PowerPolicyNotifierType =
+    power_policy_interface::service::event::NonBlockingSenderNotifier<'static, PortType, PowerPolicySenderType>;
 type PowerPolicyServiceType = Mutex<
     GlobalRawMutex,
     power_policy_service::service::Service<
         'static,
-        ArrayRegistration<'static, PortType, 2, PowerPolicySenderType, 1, ChargerType, 0>,
+        ArrayRegistration<'static, PortType, 2, PowerPolicyNotifierType, 1, ChargerType, 0>,
     >,
 >;
 
@@ -368,7 +369,7 @@ async fn main(spawner: Spawner) {
     let power_policy_registration = ArrayRegistration {
         psus: [port0, port1],
         chargers: [],
-        service_senders: [power_policy_sender],
+        service_senders: [power_policy_sender.into()],
     };
 
     static POWER_SERVICE: StaticCell<PowerPolicyServiceType> = StaticCell::new();

--- a/examples/std/src/bin/power_policy.rs
+++ b/examples/std/src/bin/power_policy.rs
@@ -21,11 +21,13 @@ use power_policy_service::{
 };
 use static_cell::StaticCell;
 
+type ServiceNotifier =
+    power_policy_interface::service::event::NonBlockingSenderNotifier<'static, DeviceType, NoopSender>;
 type ServiceType = Mutex<
     GlobalRawMutex,
     power_policy_service::service::Service<
         'static,
-        ArrayRegistration<'static, DeviceType, 2, NoopSender, 1, ChargerType, 1>,
+        ArrayRegistration<'static, DeviceType, 2, ServiceNotifier, 1, ChargerType, 1>,
     >,
 >;
 
@@ -251,7 +253,7 @@ async fn run(spawner: Spawner) {
 
     let registration = ArrayRegistration {
         psus: [device0, device1],
-        service_senders: [NoopSender],
+        service_senders: [NoopSender.into()],
         chargers: [charger0],
     };
 

--- a/examples/std/src/bin/power_policy.rs
+++ b/examples/std/src/bin/power_policy.rs
@@ -253,7 +253,7 @@ async fn run(spawner: Spawner) {
 
     let registration = ArrayRegistration {
         psus: [device0, device1],
-        service_senders: [NoopSender.into()],
+        service_notifiers: [NoopSender.into()],
         chargers: [charger0],
     };
 

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -345,11 +345,14 @@ impl type_c_interface::controller::retimer::Retimer for Controller<'_> {
     }
 }
 
+pub type PowerNotifier<'a> = power_policy_interface::psu::event::NonBlockingSenderNotifier<
+    channel::DynamicSender<'a, power_policy_interface::psu::event::EventData>,
+>;
 pub type Port<'a> = type_c_service::controller::Port<
     'a,
     Mutex<GlobalRawMutex, Controller<'a>>,
     Mutex<GlobalRawMutex, SharedState>,
     channel::DynamicSender<'a, type_c_interface::service::event::PortEventData>,
-    channel::DynamicSender<'a, power_policy_interface::psu::event::EventData>,
+    PowerNotifier<'a>,
     channel::DynamicSender<'a, type_c_service::controller::event::Loopback>,
 >;

--- a/power-policy-interface-test-mocks/src/psu.rs
+++ b/power-policy-interface-test-mocks/src/psu.rs
@@ -2,12 +2,12 @@
 
 use std::collections::VecDeque;
 
-use embedded_services::{event::NonBlockingSender, named::Named};
+use embedded_services::named::Named;
 use power_policy_interface::{
     capability::{
         ConsumerDisconnect, ConsumerPowerCapability, PowerCapability, ProviderFlags, ProviderPowerCapability,
     },
-    psu::{Error, Psu, State, event::EventData},
+    psu::{self, Error, Psu, State},
 };
 
 /// Contains a PSU function call and its arguments
@@ -19,8 +19,8 @@ pub enum FnCall {
 }
 
 /// Mock PSU for use in tests
-pub struct Mock<S: NonBlockingSender<EventData>> {
-    sender: S,
+pub struct Mock<Notifier: psu::notification::Notifier> {
+    notifier: Notifier,
     name: &'static str,
     pub state: State,
     /// Recorded function calls
@@ -33,11 +33,11 @@ pub struct Mock<S: NonBlockingSender<EventData>> {
     pub next_result_disconnect: VecDeque<Result<(), Error>>,
 }
 
-impl<S: NonBlockingSender<EventData>> Mock<S> {
-    pub fn new(name: &'static str, sender: S) -> Self {
+impl<Notifier: psu::notification::Notifier> Mock<Notifier> {
+    pub fn new(name: &'static str, notifier: Notifier) -> Self {
         Self {
             name,
-            sender,
+            notifier,
             state: Default::default(),
             fn_calls: VecDeque::new(),
             next_result_connect_consumer: VecDeque::new(),
@@ -48,29 +48,31 @@ impl<S: NonBlockingSender<EventData>> Mock<S> {
 
     pub async fn simulate_consumer_connection(&mut self, capability: ConsumerPowerCapability) {
         self.state.attach().unwrap();
-        self.sender.try_send(EventData::Attached).unwrap();
+        self.notifier.notify_attached().await.unwrap();
         self.state.update_consumer_power_capability(Some(capability)).unwrap();
-        self.sender
-            .try_send(EventData::UpdatedConsumerCapability(Some(capability)))
+        self.notifier
+            .notify_updated_consumer_capability(Some(capability))
+            .await
             .unwrap();
     }
 
     /// Simulate an already-attached consumer renegotiating a new power capability.
     pub async fn simulate_update_consumer_power_capability(&mut self, capability: Option<ConsumerPowerCapability>) {
         self.state.update_consumer_power_capability(capability).unwrap();
-        self.sender
-            .try_send(EventData::UpdatedConsumerCapability(capability))
+        self.notifier
+            .notify_updated_consumer_capability(capability)
+            .await
             .unwrap();
     }
 
     pub async fn simulate_detach(&mut self) {
         self.state.detach();
-        self.sender.try_send(EventData::Detached).unwrap();
+        self.notifier.notify_detached().await.unwrap();
     }
 
     pub async fn simulate_provider_connection(&mut self, capability: PowerCapability) {
         self.state.attach().unwrap();
-        self.sender.try_send(EventData::Attached).unwrap();
+        self.notifier.notify_attached().await.unwrap();
 
         let capability = Some(ProviderPowerCapability {
             capability,
@@ -79,15 +81,17 @@ impl<S: NonBlockingSender<EventData>> Mock<S> {
         self.state
             .update_requested_provider_power_capability(capability)
             .unwrap();
-        self.sender
-            .try_send(EventData::RequestedProviderCapability(capability))
+        self.notifier
+            .notify_requested_provider_capability(capability)
+            .await
             .unwrap();
     }
 
     pub async fn simulate_disconnect(&mut self) {
         self.state.disconnect(true).unwrap();
-        self.sender
-            .try_send(EventData::Disconnected(ConsumerDisconnect::none()))
+        self.notifier
+            .notify_disconnected(ConsumerDisconnect::none())
+            .await
             .unwrap();
     }
 
@@ -98,13 +102,14 @@ impl<S: NonBlockingSender<EventData>> Mock<S> {
         self.state
             .update_requested_provider_power_capability(capability)
             .unwrap();
-        self.sender
-            .try_send(EventData::RequestedProviderCapability(capability))
+        self.notifier
+            .notify_requested_provider_capability(capability)
+            .await
             .unwrap();
     }
 }
 
-impl<S: NonBlockingSender<EventData>> Psu for Mock<S> {
+impl<Notifier: psu::notification::Notifier> Psu for Mock<Notifier> {
     async fn connect_consumer(&mut self, capability: ConsumerPowerCapability) -> Result<(), Error> {
         self.fn_calls.push_back(FnCall::ConnectConsumer(capability));
         let result = self
@@ -150,7 +155,7 @@ impl<S: NonBlockingSender<EventData>> Psu for Mock<S> {
     }
 }
 
-impl<S: NonBlockingSender<EventData>> Named for Mock<S> {
+impl<Notifier: psu::notification::Notifier> Named for Mock<Notifier> {
     fn name(&self) -> &'static str {
         self.name
     }

--- a/power-policy-interface/src/psu/event.rs
+++ b/power-policy-interface/src/psu/event.rs
@@ -41,9 +41,9 @@ where
     pub event: EventData,
 }
 
-/// New-type that implements the [`crate::psu::notification::Notifier`] trait for any [`NonBlockingSender<Event>`].
+/// New-type that implements the [`crate::psu::notification::Notifier`] trait for any [`NonBlockingSender<EventData>`].
 ///
-/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+/// This allows the user to choose blocking/non-blocking behavior when a type supports both.
 pub struct NonBlockingSenderNotifier<S: NonBlockingSender<EventData>>(pub S);
 
 impl<S: NonBlockingSender<EventData>> crate::psu::notification::Notifier for NonBlockingSenderNotifier<S> {
@@ -103,9 +103,9 @@ impl<S: NonBlockingSender<EventData>> From<S> for NonBlockingSenderNotifier<S> {
     }
 }
 
-/// New-type that implements the [`crate::psu::notification::Notifier`] trait for any [`Sender<Event>`].
+/// New-type that implements the [`crate::psu::notification::Notifier`] trait for any [`Sender<EventData>`].
 ///
-/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+/// This allows the user to choose blocking/non-blocking behavior when a type supports both.
 pub struct SenderNotifier<S: Sender<EventData>>(pub S);
 
 impl<S: Sender<EventData>> crate::psu::notification::Notifier for SenderNotifier<S> {

--- a/power-policy-interface/src/psu/event.rs
+++ b/power-policy-interface/src/psu/event.rs
@@ -1,5 +1,10 @@
 //! Messages originating from a PSU
-use embedded_services::sync::Lockable;
+use core::future::ready;
+
+use embedded_services::{
+    event::{NonBlockingSender, Sender},
+    sync::Lockable,
+};
 
 use crate::{
     capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
@@ -34,4 +39,110 @@ where
     pub psu: &'a D,
     /// Event data
     pub event: EventData,
+}
+
+/// New-type that implements the [`crate::psu::notification::Notifier`] trait for any [`NonBlockingSender<Event>`].
+///
+/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+pub struct NonBlockingSenderNotifier<S: NonBlockingSender<EventData>>(pub S);
+
+impl<S: NonBlockingSender<EventData>> crate::psu::notification::Notifier for NonBlockingSenderNotifier<S> {
+    fn notify_attached(&mut self) -> impl Future<Output = Result<(), crate::psu::notification::Error>> {
+        ready(
+            self.0
+                .try_send(EventData::Attached)
+                .ok_or(crate::psu::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_updated_consumer_capability(
+        &mut self,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> impl Future<Output = Result<(), crate::psu::notification::Error>> {
+        ready(
+            self.0
+                .try_send(EventData::UpdatedConsumerCapability(capability))
+                .ok_or(crate::psu::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_requested_provider_capability(
+        &mut self,
+        capability: Option<ProviderPowerCapability>,
+    ) -> impl Future<Output = Result<(), crate::psu::notification::Error>> {
+        ready(
+            self.0
+                .try_send(EventData::RequestedProviderCapability(capability))
+                .ok_or(crate::psu::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_disconnected(
+        &mut self,
+        flags: ConsumerDisconnect,
+    ) -> impl Future<Output = Result<(), crate::psu::notification::Error>> {
+        ready(
+            self.0
+                .try_send(EventData::Disconnected(flags))
+                .ok_or(crate::psu::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_detached(&mut self) -> impl Future<Output = Result<(), crate::psu::notification::Error>> {
+        ready(
+            self.0
+                .try_send(EventData::Detached)
+                .ok_or(crate::psu::notification::Error::WouldBlock),
+        )
+    }
+}
+
+impl<S: NonBlockingSender<EventData>> From<S> for NonBlockingSenderNotifier<S> {
+    fn from(sender: S) -> Self {
+        Self(sender)
+    }
+}
+
+/// New-type that implements the [`crate::psu::notification::Notifier`] trait for any [`Sender<Event>`].
+///
+/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+pub struct SenderNotifier<S: Sender<EventData>>(pub S);
+
+impl<S: Sender<EventData>> crate::psu::notification::Notifier for SenderNotifier<S> {
+    async fn notify_attached(&mut self) -> Result<(), crate::psu::notification::Error> {
+        self.0.send(EventData::Attached).await;
+        Ok(())
+    }
+
+    async fn notify_updated_consumer_capability(
+        &mut self,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> Result<(), crate::psu::notification::Error> {
+        self.0.send(EventData::UpdatedConsumerCapability(capability)).await;
+        Ok(())
+    }
+
+    async fn notify_requested_provider_capability(
+        &mut self,
+        capability: Option<ProviderPowerCapability>,
+    ) -> Result<(), crate::psu::notification::Error> {
+        self.0.send(EventData::RequestedProviderCapability(capability)).await;
+        Ok(())
+    }
+
+    async fn notify_disconnected(&mut self, flags: ConsumerDisconnect) -> Result<(), crate::psu::notification::Error> {
+        self.0.send(EventData::Disconnected(flags)).await;
+        Ok(())
+    }
+
+    async fn notify_detached(&mut self) -> Result<(), crate::psu::notification::Error> {
+        self.0.send(EventData::Detached).await;
+        Ok(())
+    }
+}
+
+impl<S: Sender<EventData>> From<S> for SenderNotifier<S> {
+    fn from(sender: S) -> Self {
+        Self(sender)
+    }
 }

--- a/power-policy-interface/src/psu/mod.rs
+++ b/power-policy-interface/src/psu/mod.rs
@@ -4,6 +4,7 @@ use embedded_services::named::Named;
 use crate::capability::{ConsumerPowerCapability, PowerCapability, ProviderPowerCapability};
 
 pub mod event;
+pub mod notification;
 
 /// Error type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/power-policy-interface/src/psu/notification.rs
+++ b/power-policy-interface/src/psu/notification.rs
@@ -1,0 +1,61 @@
+//! Traits and types for PSU notifications.
+
+use embedded_services::sync::Lockable;
+
+use crate::capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// The requested operation would block
+    WouldBlock,
+}
+
+/// PSU notifier trait
+pub trait Notifier {
+    /// Notify that a PSU has attached
+    fn notify_attached(&mut self) -> impl Future<Output = Result<(), Error>>;
+    /// Notify of updated consumer capability
+    fn notify_updated_consumer_capability(
+        &mut self,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> impl Future<Output = Result<(), Error>>;
+    /// Notify of requested provider capability
+    fn notify_requested_provider_capability(
+        &mut self,
+        capability: Option<ProviderPowerCapability>,
+    ) -> impl Future<Output = Result<(), Error>>;
+    /// Notify that a PSU has disconnected
+    fn notify_disconnected(&mut self, flags: ConsumerDisconnect) -> impl Future<Output = Result<(), Error>>;
+    /// Notify that a PSU has detached
+    fn notify_detached(&mut self) -> impl Future<Output = Result<(), Error>>;
+}
+
+/// PSU notification handler
+pub trait NotificationHandler<'device> {
+    type Psu: Lockable<Inner: crate::psu::Psu> + 'device;
+
+    /// Handle a notification that a PSU has attached
+    fn process_notify_attached(&mut self, psu: &'device Self::Psu) -> impl Future<Output = Result<(), super::Error>>;
+    /// Handle a notification of updated consumer capability
+    fn process_notify_updated_consumer_capability(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> impl Future<Output = Result<(), super::Error>>;
+    /// Handle a notification of requested provider capability
+    fn process_notify_requested_provider_capability(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: Option<ProviderPowerCapability>,
+    ) -> impl Future<Output = Result<(), super::Error>>;
+    /// Handle a notification that a PSU has disconnected
+    fn process_notify_disconnected(
+        &mut self,
+        psu: &'device Self::Psu,
+        flags: ConsumerDisconnect,
+    ) -> impl Future<Output = Result<(), super::Error>>;
+    /// Handle a notification that a PSU has detached
+    fn process_notify_detached(&mut self, psu: &'device Self::Psu) -> impl Future<Output = Result<(), super::Error>>;
+}

--- a/power-policy-interface/src/service/event.rs
+++ b/power-policy-interface/src/service/event.rs
@@ -1,4 +1,9 @@
-use embedded_services::sync::Lockable;
+use core::{future::ready, marker::PhantomData};
+
+use embedded_services::{
+    event::{NonBlockingSender, Sender},
+    sync::Lockable,
+};
 
 use crate::{
     capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
@@ -77,4 +82,179 @@ where
     PSU: Lockable,
     PSU::Inner: Psu,
 {
+}
+
+/// New-type that implements the [`crate::service::notification::Notifier`] trait for any [`NonBlockingSender<Event>`].
+///
+/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+pub struct NonBlockingSenderNotifier<
+    'device,
+    PSU: Lockable<Inner: Psu> + 'device,
+    S: NonBlockingSender<Event<'device, PSU>>,
+> {
+    pub sender: S,
+    _phantom: PhantomData<&'device PSU>,
+}
+
+impl<'device, PSU: Lockable<Inner: Psu>, S: NonBlockingSender<Event<'device, PSU>>>
+    NonBlockingSenderNotifier<'device, PSU, S>
+{
+    /// Create a new [`NonBlockingSenderNotifier`]
+    pub fn new(sender: S) -> Self {
+        Self {
+            sender,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'device, PSU: Lockable<Inner: Psu>, S: NonBlockingSender<Event<'device, PSU>>>
+    crate::service::notification::Notifier<'device> for NonBlockingSenderNotifier<'device, PSU, S>
+{
+    type Psu = PSU;
+
+    fn notify_consumer_disconnected(
+        &mut self,
+        psu: &'device Self::Psu,
+        flags: ConsumerDisconnect,
+    ) -> impl Future<Output = Result<(), crate::service::notification::Error>> {
+        ready(
+            self.sender
+                .try_send(Event::ConsumerDisconnected(psu, flags))
+                .ok_or(crate::service::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_consumer_connected(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: ConsumerPowerCapability,
+    ) -> impl Future<Output = Result<(), crate::service::notification::Error>> {
+        ready(
+            self.sender
+                .try_send(Event::ConsumerConnected(psu, capability))
+                .ok_or(crate::service::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_provider_disconnected(
+        &mut self,
+        psu: &'device Self::Psu,
+    ) -> impl Future<Output = Result<(), crate::service::notification::Error>> {
+        ready(
+            self.sender
+                .try_send(Event::ProviderDisconnected(psu))
+                .ok_or(crate::service::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_provider_connected(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: ProviderPowerCapability,
+    ) -> impl Future<Output = Result<(), crate::service::notification::Error>> {
+        ready(
+            self.sender
+                .try_send(Event::ProviderConnected(psu, capability))
+                .ok_or(crate::service::notification::Error::WouldBlock),
+        )
+    }
+
+    fn notify_unconstrained(
+        &mut self,
+        unconstrained: UnconstrainedState,
+    ) -> impl Future<Output = Result<(), crate::service::notification::Error>> {
+        ready(
+            self.sender
+                .try_send(Event::Unconstrained(unconstrained))
+                .ok_or(crate::service::notification::Error::WouldBlock),
+        )
+    }
+}
+
+impl<'device, PSU: Lockable<Inner: Psu>, S: NonBlockingSender<Event<'device, PSU>>> From<S>
+    for NonBlockingSenderNotifier<'device, PSU, S>
+{
+    fn from(sender: S) -> Self {
+        Self {
+            sender,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// New-type that implements the [`crate::service::notification::Notifier`] trait for any [`Sender<Event>`].
+///
+/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+pub struct SenderNotifier<'device, PSU: Lockable<Inner: Psu> + 'device, S: Sender<Event<'device, PSU>>> {
+    pub sender: S,
+    _phantom: PhantomData<&'device PSU>,
+}
+
+impl<'device, PSU: Lockable<Inner: Psu> + 'device, S: Sender<Event<'device, PSU>>> SenderNotifier<'device, PSU, S> {
+    /// Create a new [`SenderNotifier`]
+    pub fn new(sender: S) -> Self {
+        Self {
+            sender,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'device, PSU: Lockable<Inner: Psu> + 'device, S: Sender<Event<'device, PSU>>>
+    crate::service::notification::Notifier<'device> for SenderNotifier<'device, PSU, S>
+{
+    type Psu = PSU;
+
+    async fn notify_consumer_disconnected(
+        &mut self,
+        psu: &'device Self::Psu,
+        flags: ConsumerDisconnect,
+    ) -> Result<(), crate::service::notification::Error> {
+        self.sender.send(Event::ConsumerDisconnected(psu, flags)).await;
+        Ok(())
+    }
+
+    async fn notify_consumer_connected(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: ConsumerPowerCapability,
+    ) -> Result<(), crate::service::notification::Error> {
+        self.sender.send(Event::ConsumerConnected(psu, capability)).await;
+        Ok(())
+    }
+
+    async fn notify_provider_disconnected(
+        &mut self,
+        psu: &'device Self::Psu,
+    ) -> Result<(), crate::service::notification::Error> {
+        self.sender.send(Event::ProviderDisconnected(psu)).await;
+        Ok(())
+    }
+
+    async fn notify_provider_connected(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: ProviderPowerCapability,
+    ) -> Result<(), crate::service::notification::Error> {
+        self.sender.send(Event::ProviderConnected(psu, capability)).await;
+        Ok(())
+    }
+
+    async fn notify_unconstrained(
+        &mut self,
+        unconstrained: UnconstrainedState,
+    ) -> Result<(), crate::service::notification::Error> {
+        self.sender.send(Event::Unconstrained(unconstrained)).await;
+        Ok(())
+    }
+}
+
+impl<'device, PSU: Lockable<Inner: Psu>, S: Sender<Event<'device, PSU>>> From<S> for SenderNotifier<'device, PSU, S> {
+    fn from(sender: S) -> Self {
+        Self {
+            sender,
+            _phantom: PhantomData,
+        }
+    }
 }

--- a/power-policy-interface/src/service/event.rs
+++ b/power-policy-interface/src/service/event.rs
@@ -86,7 +86,7 @@ where
 
 /// New-type that implements the [`crate::service::notification::Notifier`] trait for any [`NonBlockingSender<Event>`].
 ///
-/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+/// This allows the user to choose blocking/non-blocking behavior when a type supports both.
 pub struct NonBlockingSenderNotifier<
     'device,
     PSU: Lockable<Inner: Psu> + 'device,
@@ -185,7 +185,7 @@ impl<'device, PSU: Lockable<Inner: Psu>, S: NonBlockingSender<Event<'device, PSU
 
 /// New-type that implements the [`crate::service::notification::Notifier`] trait for any [`Sender<Event>`].
 ///
-/// This allows the user to chose blocking/non-blocking behavior when a type supports both.
+/// This allows the user to choose blocking/non-blocking behavior when a type supports both.
 pub struct SenderNotifier<'device, PSU: Lockable<Inner: Psu> + 'device, S: Sender<Event<'device, PSU>>> {
     pub sender: S,
     _phantom: PhantomData<&'device PSU>,

--- a/power-policy-interface/src/service/mod.rs
+++ b/power-policy-interface/src/service/mod.rs
@@ -1,4 +1,5 @@
 pub mod event;
+pub mod notification;
 
 /// Unconstrained state information
 #[derive(Debug, Clone, Default, Copy, PartialEq, Eq)]

--- a/power-policy-interface/src/service/notification.rs
+++ b/power-policy-interface/src/service/notification.rs
@@ -18,7 +18,7 @@ pub enum Error {
 pub trait Notifier<'device> {
     type Psu: Lockable<Inner: crate::psu::Psu> + 'device;
 
-    /// Notify that a consumer has disconneced
+    /// Notify that a consumer has disconnected
     fn notify_consumer_disconnected(
         &mut self,
         psu: &'device Self::Psu,

--- a/power-policy-interface/src/service/notification.rs
+++ b/power-policy-interface/src/service/notification.rs
@@ -1,0 +1,43 @@
+//! Traits and types for service notifications.
+use embedded_services::sync::Lockable;
+
+use crate::{
+    capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
+    service::UnconstrainedState,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Implementation would block
+    WouldBlock,
+}
+
+/// Service notifier trait
+pub trait Notifier<'device> {
+    type Psu: Lockable<Inner: crate::psu::Psu> + 'device;
+
+    /// Notify that a consumer has disconneced
+    fn notify_consumer_disconnected(
+        &mut self,
+        psu: &'device Self::Psu,
+        flags: ConsumerDisconnect,
+    ) -> impl Future<Output = Result<(), Error>>;
+    /// Notify that a consumer has been connected
+    fn notify_consumer_connected(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: ConsumerPowerCapability,
+    ) -> impl Future<Output = Result<(), Error>>;
+    /// Notify that a provider has disconnected
+    fn notify_provider_disconnected(&mut self, psu: &'device Self::Psu) -> impl Future<Output = Result<(), Error>>;
+    /// Notify that a provider has connected
+    fn notify_provider_connected(
+        &mut self,
+        psu: &'device Self::Psu,
+        capability: ProviderPowerCapability,
+    ) -> impl Future<Output = Result<(), Error>>;
+    /// Notify that the unconstrained state has changed
+    fn notify_unconstrained(&mut self, unconstrained: UnconstrainedState) -> impl Future<Output = Result<(), Error>>;
+}

--- a/power-policy-service/src/service/consumer.rs
+++ b/power-policy-service/src/service/consumer.rs
@@ -7,7 +7,6 @@ use crate::service::config::Config;
 use super::*;
 
 use power_policy_interface::psu;
-use power_policy_interface::service::event::Event as ServiceEvent;
 use power_policy_interface::{
     capability::{ConsumerDisconnect, ConsumerPowerCapability},
     psu::PsuState,
@@ -133,7 +132,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
         if unconstrained_new != self.state.unconstrained {
             info!("Unconstrained state changed: {:?}", unconstrained_new);
             self.state.unconstrained = unconstrained_new;
-            self.broadcast_event(ServiceEvent::Unconstrained(self.state.unconstrained));
+            self.notify_unconstrained(self.state.unconstrained).await;
         }
         Ok(())
     }
@@ -169,10 +168,8 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
                 .await
                 .map_err(|e| Error::Charger(e.into()))?;
         }
-        self.broadcast_event(ServiceEvent::ConsumerConnected(
-            connected_consumer.psu,
-            connected_consumer.consumer_power_capability,
-        ));
+        self.notify_consumer_connected(connected_consumer.psu, connected_consumer.consumer_power_capability)
+            .await;
 
         Ok(())
     }
@@ -227,7 +224,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
             } else {
                 ConsumerDisconnect::none().with_switching(true)
             };
-            self.broadcast_event(ServiceEvent::ConsumerDisconnected(current_consumer.psu, flags));
+            self.notify_consumer_disconnected(current_consumer.psu, flags).await;
 
             // Don't update the unconstrained here because this is a transitional state
         }
@@ -278,10 +275,8 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
             // Notify disconnect if recently detached consumer was previously attached.
             if let Some(current_consumer) = self.state.current_consumer_state {
                 self.disconnect_chargers().await?;
-                self.broadcast_event(ServiceEvent::ConsumerDisconnected(
-                    current_consumer.psu,
-                    disconnect_flags,
-                ));
+                self.notify_consumer_disconnected(current_consumer.psu, disconnect_flags)
+                    .await;
             }
             // No new consumer available
             self.state.current_consumer_state = None;

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -10,10 +10,11 @@ pub mod task;
 
 use embedded_services::error;
 use embedded_services::named::Named;
-use embedded_services::{event::NonBlockingSender, info, sync::Lockable, trace};
+use embedded_services::{info, sync::Lockable, trace};
 
 use power_policy_interface::charger::{Charger, PsuState};
 use power_policy_interface::psu::notification::NotificationHandler as _;
+use power_policy_interface::service::notification::Notifier;
 use power_policy_interface::{
     capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
     charger::{Event as ChargerEvent, EventData as ChargerEventData},
@@ -21,7 +22,7 @@ use power_policy_interface::{
         Error, Psu,
         event::{Event as PsuEvent, EventData as PsuEventData},
     },
-    service::{UnconstrainedState, event::Event as ServiceEvent},
+    service::UnconstrainedState,
 };
 
 use crate::service::registration::Registration;
@@ -111,11 +112,42 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
         total
     }
 
-    /// Send an event to all registered listeners
-    fn broadcast_event(&mut self, event: ServiceEvent<'device, Reg::Psu>) {
-        for sender in self.registration.event_senders() {
-            if sender.try_send(event).is_none() {
-                error!("Failed to send event to listener");
+    async fn notify_unconstrained(&mut self, unconstrained: UnconstrainedState) {
+        for notifier in self.registration.notifiers() {
+            if let Err(e) = notifier.notify_unconstrained(unconstrained).await {
+                error!("Failed to notify unconstrained state change: {:#?}", e);
+            }
+        }
+    }
+
+    async fn notify_consumer_connected(&mut self, psu: &'device Reg::Psu, capability: ConsumerPowerCapability) {
+        for notifier in self.registration.notifiers() {
+            if let Err(e) = notifier.notify_consumer_connected(psu, capability).await {
+                error!("Failed to notify consumer connected: {:#?}", e);
+            }
+        }
+    }
+
+    async fn notify_consumer_disconnected(&mut self, psu: &'device Reg::Psu, flags: ConsumerDisconnect) {
+        for notifier in self.registration.notifiers() {
+            if let Err(e) = notifier.notify_consumer_disconnected(psu, flags).await {
+                error!("Failed to notify consumer disconnected: {:#?}", e);
+            }
+        }
+    }
+
+    async fn notify_provider_connected(&mut self, psu: &'device Reg::Psu, capability: ProviderPowerCapability) {
+        for notifier in self.registration.notifiers() {
+            if let Err(e) = notifier.notify_provider_connected(psu, capability).await {
+                error!("Failed to notify provider connected: {:#?}", e);
+            }
+        }
+    }
+
+    async fn notify_provider_disconnected(&mut self, psu: &'device Reg::Psu) {
+        for notifier in self.registration.notifiers() {
+            if let Err(e) = notifier.notify_provider_disconnected(psu).await {
+                error!("Failed to notify provider disconnected: {:#?}", e);
             }
         }
     }

--- a/power-policy-service/src/service/mod.rs
+++ b/power-policy-service/src/service/mod.rs
@@ -13,6 +13,7 @@ use embedded_services::named::Named;
 use embedded_services::{event::NonBlockingSender, info, sync::Lockable, trace};
 
 use power_policy_interface::charger::{Charger, PsuState};
+use power_policy_interface::psu::notification::NotificationHandler as _;
 use power_policy_interface::{
     capability::{ConsumerDisconnect, ConsumerPowerCapability, ProviderPowerCapability},
     charger::{Event as ChargerEvent, EventData as ChargerEventData},
@@ -110,56 +111,6 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
         total
     }
 
-    async fn process_notify_attach(&self, device: &'device Reg::Psu) {
-        info!("({}): Received notify attached", device.lock().await.name());
-    }
-
-    async fn process_notify_detach(&mut self, device: &'device Reg::Psu) -> Result<(), Error> {
-        info!("({}): Received notify detached", device.lock().await.name());
-        self.post_provider_removed(device).await;
-        self.update_current_consumer(ConsumerDisconnect::none()).await?;
-        Ok(())
-    }
-
-    async fn process_notify_consumer_power_capability(
-        &mut self,
-        device: &'device Reg::Psu,
-        capability: Option<ConsumerPowerCapability>,
-    ) -> Result<(), Error> {
-        info!(
-            "({}): Received notify consumer capability: {:#?}",
-            device.lock().await.name(),
-            capability,
-        );
-
-        self.update_current_consumer(ConsumerDisconnect::none()).await
-    }
-
-    async fn process_request_provider_power_capabilities(
-        &mut self,
-        requester: &'device Reg::Psu,
-        capability: Option<ProviderPowerCapability>,
-    ) -> Result<(), Error> {
-        info!(
-            "({}): Received request provider capability: {:#?}",
-            requester.lock().await.name(),
-            capability,
-        );
-
-        self.connect_provider(requester).await
-    }
-
-    async fn process_notify_disconnect(
-        &mut self,
-        device: &'device Reg::Psu,
-        flags: ConsumerDisconnect,
-    ) -> Result<(), Error> {
-        info!("({}): Received notify disconnect", device.lock().await.name());
-        self.post_provider_removed(device).await;
-        self.update_current_consumer(flags).await?;
-        Ok(())
-    }
-
     /// Send an event to all registered listeners
     fn broadcast_event(&mut self, event: ServiceEvent<'device, Reg::Psu>) {
         for sender in self.registration.event_senders() {
@@ -172,19 +123,17 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
     pub async fn process_psu_event(&mut self, event: PsuEvent<'device, Reg::Psu>) -> Result<(), Error> {
         let device = event.psu;
         match event.event {
-            PsuEventData::Attached => {
-                self.process_notify_attach(device).await;
-                Ok(())
-            }
-            PsuEventData::Detached => self.process_notify_detach(device).await,
+            PsuEventData::Attached => self.process_notify_attached(device).await,
+            PsuEventData::Detached => self.process_notify_detached(device).await,
             PsuEventData::UpdatedConsumerCapability(capability) => {
-                self.process_notify_consumer_power_capability(device, capability).await
-            }
-            PsuEventData::RequestedProviderCapability(capability) => {
-                self.process_request_provider_power_capabilities(device, capability)
+                self.process_notify_updated_consumer_capability(device, capability)
                     .await
             }
-            PsuEventData::Disconnected(flags) => self.process_notify_disconnect(device, flags).await,
+            PsuEventData::RequestedProviderCapability(capability) => {
+                self.process_notify_requested_provider_capability(device, capability)
+                    .await
+            }
+            PsuEventData::Disconnected(flags) => self.process_notify_disconnected(device, flags).await,
             _ => {
                 info!(
                     "Received unknown PSU event from ({}): {:?}",
@@ -222,6 +171,63 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
                 ));
             }
         };
+        Ok(())
+    }
+}
+
+impl<'device, Reg: Registration<'device>, Customization: customization::Customization>
+    power_policy_interface::psu::notification::NotificationHandler<'device> for Service<'device, Reg, Customization>
+{
+    type Psu = Reg::Psu;
+
+    async fn process_notify_attached(&mut self, device: &'device Reg::Psu) -> Result<(), Error> {
+        info!("({}): Received notify attached", device.lock().await.name());
+        Ok(())
+    }
+
+    async fn process_notify_detached(&mut self, device: &'device Reg::Psu) -> Result<(), Error> {
+        info!("({}): Received notify detached", device.lock().await.name());
+        self.post_provider_removed(device).await;
+        self.update_current_consumer(ConsumerDisconnect::none()).await?;
+        Ok(())
+    }
+
+    async fn process_notify_updated_consumer_capability(
+        &mut self,
+        device: &'device Reg::Psu,
+        capability: Option<ConsumerPowerCapability>,
+    ) -> Result<(), Error> {
+        info!(
+            "({}): Received notify consumer capability: {:#?}",
+            device.lock().await.name(),
+            capability,
+        );
+
+        self.update_current_consumer(ConsumerDisconnect::none()).await
+    }
+
+    async fn process_notify_requested_provider_capability(
+        &mut self,
+        requester: &'device Reg::Psu,
+        capability: Option<ProviderPowerCapability>,
+    ) -> Result<(), Error> {
+        info!(
+            "({}): Received request provider capability: {:#?}",
+            requester.lock().await.name(),
+            capability,
+        );
+
+        self.connect_provider(requester).await
+    }
+
+    async fn process_notify_disconnected(
+        &mut self,
+        device: &'device Reg::Psu,
+        flags: ConsumerDisconnect,
+    ) -> Result<(), Error> {
+        info!("({}): Received notify disconnect", device.lock().await.name());
+        self.post_provider_removed(device).await;
+        self.update_current_consumer(flags).await?;
         Ok(())
     }
 }

--- a/power-policy-service/src/service/provider.rs
+++ b/power-policy-service/src/service/provider.rs
@@ -98,13 +98,13 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
             e
         } else {
             locked_requester.connect_provider(target_power).await?;
-            self.post_provider_connected(requester, target_power);
+            self.post_provider_connected(requester, target_power).await;
             Ok(())
         }
     }
 
     /// Common logic for after a provider has successfully connected
-    fn post_provider_connected(&mut self, requester: &'device Reg::Psu, target_power: ProviderPowerCapability) {
+    async fn post_provider_connected(&mut self, requester: &'device Reg::Psu, target_power: ProviderPowerCapability) {
         if self
             .state
             .connected_providers
@@ -113,7 +113,8 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
         {
             error!("Tracked providers set is full");
         }
-        self.broadcast_event(ServiceEvent::ProviderConnected(requester, target_power));
+
+        self.notify_provider_connected(requester, target_power).await;
     }
 
     /// Common logic for when a provider is removed
@@ -138,7 +139,7 @@ impl<'device, Reg: Registration<'device>, Customization: customization::Customiz
                 self.state.current_provider_state.state = PowerState::Unlimited;
             }
 
-            self.broadcast_event(ServiceEvent::ProviderDisconnected(psu));
+            self.notify_provider_disconnected(psu).await;
             true
         } else {
             false

--- a/power-policy-service/src/service/registration.rs
+++ b/power-policy-service/src/service/registration.rs
@@ -1,18 +1,18 @@
 //! Code related to registration with the power policy service.
 
-use embedded_services::{event::NonBlockingSender, sync::Lockable};
-use power_policy_interface::{charger, psu, service::event::Event as ServiceEvent};
+use embedded_services::sync::Lockable;
+use power_policy_interface::{charger, psu};
 
 /// Registration trait that abstracts over various registration details.
 pub trait Registration<'device> {
     type Psu: Lockable<Inner: psu::Psu> + 'device;
-    type ServiceSender: NonBlockingSender<ServiceEvent<'device, Self::Psu>>;
+    type ServiceNotifier: power_policy_interface::service::notification::Notifier<'device, Psu = Self::Psu>;
     type Charger: Lockable<Inner: charger::Charger> + 'device;
 
     /// Returns a slice to access PSU devices
     fn psus(&self) -> &[&'device Self::Psu];
     /// Returns a slice to access power policy event senders
-    fn event_senders(&mut self) -> &mut [Self::ServiceSender];
+    fn notifiers(&mut self) -> &mut [Self::ServiceNotifier];
     /// Returns a slice to access charger devices
     fn chargers(&self) -> &[&'device Self::Charger];
 }
@@ -22,7 +22,7 @@ pub struct ArrayRegistration<
     'device,
     Psu: Lockable<Inner: psu::Psu> + 'device,
     const PSU_COUNT: usize,
-    ServiceSender: NonBlockingSender<ServiceEvent<'device, Psu>>,
+    ServiceNotifier: power_policy_interface::service::notification::Notifier<'device, Psu = Psu>,
     const SERVICE_SENDER_COUNT: usize,
     Charger: Lockable<Inner: charger::Charger> + 'device,
     const CHARGER_COUNT: usize,
@@ -32,29 +32,29 @@ pub struct ArrayRegistration<
     /// Array of registered chargers
     pub chargers: [&'device Charger; CHARGER_COUNT],
     /// Array of power policy service event senders
-    pub service_senders: [ServiceSender; SERVICE_SENDER_COUNT],
+    pub service_senders: [ServiceNotifier; SERVICE_SENDER_COUNT],
 }
 
 impl<
     'device,
     Psu: Lockable<Inner: psu::Psu> + 'device,
     const PSU_COUNT: usize,
-    ServiceSender: NonBlockingSender<ServiceEvent<'device, Psu>>,
+    ServiceNotifier: power_policy_interface::service::notification::Notifier<'device, Psu = Psu>,
     const SERVICE_SENDER_COUNT: usize,
     Charger: Lockable<Inner: charger::Charger> + 'device,
     const CHARGER_COUNT: usize,
 > Registration<'device>
-    for ArrayRegistration<'device, Psu, PSU_COUNT, ServiceSender, SERVICE_SENDER_COUNT, Charger, CHARGER_COUNT>
+    for ArrayRegistration<'device, Psu, PSU_COUNT, ServiceNotifier, SERVICE_SENDER_COUNT, Charger, CHARGER_COUNT>
 {
     type Psu = Psu;
-    type ServiceSender = ServiceSender;
+    type ServiceNotifier = ServiceNotifier;
     type Charger = Charger;
 
     fn psus(&self) -> &[&'device Self::Psu] {
         &self.psus
     }
 
-    fn event_senders(&mut self) -> &mut [Self::ServiceSender] {
+    fn notifiers(&mut self) -> &mut [Self::ServiceNotifier] {
         &mut self.service_senders
     }
 

--- a/power-policy-service/src/service/registration.rs
+++ b/power-policy-service/src/service/registration.rs
@@ -11,7 +11,7 @@ pub trait Registration<'device> {
 
     /// Returns a slice to access PSU devices
     fn psus(&self) -> &[&'device Self::Psu];
-    /// Returns a slice to access power policy event senders
+    /// Returns a slice to access power policy notifiers
     fn notifiers(&mut self) -> &mut [Self::ServiceNotifier];
     /// Returns a slice to access charger devices
     fn chargers(&self) -> &[&'device Self::Charger];
@@ -23,7 +23,7 @@ pub struct ArrayRegistration<
     Psu: Lockable<Inner: psu::Psu> + 'device,
     const PSU_COUNT: usize,
     ServiceNotifier: power_policy_interface::service::notification::Notifier<'device, Psu = Psu>,
-    const SERVICE_SENDER_COUNT: usize,
+    const SERVICE_NOTIFIER_COUNT: usize,
     Charger: Lockable<Inner: charger::Charger> + 'device,
     const CHARGER_COUNT: usize,
 > {
@@ -31,8 +31,8 @@ pub struct ArrayRegistration<
     pub psus: [&'device Psu; PSU_COUNT],
     /// Array of registered chargers
     pub chargers: [&'device Charger; CHARGER_COUNT],
-    /// Array of power policy service event senders
-    pub service_senders: [ServiceNotifier; SERVICE_SENDER_COUNT],
+    /// Array of power policy service notifiers
+    pub service_notifiers: [ServiceNotifier; SERVICE_NOTIFIER_COUNT],
 }
 
 impl<
@@ -40,11 +40,11 @@ impl<
     Psu: Lockable<Inner: psu::Psu> + 'device,
     const PSU_COUNT: usize,
     ServiceNotifier: power_policy_interface::service::notification::Notifier<'device, Psu = Psu>,
-    const SERVICE_SENDER_COUNT: usize,
+    const SERVICE_NOTIFIER_COUNT: usize,
     Charger: Lockable<Inner: charger::Charger> + 'device,
     const CHARGER_COUNT: usize,
 > Registration<'device>
-    for ArrayRegistration<'device, Psu, PSU_COUNT, ServiceNotifier, SERVICE_SENDER_COUNT, Charger, CHARGER_COUNT>
+    for ArrayRegistration<'device, Psu, PSU_COUNT, ServiceNotifier, SERVICE_NOTIFIER_COUNT, Charger, CHARGER_COUNT>
 {
     type Psu = Psu;
     type ServiceNotifier = ServiceNotifier;
@@ -55,7 +55,7 @@ impl<
     }
 
     fn notifiers(&mut self) -> &mut [Self::ServiceNotifier] {
-        &mut self.service_senders
+        &mut self.service_notifiers
     }
 
     fn chargers(&self) -> &[&'device Self::Charger] {

--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -48,7 +48,9 @@ pub const DEFAULT_PER_CALL_TIMEOUT: Duration = Duration::from_millis(100);
 
 const EVENT_CHANNEL_SIZE: usize = 4;
 
-pub type DeviceType<'a> = Mutex<GlobalRawMutex, Mock<DynamicSender<'a, EventData>>>;
+pub type PowerNotifier<'device> =
+    power_policy_interface::psu::event::NonBlockingSenderNotifier<DynamicSender<'device, EventData>>;
+pub type DeviceType<'device> = Mutex<GlobalRawMutex, Mock<PowerNotifier<'device>>>;
 pub type ServiceType<'device, 'sender, Customization> = Service<
     'device,
     ArrayRegistration<
@@ -105,12 +107,12 @@ pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, c
     let device0_event_channel: Channel<GlobalRawMutex, EventData, EVENT_CHANNEL_SIZE> = Channel::new();
     let device0_sender = device0_event_channel.dyn_sender();
     let device0_receiver = device0_event_channel.dyn_receiver();
-    let device0 = Mutex::new(Mock::new("PSU0", device0_sender));
+    let device0 = Mutex::new(Mock::new("PSU0", device0_sender.into()));
 
     let device1_event_channel: Channel<GlobalRawMutex, EventData, EVENT_CHANNEL_SIZE> = Channel::new();
     let device1_sender = device1_event_channel.dyn_sender();
     let device1_receiver = device1_event_channel.dyn_receiver();
-    let device1 = Mutex::new(Mock::new("PSU1", device1_sender));
+    let device1 = Mutex::new(Mock::new("PSU1", device1_sender.into()));
 
     let completion_signal = embassy_sync::signal::Signal::new();
 

--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -130,7 +130,7 @@ pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, c
 
     let power_policy_registration = ArrayRegistration {
         psus: [&device0, &device1],
-        service_senders: [service_event_channel.dyn_sender().into()],
+        service_notifiers: [service_event_channel.dyn_sender().into()],
         chargers: [],
     };
 

--- a/power-policy-service/tests/common/mod.rs
+++ b/power-policy-service/tests/common/mod.rs
@@ -51,13 +51,18 @@ const EVENT_CHANNEL_SIZE: usize = 4;
 pub type PowerNotifier<'device> =
     power_policy_interface::psu::event::NonBlockingSenderNotifier<DynamicSender<'device, EventData>>;
 pub type DeviceType<'device> = Mutex<GlobalRawMutex, Mock<PowerNotifier<'device>>>;
+pub type ServiceNotifier<'sender, 'device> = power_policy_interface::service::event::NonBlockingSenderNotifier<
+    'device,
+    DeviceType<'device>,
+    DynamicSender<'sender, ServiceEvent<'device, DeviceType<'device>>>,
+>;
 pub type ServiceType<'device, 'sender, Customization> = Service<
     'device,
     ArrayRegistration<
         'device,
         DeviceType<'device>,
         2,
-        DynamicSender<'sender, ServiceEvent<'device, DeviceType<'device>>>,
+        ServiceNotifier<'sender, 'device>,
         1,
         ChargerType<DynamicSender<'device, power_policy_interface::charger::event::EventData>>,
         0,
@@ -125,7 +130,7 @@ pub async fn run_test<T: Test>(timeout: Duration, mut test: T, config: Config, c
 
     let power_policy_registration = ArrayRegistration {
         psus: [&device0, &device1],
-        service_senders: [service_event_channel.dyn_sender()],
+        service_senders: [service_event_channel.dyn_sender().into()],
         chargers: [],
     };
 

--- a/type-c-service/src/controller/electrical_disconnect.rs
+++ b/type-c-service/src/controller/electrical_disconnect.rs
@@ -13,10 +13,10 @@ impl<
     C: Lockable<Inner: Pd + ElectricalDisconnect>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
 > type_c_interface::port::electrical_disconnect::ElectricalDisconnect
-    for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+    for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn execute_electrical_disconnect(&mut self, reconnect_time_s: Option<NonZeroU8>) -> Result<(), PdError> {
         self.controller

--- a/type-c-service/src/controller/macros.rs
+++ b/type-c-service/src/controller/macros.rs
@@ -44,8 +44,8 @@ macro_rules! define_controller_port_static_cell_channel {
             // We prefix all aliases with 'Inner' to avoid potential name conflicts with user code when this macro is invoked
             // Unfortunately, super::$ty is not valid syntax in a macro, so we have to pull in everything with super::*.
             /// Type alias for the power policy sender
-            pub type InnerPowerPolicySenderType =
-                ::embassy_sync::channel::DynamicSender<'static, ::power_policy_interface::psu::event::EventData>;
+            pub type InnerPowerPolicyNotifierType =
+                ::power_policy_interface::psu::event::NonBlockingSenderNotifier<::embassy_sync::channel::DynamicSender<'static, ::power_policy_interface::psu::event::EventData>>;
             /// Type alias for the power policy receiver
             pub type InnerPowerPolicyReceiverType =
                 ::embassy_sync::channel::DynamicReceiver<'static, ::power_policy_interface::psu::event::EventData>;
@@ -84,7 +84,7 @@ macro_rules! define_controller_port_static_cell_channel {
                     // Type-C service event sender type
                     InnerTypeCSenderType,
                     // Power policy event sender type
-                    InnerPowerPolicySenderType,
+                    InnerPowerPolicyNotifierType,
                     // Loopback event sender type
                     InnerLoopbackSenderType,
                 >,
@@ -171,7 +171,7 @@ macro_rules! define_controller_port_static_cell_channel {
                     controller,
                     shared_state,
                     type_c_sender,
-                    power_policy_sender,
+                    power_policy_sender.into(),
                     loopback_sender,
                 )));
                 let event_receiver = $crate::controller::event_receiver::EventReceiver::new(

--- a/type-c-service/src/controller/max_sink_voltage.rs
+++ b/type-c-service/src/controller/max_sink_voltage.rs
@@ -12,10 +12,10 @@ impl<
     C: Lockable<Inner: Pd + MaxSinkVoltage>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
 > type_c_interface::port::max_sink_voltage::MaxSinkVoltage
-    for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+    for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn set_max_sink_voltage(&mut self, voltage_mv: Option<u16>) -> Result<(), PdError> {
         // A change in the maximum sink voltage can trigger a PD renegotiation. During that transition the
@@ -41,14 +41,13 @@ impl<
             if let Err(e) = self.psu_state.disconnect(true) {
                 error!("({}): Error updating PSU state on disconnect: {:?}", self.name, e);
             }
-            if self
-                .power_policy_sender
-                .try_send(power_policy_interface::psu::event::EventData::Disconnected(
-                    ConsumerDisconnect::none().with_renegotiation(true),
-                ))
-                .is_none()
+
+            if let Err(e) = self
+                .power_policy_notifier
+                .notify_disconnected(ConsumerDisconnect::none().with_renegotiation(true))
+                .await
             {
-                error!("({}): Failed to notify power policy of disconnect", self.name);
+                error!("({}): Failed to notify power policy of disconnect: {:#?}", self.name, e);
             }
         }
 

--- a/type-c-service/src/controller/mod.rs
+++ b/type-c-service/src/controller/mod.rs
@@ -29,7 +29,7 @@ pub struct Port<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
 > {
     /// Local port
@@ -44,8 +44,8 @@ pub struct Port<
     status: PortStatus,
     /// Sender for type-c service events
     type_c_sender: TypeCSender,
-    /// Sender for power policy events
-    power_policy_sender: PowerSender,
+    /// Notifier for power policy events
+    power_policy_notifier: PowerNotifier,
     /// Configuration
     config: config::Config,
     /// Shared state
@@ -59,9 +59,9 @@ impl<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     /// Create new Port instance
     // TODO: refactor arguments into a registration struct
@@ -73,7 +73,7 @@ impl<
         controller: &'device C,
         shared_state: &'device Shared,
         type_c_sender: TypeCSender,
-        power_policy_sender: PowerSender,
+        power_policy_notifier: PowerNotifier,
         loopback_sender: LoopbackSender,
     ) -> Self {
         Self {
@@ -82,7 +82,7 @@ impl<
             port,
             status: PortStatus::default(),
             psu_state: power_policy_interface::psu::State::default(),
-            power_policy_sender,
+            power_policy_notifier,
             config,
             shared_state,
             loopback_sender,
@@ -176,22 +176,14 @@ impl<
                 return Err(PdError::Failed);
             }
 
-            if self
-                .power_policy_sender
-                .try_send(power_policy_interface::psu::event::EventData::Attached)
-                .is_none()
-            {
-                error!("Failed to send power policy event");
+            if let Err(e) = self.power_policy_notifier.notify_attached().await {
+                error!("({}): Failed to notify power policy of attach: {:#?}", self.name, e);
             }
         } else {
             info!("Plug removed");
             self.psu_state.detach();
-            if self
-                .power_policy_sender
-                .try_send(power_policy_interface::psu::event::EventData::Detached)
-                .is_none()
-            {
-                error!("Failed to send power policy event");
+            if let Err(e) = self.power_policy_notifier.notify_detached().await {
+                error!("({}): Failed to notify power policy of detach: {:#?}", self.name, e);
             }
         }
 
@@ -234,9 +226,9 @@ impl<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> Named for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> Named for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     fn name(&self) -> &'static str {
         self.name

--- a/type-c-service/src/controller/pd.rs
+++ b/type-c-service/src/controller/pd.rs
@@ -23,9 +23,9 @@ impl<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     /// Process a VDM event by retrieving the relevant VDM data from the `controller` for the appropriate `port`.
     pub(super) async fn process_vdm_event(
@@ -86,9 +86,9 @@ impl<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> type_c_interface::port::pd::Pd for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> type_c_interface::port::pd::Pd for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn get_port_status(&mut self) -> Result<PortStatus, PdError> {
         self.controller.lock().await.get_port_status(self.port).await
@@ -176,9 +176,9 @@ impl<
     C: Lockable<Inner: Pd + StateMachine>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> type_c_interface::port::pd::StateMachine for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> type_c_interface::port::pd::StateMachine for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn set_pd_state_machine_config(&mut self, config: PdStateMachineConfig) -> Result<(), PdError> {
         self.controller

--- a/type-c-service/src/controller/power.rs
+++ b/type-c-service/src/controller/power.rs
@@ -118,14 +118,15 @@ impl<
         if let Err(e) = self.psu_state.disconnect(true) {
             error!("({}): Error updating PSU state on role swap: {:?}", self.name, e);
         }
-        if self
-            .power_policy_sender
-            .try_send(power_policy_interface::psu::event::EventData::Disconnected(
-                ConsumerDisconnect::none(),
-            ))
-            .is_none()
+        if let Err(e) = self
+            .power_policy_notifier
+            .notify_disconnected(ConsumerDisconnect::none())
+            .await
         {
-            error!("({}): Failed to notify power policy of role swap disconnect", self.name);
+            error!(
+                "({}): Failed to notify power policy of role swap disconnect: {:#?}",
+                self.name, e
+            );
         }
 
         Ok(())

--- a/type-c-service/src/controller/power.rs
+++ b/type-c-service/src/controller/power.rs
@@ -21,9 +21,9 @@ impl<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     /// Handle a new contract as consumer
     pub(super) async fn process_new_consumer_contract(&mut self, new_status: &PortStatus) -> Result<(), PdError> {
@@ -44,12 +44,16 @@ impl<
             error!("Failed to update consumer power capability: {:?}", e);
             return Err(PdError::Failed);
         }
-        if self
-            .power_policy_sender
-            .try_send(power_policy_interface::psu::event::EventData::UpdatedConsumerCapability(available_sink_contract))
-            .is_none()
+
+        if let Err(e) = self
+            .power_policy_notifier
+            .notify_updated_consumer_capability(available_sink_contract)
+            .await
         {
-            error!("Failed to send updated consumer capability event");
+            error!(
+                "({}): Failed to notify power policy of updated consumer capability: {:#?}",
+                self.name, e
+            );
         }
         Ok(())
     }
@@ -66,12 +70,16 @@ impl<
             error!("Failed to update requested provider power capability: {:?}", e);
             return Err(PdError::Failed);
         }
-        if self
-            .power_policy_sender
-            .try_send(power_policy_interface::psu::event::EventData::RequestedProviderCapability(capability))
-            .is_none()
+
+        if let Err(e) = self
+            .power_policy_notifier
+            .notify_requested_provider_capability(capability)
+            .await
         {
-            error!("Failed to send requested provider capability event");
+            error!(
+                "({}): Failed to notify power policy of requested provider capability: {:#?}",
+                self.name, e
+            );
         }
         Ok(())
     }
@@ -172,9 +180,9 @@ impl<
     C: Lockable<Inner: Pd>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> Psu for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> Psu for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn disconnect(&mut self) -> Result<(), PsuError> {
         self.controller
@@ -228,10 +236,10 @@ impl<
     C: Lockable<Inner: Pd + SystemPowerStateStatus>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
 > type_c_interface::port::power::SystemPowerStateStatus
-    for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+    for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn set_system_power_state_status(
         &mut self,

--- a/type-c-service/src/controller/retimer.rs
+++ b/type-c-service/src/controller/retimer.rs
@@ -12,9 +12,9 @@ impl<
     C: Lockable<Inner: Pd + Retimer>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> type_c_interface::port::retimer::Retimer for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> type_c_interface::port::retimer::Retimer for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn get_rt_fw_update_status(&mut self) -> Result<RetimerFwUpdateState, PdError> {
         self.controller.lock().await.get_rt_fw_update_status(self.port).await

--- a/type-c-service/src/controller/type_c.rs
+++ b/type-c-service/src/controller/type_c.rs
@@ -12,9 +12,10 @@ impl<
     C: Lockable<Inner: Pd + StateMachine>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> type_c_interface::port::type_c::StateMachine for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> type_c_interface::port::type_c::StateMachine
+    for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn set_type_c_state_machine_config(&mut self, state: TypeCStateMachineState) -> Result<(), PdError> {
         self.controller

--- a/type-c-service/src/controller/ucsi.rs
+++ b/type-c-service/src/controller/ucsi.rs
@@ -11,9 +11,9 @@ impl<
     C: Lockable<Inner: Pd + UcsiLpm>,
     Shared: Lockable<Inner = SharedState>,
     TypeCSender: NonBlockingSender<type_c_interface::service::event::PortEventData>,
-    PowerSender: NonBlockingSender<power_policy_interface::psu::event::EventData>,
+    PowerNotifier: power_policy_interface::psu::notification::Notifier,
     LoopbackSender: NonBlockingSender<event::Loopback>,
-> type_c_interface::ucsi::Lpm for Port<'device, C, Shared, TypeCSender, PowerSender, LoopbackSender>
+> type_c_interface::ucsi::Lpm for Port<'device, C, Shared, TypeCSender, PowerNotifier, LoopbackSender>
 {
     async fn execute_lpm_command(&mut self, command: lpm::LocalCommand) -> Result<Option<lpm::ResponseData>, PdError> {
         self.controller.lock().await.execute_lpm_command(command).await

--- a/type-c-service/tests/common/mod.rs
+++ b/type-c-service/tests/common/mod.rs
@@ -82,6 +82,12 @@ pub type PowerPolicyServiceSender<'port, 'ch> = PowerPolicyServiceEventRouter<'p
 /// Receiver for events broadcast by the power policy service
 pub type PowerPolicyServiceReceiver<'port, 'ch> =
     DynamicReceiver<'ch, power_policy_interface::service::event::Event<'port, PortMutexType<'port, 'ch>>>;
+/// Notifier for events broadcast by the power policy service
+type PowerPolicyNotifierType<'port, 'ch> = power_policy_interface::service::event::NonBlockingSenderNotifier<
+    'port,
+    PortMutexType<'port, 'ch>,
+    PowerPolicyServiceSender<'port, 'ch>,
+>;
 /// Power policy registration type
 pub type PowerPolicyRegistrationType<'port, 'ch> = power_policy_service::service::registration::ArrayRegistration<
     'port,
@@ -90,7 +96,7 @@ pub type PowerPolicyRegistrationType<'port, 'ch> = power_policy_service::service
     // PSU count
     TYPE_C_PORT_COUNT,
     // Senders for events broadcast by the service
-    PowerPolicyServiceSender<'port, 'ch>,
+    PowerPolicyNotifierType<'port, 'ch>,
     // Number of registered service event senders
     POWER_POLICY_SENDER_COUNT,
     // Charger type
@@ -389,7 +395,7 @@ pub async fn run_test(
         power_policy_service::service::registration::ArrayRegistration {
             psus: [&port0, &port1, &port2],
             chargers: [],
-            service_senders: [power_policy_service_event_router],
+            service_senders: [power_policy_service_event_router.into()],
         },
         Default::default(),
     ));

--- a/type-c-service/tests/common/mod.rs
+++ b/type-c-service/tests/common/mod.rs
@@ -39,6 +39,8 @@ pub type PortTypeCReceiver<'a> = DynamicReceiver<'a, type_c_interface::service::
 pub type PortPowerSender<'a> = DynamicSender<'a, power_policy_interface::psu::event::EventData>;
 /// Corresponding receiver for [`PortPowerSender`]
 pub type PortPowerReceiver<'a> = DynamicReceiver<'a, power_policy_interface::psu::event::EventData>;
+/// Power policy notification wrapper
+pub type PortPowerNotifier<'a> = power_policy_interface::psu::event::NonBlockingSenderNotifier<PortPowerSender<'a>>;
 /// [`type_c_service::controller::Port`] sender for loopback events
 pub type PortLoopbackSender<'a> = DynamicSender<'a, type_c_service::controller::event::Loopback>;
 /// Corresponding receiver for [`PortLoopbackSender`]
@@ -60,8 +62,8 @@ pub type PortMutexType<'port, 'ch> = Mutex<
         PortSharedState,
         // Sender to the type-C service
         PortTypeCSender<'ch>,
-        // Sender to the power policy
-        PortPowerSender<'ch>,
+        // Power policy notifier
+        PortPowerNotifier<'ch>,
         // Loopback sender
         PortLoopbackSender<'ch>,
     >,
@@ -215,7 +217,7 @@ macro_rules! define_port {
                     &paste! { [<$name _mock>] },
                     &paste! { [<$name _shared_state>] },
                     paste! { [<$name _type_c_sender>] },
-                    paste! { [<$name _power_policy_sender>] },
+                    paste! { [<$name _power_policy_sender>].into() },
                     paste! { [<$name _loopback_sender>] },
             )),
             mock: &paste! { [<$name _mock>] },

--- a/type-c-service/tests/common/mod.rs
+++ b/type-c-service/tests/common/mod.rs
@@ -395,7 +395,7 @@ pub async fn run_test(
         power_policy_service::service::registration::ArrayRegistration {
             psus: [&port0, &port1, &port2],
             chargers: [],
-            service_senders: [power_policy_service_event_router.into()],
+            service_notifiers: [power_policy_service_event_router.into()],
         },
         Default::default(),
     ));


### PR DESCRIPTION
Refactor the existing power policy PSU notification code to use generic notifier and handler traits instead of channel-based traits. Provide implementations of these traits for existing channel-based code.