### PR TITLE
type-c-service/max_sink_voltage: Port recovery logic from v1

### DIFF
--- a/type-c-service/src/controller/event.rs
+++ b/type-c-service/src/controller/event.rs
@@ -19,4 +19,6 @@ pub enum Event {
 pub enum Loopback {
     /// Port event
     PortEvent(PortEventBitfield),
+    /// Sink ready deadline invalidated
+    SinkReadyDeadlineInvalidated,
 }

--- a/type-c-service/src/controller/event_receiver.rs
+++ b/type-c-service/src/controller/event_receiver.rs
@@ -119,7 +119,7 @@ impl<
     ///
     /// Returns the local port ID and the event bitfield.
     pub async fn wait_event(&mut self) -> Event {
-        let timeout = self.shared_state.lock().await.sink_ready_timeout;
+        let timeout = self.shared_state.lock().await.sink_ready_deadline;
         match select(self.port_event_receiver.wait_next(), async move {
             if let Some(timeout) = timeout {
                 Timer::at(timeout).await;
@@ -133,7 +133,7 @@ impl<
             Either::Second(_) => {
                 let mut status_event = PortStatusEventBitfield::none();
                 status_event.set_sink_ready(true);
-                self.shared_state.lock().await.sink_ready_timeout = None;
+                self.shared_state.lock().await.sink_ready_deadline = None;
                 Event::PortEvent(PortEvent::StatusChanged(status_event))
             }
         }

--- a/type-c-service/src/controller/event_receiver.rs
+++ b/type-c-service/src/controller/event_receiver.rs
@@ -1,7 +1,7 @@
 //! This module contains event receiver types for the controller wrapper.
 use core::array;
 use core::future::pending;
-use embassy_futures::select::{Either, select};
+use embassy_futures::select::{Either3, select3};
 use embassy_time::Timer;
 use embedded_services::error;
 use embedded_services::event::{NonBlockingSender, Receiver};
@@ -40,49 +40,6 @@ impl<const N: usize, S: NonBlockingSender<PortEventBitfield>> PortEventSplitter<
     }
 }
 
-/// Struct to receive and stream port events from the controller.
-pub struct PortEventReceiver<R: Receiver<PortEventBitfield>, LoopbackReceiver: Receiver<Loopback>> {
-    /// Receiver for the controller's interrupt events
-    receiver: R,
-    /// Port event streaming state
-    streaming_state: Option<PortEventStreamer<array::IntoIter<PortEventBitfield, 1>>>,
-    /// Loopback receiver for software-generated events
-    loopback_receiver: LoopbackReceiver,
-}
-
-impl<R: Receiver<PortEventBitfield>, LoopbackReceiver: Receiver<Loopback>> PortEventReceiver<R, LoopbackReceiver> {
-    /// Create a new instance
-    pub fn new(receiver: R, loopback_receiver: LoopbackReceiver) -> Self {
-        Self {
-            receiver,
-            streaming_state: None,
-            loopback_receiver,
-        }
-    }
-
-    /// Wait for the next port event
-    pub async fn wait_next(&mut self) -> type_c_interface::port::event::PortEvent {
-        loop {
-            let streaming_state = if let Some(streaming_state) = &mut self.streaming_state {
-                // Yield to ensure we don't monopolize the executor
-                embassy_futures::yield_now().await;
-                streaming_state
-            } else {
-                let (Either::First(Loopback::PortEvent(events)) | Either::Second(events)) =
-                    select(self.loopback_receiver.wait_next(), self.receiver.wait_next()).await;
-                self.streaming_state
-                    .insert(PortEventStreamer::new([events].into_iter()))
-            };
-
-            if let Some((_, event)) = streaming_state.next() {
-                return event;
-            } else {
-                self.streaming_state = None;
-            }
-        }
-    }
-}
-
 /// Struct used for containing controller event receivers.
 pub struct EventReceiver<
     'a,
@@ -91,7 +48,11 @@ pub struct EventReceiver<
     LoopbackReceiver: Receiver<Loopback>,
 > {
     /// Port event receiver
-    port_event_receiver: PortEventReceiver<InterruptReceiver, LoopbackReceiver>,
+    port_event_receiver: InterruptReceiver,
+    /// Port event streaming state
+    streaming_state: Option<PortEventStreamer<array::IntoIter<PortEventBitfield, 1>>>,
+    /// Loopback event receiver
+    loopback_receiver: LoopbackReceiver,
     /// Shared state
     shared_state: &'a State,
 }
@@ -111,30 +72,62 @@ impl<
     ) -> Self {
         Self {
             shared_state,
-            port_event_receiver: PortEventReceiver::new(port_event_receiver, loopback_receiver),
+            port_event_receiver,
+            streaming_state: None,
+            loopback_receiver,
         }
     }
 
-    /// Wait for the next port event from any port.
-    ///
-    /// Returns the local port ID and the event bitfield.
+    /// Wait for the next port event from a single port.
     pub async fn wait_event(&mut self) -> Event {
-        let timeout = self.shared_state.lock().await.sink_ready_deadline;
-        match select(self.port_event_receiver.wait_next(), async move {
-            if let Some(timeout) = timeout {
-                Timer::at(timeout).await;
+        loop {
+            if let Some(streaming_state) = &mut self.streaming_state {
+                // If we have a streaming state, prioritize processing it before waiting for new events. This
+                // ensures that any pending events stay buffered in the receiver.
+
+                // Yield to ensure we don't monopolize the executor
+                embassy_futures::yield_now().await;
+
+                if let Some((_, event)) = streaming_state.next() {
+                    return Event::PortEvent(event);
+                }
+
+                // Done streaming, clear the state and continue to wait for new events.
+                self.streaming_state = None;
             } else {
-                pending::<()>().await;
-            }
-        })
-        .await
-        {
-            Either::First(event) => Event::PortEvent(event),
-            Either::Second(_) => {
-                let mut status_event = PortStatusEventBitfield::none();
-                status_event.set_sink_ready(true);
-                self.shared_state.lock().await.sink_ready_deadline = None;
-                Event::PortEvent(PortEvent::StatusChanged(status_event))
+                let timeout = self.shared_state.lock().await.sink_ready_deadline;
+                match select3(
+                    self.port_event_receiver.wait_next(),
+                    async move {
+                        if let Some(timeout) = timeout {
+                            Timer::at(timeout).await;
+                        } else {
+                            pending::<()>().await;
+                        }
+                    },
+                    self.loopback_receiver.wait_next(),
+                )
+                .await
+                {
+                    Either3::First(events) => {
+                        self.streaming_state = Some(PortEventStreamer::new([events].into_iter()));
+                    }
+                    Either3::Second(_) => {
+                        let mut status_event = PortStatusEventBitfield::none();
+                        status_event.set_sink_ready(true);
+                        self.shared_state.lock().await.sink_ready_deadline = None;
+                        return Event::PortEvent(PortEvent::StatusChanged(status_event));
+                    }
+                    Either3::Third(event) => match event {
+                        Loopback::PortEvent(events) => {
+                            self.streaming_state = Some(PortEventStreamer::new([events].into_iter()));
+                            // Continue, the next iteration will handle streaming the port events.
+                        }
+                        Loopback::SinkReadyDeadlineInvalidated => {
+                            // Continue, the next iteration will wait for the update sink ready deadline.
+                        }
+                    },
+                }
             }
         }
     }

--- a/type-c-service/src/controller/macros.rs
+++ b/type-c-service/src/controller/macros.rs
@@ -8,7 +8,7 @@ use crate::controller::{event_receiver::EventReceiver, state};
 
 pub const DEFAULT_POWER_POLICY_CHANNEL_SIZE: usize = 2;
 pub const DEFAULT_TYPE_C_CHANNEL_SIZE: usize = 2;
-pub const DEFAULT_LOOPBACK_CHANNEL_SIZE: usize = 1;
+pub const DEFAULT_LOOPBACK_CHANNEL_SIZE: usize = 4;
 pub const DEFAULT_INTERRUPT_CHANNEL_SIZE: usize = 4;
 
 /// Components returned from port creation

--- a/type-c-service/src/controller/max_sink_voltage.rs
+++ b/type-c-service/src/controller/max_sink_voltage.rs
@@ -1,4 +1,5 @@
 //! Max sink voltage port trait implementation
+use embassy_time::Instant;
 use embedded_services::{event::NonBlockingSender, sync::Lockable};
 use embedded_usb_pd::PdError;
 use power_policy_interface::capability::ConsumerDisconnect;
@@ -34,6 +35,18 @@ impl<
         if disable_sink_path {
             debug!("({}): Disabling sink path before max sink voltage change", self.name);
             self.controller.lock().await.enable_sink_path(self.port, false).await?;
+
+            // In general it's not possible to know if setting the max sink voltage will trigger a renegotiation
+            // because the logic to select a particular contract is specific to the PD controller.
+            // Enable the sink ready timeout as a recovery mechanism. If there's no renegotiation, then the timeout
+            // will result in us broadcasting the existing contract back to the power policy.
+            {
+                let mut shared_state = self.shared_state.lock().await;
+                if shared_state.sink_ready_deadline.is_none() {
+                    shared_state.sink_ready_deadline =
+                        Some(Instant::now() + Self::check_sink_ready_timeout_duration(self.status.epr));
+                }
+            }
 
             // Move our local state out of the consumer state and notify the power policy so it stops
             // tracking us as the active consumer and broadcasts a ConsumerDisconnected event. The

--- a/type-c-service/src/controller/max_sink_voltage.rs
+++ b/type-c-service/src/controller/max_sink_voltage.rs
@@ -46,6 +46,17 @@ impl<
                     shared_state.sink_ready_deadline =
                         Some(Instant::now() + Self::check_sink_ready_timeout_duration(self.status.epr));
                 }
+
+                if self
+                    .loopback_sender
+                    .try_send(event::Loopback::SinkReadyDeadlineInvalidated)
+                    .is_none()
+                {
+                    error!(
+                        "({}): Failed to send SinkReadyDeadlineInvalidated loopback event, channel full",
+                        self.name
+                    );
+                }
             }
 
             // Move our local state out of the consumer state and notify the power policy so it stops

--- a/type-c-service/src/controller/power.rs
+++ b/type-c-service/src/controller/power.rs
@@ -132,6 +132,20 @@ impl<
         Ok(())
     }
 
+    /// Returns the timeout duration for the sink ready check.
+    pub(super) fn check_sink_ready_timeout_duration(is_epr: bool) -> Duration {
+        Duration::from_millis(
+            (if is_epr {
+                T_PS_TRANSITION_EPR_MS
+            } else {
+                T_PS_TRANSITION_SPR_MS
+            }
+            .maximum
+            .0 * 2)
+                .into(),
+        )
+    }
+
     /// Check the sink ready timeout
     ///
     /// After accepting a sink contract (new contract as consumer), the PD spec guarantees that the
@@ -145,32 +159,26 @@ impl<
     ) -> Result<(), PdError> {
         let contract_changed = self.status.available_sink_contract != new_status.available_sink_contract;
         let mut shared_state = self.shared_state.lock().await;
-        let timeout = &mut shared_state.sink_ready_timeout;
+        let deadline = &mut shared_state.sink_ready_deadline;
 
         // Don't start the timeout if the sink has signaled it's ready or if the contract didn't change.
         // The latter ensures that soft resets won't continually reset the ready timeout
         debug!(
             "({}): Check sink ready: new_contract={:?}, sink_ready={:?}, contract_changed={:?}, deadline={:?}",
-            self.name, new_contract, sink_ready, contract_changed, timeout,
+            self.name, new_contract, sink_ready, contract_changed, deadline,
         );
         if new_contract && !sink_ready && contract_changed {
             // Start the timeout
             // Double the spec maximum transition time to provide a safety margin for hardware/controller delays or out-of-spec controllers.
-            let timeout_ms = if new_status.epr {
-                T_PS_TRANSITION_EPR_MS
-            } else {
-                T_PS_TRANSITION_SPR_MS
-            }
-            .maximum
-            .0 * 2;
+            let timeout = Self::check_sink_ready_timeout_duration(new_status.epr);
 
-            debug!("({}): Sink ready timeout started for {}ms", self.name, timeout_ms);
-            *timeout = Some(Instant::now() + Duration::from_millis(timeout_ms as u64));
-        } else if timeout.is_some()
+            debug!("({}): Sink ready timeout started for {}ms", self.name, timeout);
+            *deadline = Some(Instant::now() + timeout);
+        } else if deadline.is_some()
             && (!new_status.is_connected() || new_status.available_sink_contract.is_none() || sink_ready)
         {
             debug!("({}): Sink ready timeout cleared", self.name);
-            *timeout = None;
+            *deadline = None;
         }
         Ok(())
     }

