### PR TITLE
Update toolchain to keep compatibility with rust-analyzer

### DIFF
--- a/examples/rt633/rust-toolchain.toml
+++ b/examples/rt633/rust-toolchain.toml
@@ -1,3 +1,9 @@
 [toolchain]
-targets = [ "thumbv8m.main-none-eabihf" ]
-components = [ "rust-src", "rustfmt", "llvm-tools-preview", "clippy" ]
+targets = ["thumbv8m.main-none-eabihf"]
+components = [
+    "rust-src",
+    "rustfmt",
+    "llvm-tools-preview",
+    "clippy",
+    "rust-analyzer",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,10 @@
 [toolchain]
-channel = "1.93"
+channel = "1.97"
 targets = ["thumbv8m.main-none-eabihf"]
-components = ["rust-src", "rustfmt", "llvm-tools-preview", "clippy"]
+components = [
+    "rust-src",
+    "rustfmt",
+    "llvm-tools-preview",
+    "clippy",
+    "rust-analyzer",
+]


### PR DESCRIPTION
The rust-analyzer compatible with the latest vscode is incompatible with 1.93, so bump the workspace toolchain to the latest version (1.97) to resolve this.

This only applies to the workspace toolchain; not bumping the project's rust-version so our downstream dependents shouldn't be impacted / forced to upgrade.