--- a/type-c-service/src/controller/state.rs
+++ b/type-c-service/src/controller/state.rs
@@ -3,21 +3,21 @@ use embassy_time::Instant;
 /// State shared between the port and event receiver
 #[derive(Copy, Clone)]
 pub struct SharedState {
-    /// Sink ready timeout
-    pub(crate) sink_ready_timeout: Option<Instant>,
+    /// Sink ready deadline
+    pub(crate) sink_ready_deadline: Option<Instant>,
 }
 
 impl SharedState {
     /// Create a new instance with default values
     pub fn new() -> Self {
         Self {
-            sink_ready_timeout: None,
+            sink_ready_deadline: None,
         }
     }
 
-    /// Get the current sink ready timeout deadline, if one is pending
-    pub fn sink_ready_timeout(&self) -> Option<Instant> {
-        self.sink_ready_timeout
+    /// Get the current sink ready deadline, if one is pending
+    pub fn sink_ready_deadline(&self) -> Option<Instant> {
+        self.sink_ready_deadline
     }
 }
 

--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -4,6 +4,7 @@ use std::ptr;
 
 use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, TimeoutError, with_timeout};
+use embedded_services::info;
 use embedded_usb_pd::{
     PowerRole,
     constants::{T_PS_TRANSITION_EPR_MS, T_PS_TRANSITION_SPR_MS},
@@ -312,9 +313,11 @@ impl Test for TestConsumerFlowTimerSinkReady {
             mock0.next_result_enable_sink_path.push_back(Ok(()));
         }
 
+        info!("Starting test: consumer flow with software sink-ready timeout");
         // Initially detached with no pending sink-ready timeout.
         assert_eq!(port.lock().await.state().psu_state, PsuState::Detached);
         assert!(shared_state.lock().await.sink_ready_deadline().is_none());
+        info!("Starting test: consumer flow with software sink-ready timeout");
 
         let start = Instant::now();
 
@@ -322,11 +325,14 @@ impl Test for TestConsumerFlowTimerSinkReady {
         let mut interrupt = PortEventBitfield::none();
         interrupt.status.set_plug_inserted_or_removed(true);
         interrupt.status.set_new_power_contract_as_consumer(true);
+        info!("Sending plug interrupt to port");
         interrupt_sender.send(interrupt).await;
 
         // Drive the receiver manually so the intermediate state is observable before the timer
         // fires. This first event is the plug interrupt that was just sent.
+        info!("Waiting for first event from event receiver");
         let event = event_receiver.wait_event().await;
+        info!("Received first event from event receiver: {:?}", event);
         port.lock().await.process_event(event).await.unwrap();
 
         // The port is attached but not consuming yet, the sink-ready timeout is armed, and no
@@ -517,6 +523,94 @@ impl Test for TestSinkDisableOnVoltageChange {
     }
 }
 
+/// Ensures that the sink ready deadline is invalidated when the max sink voltage is changed, which
+/// allows the event receiver to pick up on the new sink ready deadline.
+struct TestSetMaxVoltageSinkReadyDeadlineInvalidation;
+
+impl Test for TestSetMaxVoltageSinkReadyDeadlineInvalidation {
+    async fn run<'port, 'ch>(
+        &mut self,
+        type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        _port1: TestPort<'port, 'ch>,
+        _port2: TestPort<'port, 'ch>,
+    ) {
+        let TestPort {
+            port,
+            mock,
+            mut event_receiver,
+            ..
+        } = port0;
+
+        {
+            // Set up the mock to report a sink connection and allow enabling the sink path
+            let mut mock = mock.lock().await;
+
+            mock.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_sink_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Sink,
+                ..Default::default()
+            }));
+            mock.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        // Simulate a plug event and a new consumer contract
+        let mut port_event = PortStatusEventBitfield::none();
+        port_event.set_plug_inserted_or_removed(true);
+        port_event.set_new_power_contract_as_consumer(true);
+        port_event.set_sink_ready(true);
+
+        port.lock()
+            .await
+            .process_event(Event::PortEvent(PortEvent::StatusChanged(port_event)))
+            .await
+            .unwrap();
+
+        let (type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+
+        // Power policy service should broadcast a consumer connected event
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ConsumerConnected(psu, capability)) => {
+                assert_eq!(
+                    capability,
+                    ConsumerPowerCapability {
+                        capability: POWER_CAPABILITY_5V_1A5,
+                        flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
+                    }
+                );
+                assert!(ptr::eq(psu, port));
+            }
+            _ => panic!("Did not receive consumer connected event"),
+        }
+        // Shouldn't get any Type-C service events in this flow
+        assert_eq!(type_c_result.err(), Some(TimeoutError));
+
+        {
+            // Set up the mock to accept a max sink voltage change and disable the sink path
+            let mut mock = mock.lock().await;
+
+            mock.next_result_set_max_sink_voltage.push_back(Ok(()));
+            mock.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        // Ensure that the sink ready deadline is invalidated when the max sink voltage is changed.
+        // This join will timeout otherwise
+        let (event, set_max_sink_voltage_result) = join(event_receiver.wait_event(), async {
+            port.lock().await.set_max_sink_voltage(None).await
+        })
+        .await;
+
+        set_max_sink_voltage_result.unwrap();
+        assert!(matches!(event, Event::PortEvent(_)));
+    }
+}
+
 /// It's not possible to know if setting the max sink voltage will trigger a renegotiation
 /// because the logic to select a particular contract is specific to the PD controller.
 /// This test ensures that the sink path is disabled and the power policy is notified regardless of whether a renegotiation occurs.
@@ -579,7 +673,7 @@ impl Test for TestSetMaxSinkVoltageRecovery {
                         flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
                     }
                 );
-                assert!(ptr::eq(psu, port0.port));
+                assert!(ptr::eq(psu, port));
             }
             _ => panic!("Did not receive consumer connected event"),
         }
@@ -606,7 +700,7 @@ impl Test for TestSetMaxSinkVoltageRecovery {
         match power_policy_result {
             Ok(PowerPolicyEvent::ConsumerDisconnected(psu, flags)) => {
                 assert_eq!(flags, ConsumerDisconnect::none().with_renegotiation(true));
-                assert!(ptr::eq(psu, port0.port));
+                assert!(ptr::eq(psu, port));
             }
             _ => panic!("Did not receive consumer disconnected event"),
         }
@@ -652,7 +746,7 @@ impl Test for TestSetMaxSinkVoltageRecovery {
                         flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
                     }
                 );
-                assert!(ptr::eq(psu, port0.port));
+                assert!(ptr::eq(psu, port));
             }
             _ => panic!("Did not receive consumer connected event"),
         }
@@ -1006,6 +1100,17 @@ async fn test_set_max_sink_voltage_recovery() {
         Default::default(),
         Default::default(),
         TestSetMaxSinkVoltageRecovery,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_set_max_voltage_sink_ready_deadline_invalidation() {
+    common::run_test(
+        DEFAULT_TEST_DURATION,
+        Default::default(),
+        Default::default(),
+        TestSetMaxVoltageSinkReadyDeadlineInvalidation,
     )
     .await;
 }

--- a/type-c-service/tests/power.rs
+++ b/type-c-service/tests/power.rs
@@ -4,7 +4,11 @@ use std::ptr;
 
 use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, TimeoutError, with_timeout};
-use embedded_usb_pd::{PowerRole, constants::T_PS_TRANSITION_SPR_MS, type_c::ConnectionState};
+use embedded_usb_pd::{
+    PowerRole,
+    constants::{T_PS_TRANSITION_EPR_MS, T_PS_TRANSITION_SPR_MS},
+    type_c::ConnectionState,
+};
 use power_policy_interface::{
     capability::{
         ConsumerDisconnect, ConsumerFlags, ConsumerPowerCapability, ProviderFlags, ProviderPowerCapability, PsuType,
@@ -310,7 +314,7 @@ impl Test for TestConsumerFlowTimerSinkReady {
 
         // Initially detached with no pending sink-ready timeout.
         assert_eq!(port.lock().await.state().psu_state, PsuState::Detached);
-        assert!(shared_state.lock().await.sink_ready_timeout().is_none());
+        assert!(shared_state.lock().await.sink_ready_deadline().is_none());
 
         let start = Instant::now();
 
@@ -328,7 +332,7 @@ impl Test for TestConsumerFlowTimerSinkReady {
         // The port is attached but not consuming yet, the sink-ready timeout is armed, and no
         // consumer connection has been broadcast to the power policy.
         assert_eq!(port.lock().await.state().psu_state, PsuState::Idle);
-        assert!(shared_state.lock().await.sink_ready_timeout().is_some());
+        assert!(shared_state.lock().await.sink_ready_deadline().is_some());
         assert!(power_policy_receiver.try_receive().is_err());
 
         // The next event is synthesized *inside* `wait_event` by a real timer; nothing in this test
@@ -348,7 +352,7 @@ impl Test for TestConsumerFlowTimerSinkReady {
         // The timer cleared the sink-ready timeout when it synthesized the sink-ready event. The
         // port is not a connected consumer yet: it has only forwarded the updated consumer
         // capability to the power policy, which still has to connect it.
-        assert!(shared_state.lock().await.sink_ready_timeout().is_none());
+        assert!(shared_state.lock().await.sink_ready_deadline().is_none());
 
         // The power policy should now broadcast a consumer connect event.
         match with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()).await {
@@ -390,7 +394,7 @@ impl Test for TestConsumerFlowTimerSinkReady {
 
         // Back to detached with no pending sink-ready timeout.
         assert_eq!(port.lock().await.state().psu_state, PsuState::Detached);
-        assert!(shared_state.lock().await.sink_ready_timeout().is_none());
+        assert!(shared_state.lock().await.sink_ready_deadline().is_none());
     }
 }
 
@@ -510,6 +514,150 @@ impl Test for TestSinkDisableOnVoltageChange {
             );
             assert!(mock0.fn_calls.is_empty());
         }
+    }
+}
+
+/// It's not possible to know if setting the max sink voltage will trigger a renegotiation
+/// because the logic to select a particular contract is specific to the PD controller.
+/// This test ensures that the sink path is disabled and the power policy is notified regardless of whether a renegotiation occurs.
+struct TestSetMaxSinkVoltageRecovery;
+
+impl Test for TestSetMaxSinkVoltageRecovery {
+    async fn run<'port, 'ch>(
+        &mut self,
+        type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        _port1: TestPort<'port, 'ch>,
+        _port2: TestPort<'port, 'ch>,
+    ) {
+        let TestPort {
+            port,
+            mock,
+            mut event_receiver,
+            ..
+        } = port0;
+
+        {
+            // Set up the mock to report a sink connection and allow enabling the sink path
+            let mut mock = mock.lock().await;
+
+            mock.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_sink_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Sink,
+                ..Default::default()
+            }));
+            mock.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        // Simulate a plug event and a new consumer contract
+        let mut port_event = PortStatusEventBitfield::none();
+        port_event.set_plug_inserted_or_removed(true);
+        port_event.set_new_power_contract_as_consumer(true);
+        port_event.set_sink_ready(true);
+
+        port.lock()
+            .await
+            .process_event(Event::PortEvent(PortEvent::StatusChanged(port_event)))
+            .await
+            .unwrap();
+
+        let (type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+
+        // Power policy service should broadcast a consumer connected event
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ConsumerConnected(psu, capability)) => {
+                assert_eq!(
+                    capability,
+                    ConsumerPowerCapability {
+                        capability: POWER_CAPABILITY_5V_1A5,
+                        flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
+                    }
+                );
+                assert!(ptr::eq(psu, port0.port));
+            }
+            _ => panic!("Did not receive consumer connected event"),
+        }
+        // Shouldn't get any Type-C service events in this flow
+        assert_eq!(type_c_result.err(), Some(TimeoutError));
+
+        {
+            // Set up the mock to accept a max sink voltage change and disable the sink path
+            let mut mock = mock.lock().await;
+
+            mock.next_result_set_max_sink_voltage.push_back(Ok(()));
+            mock.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        port.lock().await.set_max_sink_voltage(None).await.unwrap();
+
+        let (type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+
+        // Power policy service should broadcast a consumer disconnected event
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ConsumerDisconnected(psu, flags)) => {
+                assert_eq!(flags, ConsumerDisconnect::none().with_renegotiation(true));
+                assert!(ptr::eq(psu, port0.port));
+            }
+            _ => panic!("Did not receive consumer disconnected event"),
+        }
+        // Shouldn't get any Type-C service events in this flow
+        assert_eq!(type_c_result.err(), Some(TimeoutError));
+
+        {
+            // Setup the mock to return the existing contract and enable the sink path again
+            let mut mock = mock.lock().await;
+
+            mock.next_result_get_port_status.push_back(Ok(PortStatus {
+                available_sink_contract: Some(POWER_CAPABILITY_5V_1A5),
+                connection_state: Some(ConnectionState::Attached),
+                power_role: PowerRole::Sink,
+                ..Default::default()
+            }));
+            mock.next_result_enable_sink_path.push_back(Ok(()));
+        }
+
+        // Wait for sink ready recovery, x3 just to be safe and ensure the deadline has passed.
+        let event = with_timeout(
+            Duration::from_millis(T_PS_TRANSITION_EPR_MS.maximum.0 as u64 * 3),
+            event_receiver.wait_event(),
+        )
+        .await
+        .unwrap();
+
+        port.lock().await.process_event(event).await.unwrap();
+
+        let (type_c_result, power_policy_result) = join(
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, type_c_receiver.receive()),
+            with_timeout(DEFAULT_PER_CALL_TIMEOUT, power_policy_receiver.receive()),
+        )
+        .await;
+
+        // Power policy service should broadcast a consumer connected event
+        match power_policy_result {
+            Ok(PowerPolicyEvent::ConsumerConnected(psu, capability)) => {
+                assert_eq!(
+                    capability,
+                    ConsumerPowerCapability {
+                        capability: POWER_CAPABILITY_5V_1A5,
+                        flags: ConsumerFlags::none().with_psu_type(PsuType::TypeC),
+                    }
+                );
+                assert!(ptr::eq(psu, port0.port));
+            }
+            _ => panic!("Did not receive consumer connected event"),
+        }
+        // Shouldn't get any Type-C service events in this flow
+        assert_eq!(type_c_result.err(), Some(TimeoutError));
     }
 }
 
@@ -847,6 +995,17 @@ async fn test_sink_disable_on_voltage_change() {
         Default::default(),
         Default::default(),
         TestSinkDisableOnVoltageChange,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_set_max_sink_voltage_recovery() {
+    common::run_test(
+        DEFAULT_TEST_DURATION,
+        Default::default(),
+        Default::default(),
+        TestSetMaxSinkVoltageRecovery,
     )
     .await;
 }


### PR DESCRIPTION
Pull in the recovery logic from v1 and add test coverage.