### PR TITLE
power-policy-service: Introduce `DisconnectReason` enum

### DIFF
--- a/embedded-service/src/power/policy/action/device.rs
+++ b/embedded-service/src/power/policy/action/device.rs
@@ -55,7 +55,7 @@ impl<'a, S: Kind> Device<'a, S> {
     }
 
     /// Disconnect this device
-    async fn disconnect_internal(&self, flags: flags::ConsumerDisconnect) -> Result<(), Error> {
+    async fn disconnect_internal(&self, flags: flags::Disconnect) -> Result<(), Error> {
         info!("Device {} disconnecting", self.device.id().0);
         self.device.update_consumer_capability(None).await;
         self.device.update_requested_provider_capability(None).await;
@@ -136,7 +136,7 @@ impl Device<'_, Idle> {
 
 impl<'a> Device<'a, ConnectedConsumer> {
     /// Disconnect this device
-    pub async fn disconnect(self, flags: flags::ConsumerDisconnect) -> Result<Device<'a, Idle>, Error> {
+    pub async fn disconnect(self, flags: flags::Disconnect) -> Result<Device<'a, Idle>, Error> {
         self.disconnect_internal(flags).await?;
         Ok(Device::new(self.device))
     }
@@ -152,7 +152,7 @@ impl<'a> Device<'a, ConnectedConsumer> {
 
 impl<'a> Device<'a, ConnectedProvider> {
     /// Disconnect this device
-    pub async fn disconnect(self, flags: flags::ConsumerDisconnect) -> Result<Device<'a, Idle>, Error> {
+    pub async fn disconnect(self, flags: flags::Disconnect) -> Result<Device<'a, Idle>, Error> {
         self.disconnect_internal(flags).await?;
         Ok(Device::new(self.device))
     }

--- a/embedded-service/src/power/policy/flags.rs
+++ b/embedded-service/src/power/policy/flags.rs
@@ -131,63 +131,73 @@ bitfield! {
     /// Flags for disconnect events
     #[derive(Copy, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    struct ConsumerDisconnectRaw(u32);
+    struct DisconnectRaw(u32);
     impl Debug;
-    /// Renegotiation
-    ///
-    /// When set this flag indicates that the current consumer is attempting to negotiate a new power capability.
-    pub bool, renegotiation, set_renegotiation: 0;
-    /// Switching
-    ///
-    /// When set this flag indicates that the service is switching to a different PSU.
-    pub bool, switching, set_switching: 1;
+    /// Disconnect reason
+    pub u8, reason, set_reason: 3, 0;
 }
 
-/// Type safe wrapper for consumer disconnect flags
+/// Disconnect reason
+#[derive(Copy, Clone, Debug, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[num_enum(error_type(name = InvalidDisconnectReason, constructor = InvalidDisconnectReason))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum DisconnectReason {
+    /// Unknown/Unspecified
+    Unknown,
+    /// Switching to a different PSU
+    Switching,
+    /// Renegotiation triggered by device
+    AutoRenegotiation,
+    /// Renegotiation triggered by code
+    ManualRenegotiation,
+}
+
+impl DisconnectReason {
+    /// Check if the reason is a renegotiation
+    pub fn is_renegotiation(&self) -> bool {
+        matches!(
+            self,
+            DisconnectReason::AutoRenegotiation | DisconnectReason::ManualRenegotiation
+        )
+    }
+}
+
+/// Conversion error for [`PsuType`]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ConsumerDisconnect(ConsumerDisconnectRaw);
+pub struct InvalidDisconnectReason(pub u8);
 
-impl ConsumerDisconnect {
-    /// Create new consumer disconnect flags with no flags set
+/// Type safe wrapper for disconnect flags
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Disconnect(DisconnectRaw);
+
+impl Disconnect {
+    /// Create new disconnect flags with no flags set
     pub const fn none() -> Self {
-        Self(ConsumerDisconnectRaw(0))
+        Self(DisconnectRaw(0))
     }
 
-    /// Builder method to set the renegotiation flag
-    pub fn with_renegotiation(mut self, value: bool) -> Self {
-        self.set_renegotiation(value);
+    /// Builder method to set the disconnect reason
+    pub fn with_reason(mut self, reason: DisconnectReason) -> Self {
+        self.set_reason(reason);
         self
     }
 
-    /// Set the value of the renegotiation flag
-    pub fn set_renegotiation(&mut self, value: bool) {
-        self.0.set_renegotiation(value);
+    /// Set the disconnect reason
+    pub fn set_reason(&mut self, reason: DisconnectReason) {
+        self.0.set_reason(reason.into());
     }
 
-    /// Get the value of the renegotiation flag
-    pub fn renegotiation(&self) -> bool {
-        self.0.renegotiation()
-    }
-
-    /// Builder method to set the switching flag
-    pub fn with_switching(mut self, value: bool) -> Self {
-        self.set_switching(value);
-        self
-    }
-
-    /// Set the value of the switching flag
-    pub fn set_switching(&mut self, value: bool) {
-        self.0.set_switching(value);
-    }
-
-    /// Get the value of the switching flag
-    pub fn switching(&self) -> bool {
-        self.0.switching()
+    /// Get the disconnect reason
+    pub fn reason(&self) -> DisconnectReason {
+        DisconnectReason::try_from(self.0.reason()).unwrap_or(DisconnectReason::Unknown)
     }
 }
 
-impl Default for ConsumerDisconnect {
+impl Default for Disconnect {
     fn default() -> Self {
         Self::none()
     }
@@ -224,6 +234,31 @@ mod tests {
     }
 
     #[test]
+    fn test_disconnect_reason_conversion() {
+        // Test valid conversions
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::Unknown)),
+            Ok(DisconnectReason::Unknown)
+        );
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::Switching)),
+            Ok(DisconnectReason::Switching)
+        );
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::AutoRenegotiation)),
+            Ok(DisconnectReason::AutoRenegotiation)
+        );
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::ManualRenegotiation)),
+            Ok(DisconnectReason::ManualRenegotiation)
+        );
+
+        for i in 4..=255 {
+            assert_eq!(DisconnectReason::try_from(i), Err(InvalidDisconnectReason(i)));
+        }
+    }
+
+    #[test]
     fn test_consumer_unconstrained() {
         let mut consumer = Consumer::none().with_unconstrained_power();
         assert_eq!(consumer.0.0, 0x1);
@@ -248,18 +283,26 @@ mod tests {
     }
 
     #[test]
-    fn test_consumer_disconnect_renegotiation() {
-        let mut disconnect = ConsumerDisconnect::none().with_renegotiation(true);
-        assert_eq!(disconnect.0.0, 0x1);
-        disconnect.set_renegotiation(false);
+    fn test_consumer_disconnect_manual_renegotiation() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::ManualRenegotiation);
+        assert_eq!(disconnect.0.0, 0x3);
+        disconnect.set_reason(DisconnectReason::Unknown);
+        assert_eq!(disconnect.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_consumer_disconnect_auto_renegotiation() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::AutoRenegotiation);
+        assert_eq!(disconnect.0.0, 0x2);
+        disconnect.set_reason(DisconnectReason::Unknown);
         assert_eq!(disconnect.0.0, 0x0);
     }
 
     #[test]
     fn test_consumer_disconnect_switching() {
-        let mut disconnect = ConsumerDisconnect::none().with_switching(true);
-        assert_eq!(disconnect.0.0, 0x2);
-        disconnect.set_switching(false);
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::Switching);
+        assert_eq!(disconnect.0.0, 0x1);
+        disconnect.set_reason(DisconnectReason::Unknown);
         assert_eq!(disconnect.0.0, 0x0);
     }
 }

--- a/embedded-service/src/power/policy/flags.rs
+++ b/embedded-service/src/power/policy/flags.rs
@@ -144,14 +144,20 @@ bitfield! {
 #[repr(u8)]
 #[non_exhaustive]
 pub enum DisconnectReason {
-    /// Unknown/Unspecified
-    Unknown,
+    /// The device is no longer capable of providing or consuming power, no further information is available
+    NoLongerCapable,
+    /// The device has been physically detached
+    Detached,
     /// Switching to a different PSU
     Switching,
     /// Renegotiation triggered by device
     AutoRenegotiation,
     /// Renegotiation triggered by code
     ManualRenegotiation,
+    /// The device has changed its role
+    RoleSwap,
+    /// The device experienced a reset
+    Reset,
 }
 
 impl DisconnectReason {
@@ -193,7 +199,7 @@ impl Disconnect {
 
     /// Get the disconnect reason
     pub fn reason(&self) -> DisconnectReason {
-        DisconnectReason::try_from(self.0.reason()).unwrap_or(DisconnectReason::Unknown)
+        DisconnectReason::try_from(self.0.reason()).unwrap_or(DisconnectReason::NoLongerCapable)
     }
 }
 
@@ -237,8 +243,12 @@ mod tests {
     fn test_disconnect_reason_conversion() {
         // Test valid conversions
         assert_eq!(
-            DisconnectReason::try_from(u8::from(DisconnectReason::Unknown)),
-            Ok(DisconnectReason::Unknown)
+            DisconnectReason::try_from(u8::from(DisconnectReason::NoLongerCapable)),
+            Ok(DisconnectReason::NoLongerCapable)
+        );
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::Detached)),
+            Ok(DisconnectReason::Detached)
         );
         assert_eq!(
             DisconnectReason::try_from(u8::from(DisconnectReason::Switching)),
@@ -252,8 +262,16 @@ mod tests {
             DisconnectReason::try_from(u8::from(DisconnectReason::ManualRenegotiation)),
             Ok(DisconnectReason::ManualRenegotiation)
         );
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::RoleSwap)),
+            Ok(DisconnectReason::RoleSwap)
+        );
+        assert_eq!(
+            DisconnectReason::try_from(u8::from(DisconnectReason::Reset)),
+            Ok(DisconnectReason::Reset)
+        );
 
-        for i in 4..=255 {
+        for i in 7..=255 {
             assert_eq!(DisconnectReason::try_from(i), Err(InvalidDisconnectReason(i)));
         }
     }
@@ -283,26 +301,56 @@ mod tests {
     }
 
     #[test]
-    fn test_consumer_disconnect_manual_renegotiation() {
-        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::ManualRenegotiation);
-        assert_eq!(disconnect.0.0, 0x3);
-        disconnect.set_reason(DisconnectReason::Unknown);
+    fn test_disconnect_no_longer_capable() {
+        let disconnect = Disconnect::none().with_reason(DisconnectReason::NoLongerCapable);
         assert_eq!(disconnect.0.0, 0x0);
     }
 
     #[test]
-    fn test_consumer_disconnect_auto_renegotiation() {
-        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::AutoRenegotiation);
-        assert_eq!(disconnect.0.0, 0x2);
-        disconnect.set_reason(DisconnectReason::Unknown);
-        assert_eq!(disconnect.0.0, 0x0);
-    }
-
-    #[test]
-    fn test_consumer_disconnect_switching() {
-        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::Switching);
+    fn test_disconnect_detached() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::Detached);
         assert_eq!(disconnect.0.0, 0x1);
-        disconnect.set_reason(DisconnectReason::Unknown);
+        disconnect.set_reason(DisconnectReason::NoLongerCapable);
+        assert_eq!(disconnect.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_disconnect_switching() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::Switching);
+        assert_eq!(disconnect.0.0, 0x2);
+        disconnect.set_reason(DisconnectReason::NoLongerCapable);
+        assert_eq!(disconnect.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_disconnect_auto_renegotiation() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::AutoRenegotiation);
+        assert_eq!(disconnect.0.0, 0x3);
+        disconnect.set_reason(DisconnectReason::NoLongerCapable);
+        assert_eq!(disconnect.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_disconnect_manual_renegotiation() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::ManualRenegotiation);
+        assert_eq!(disconnect.0.0, 0x4);
+        disconnect.set_reason(DisconnectReason::NoLongerCapable);
+        assert_eq!(disconnect.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_disconnect_role_swap() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::RoleSwap);
+        assert_eq!(disconnect.0.0, 0x5);
+        disconnect.set_reason(DisconnectReason::NoLongerCapable);
+        assert_eq!(disconnect.0.0, 0x0);
+    }
+
+    #[test]
+    fn test_disconnect_reset() {
+        let mut disconnect = Disconnect::none().with_reason(DisconnectReason::Reset);
+        assert_eq!(disconnect.0.0, 0x6);
+        disconnect.set_reason(DisconnectReason::NoLongerCapable);
         assert_eq!(disconnect.0.0, 0x0);
     }
 }

--- a/embedded-service/src/power/policy/flags.rs
+++ b/embedded-service/src/power/policy/flags.rs
@@ -170,7 +170,7 @@ impl DisconnectReason {
     }
 }
 
-/// Conversion error for [`PsuType`]
+/// Conversion error for [`DisconnectReason`]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InvalidDisconnectReason(pub u8);

--- a/embedded-service/src/power/policy/mod.rs
+++ b/embedded-service/src/power/policy/mod.rs
@@ -142,7 +142,7 @@ impl UnconstrainedState {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CommsData {
     /// Consumer disconnected
-    ConsumerDisconnected(DeviceId, flags::ConsumerDisconnect),
+    ConsumerDisconnected(DeviceId, flags::Disconnect),
     /// Consumer connected
     ConsumerConnected(DeviceId, ConsumerPowerCapability),
     /// Provider disconnected

--- a/embedded-service/src/power/policy/policy.rs
+++ b/embedded-service/src/power/policy/policy.rs
@@ -26,7 +26,7 @@ pub enum RequestData {
     /// Request the given amount of power to provider
     RequestProviderCapability(ProviderPowerCapability),
     /// Notify that a device cannot consume or provide power anymore
-    NotifyDisconnect(flags::ConsumerDisconnect),
+    NotifyDisconnect(flags::Disconnect),
     /// Notify that a device has detached
     NotifyDetached,
 }

--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -277,7 +277,10 @@ impl PowerPolicy {
             if let Some(consumer_state) = state.current_consumer_state {
                 self.disconnect_chargers().await?;
                 self.comms_notify(CommsMessage {
-                    data: CommsData::ConsumerDisconnected(consumer_state.device_id, Disconnect::default()),
+                    data: CommsData::ConsumerDisconnected(
+                        consumer_state.device_id,
+                        Disconnect::default().with_reason(DisconnectReason::Detached),
+                    ),
                 })
                 .await;
             }

--- a/power-policy-service/src/consumer.rs
+++ b/power-policy-service/src/consumer.rs
@@ -2,6 +2,8 @@ use core::cmp::Ordering;
 use embedded_services::debug;
 use embedded_services::power::policy::charger::Device as ChargerDevice;
 use embedded_services::power::policy::charger::PolicyEvent;
+use embedded_services::power::policy::flags::Disconnect;
+use embedded_services::power::policy::flags::DisconnectReason;
 use embedded_services::power::policy::policy::check_chargers_ready;
 use embedded_services::power::policy::policy::init_chargers;
 
@@ -188,9 +190,9 @@ impl PowerPolicy {
     ) -> Result<(), Error> {
         // Handle our current consumer
         if let Some(current_consumer) = state.current_consumer_state {
-            if new_consumer.device_id == current_consumer.device_id
-                && new_consumer.consumer_power_capability == current_consumer.consumer_power_capability
-            {
+            let is_same_psu = new_consumer.device_id == current_consumer.device_id;
+
+            if is_same_psu && new_consumer.consumer_power_capability == current_consumer.consumer_power_capability {
                 // If the consumer is the same device, capability, and is still available, we don't need to do anything
                 info!("Best consumer is the same, not switching");
                 return Ok(());
@@ -220,7 +222,11 @@ impl PowerPolicy {
             self.comms_notify(CommsMessage {
                 data: CommsData::ConsumerDisconnected(
                     current_consumer.device_id,
-                    flags::ConsumerDisconnect::default().with_switching(true),
+                    if is_same_psu {
+                        Disconnect::default().with_reason(DisconnectReason::AutoRenegotiation)
+                    } else {
+                        Disconnect::default().with_reason(DisconnectReason::Switching)
+                    },
                 ),
             })
             .await;
@@ -271,10 +277,7 @@ impl PowerPolicy {
             if let Some(consumer_state) = state.current_consumer_state {
                 self.disconnect_chargers().await?;
                 self.comms_notify(CommsMessage {
-                    data: CommsData::ConsumerDisconnected(
-                        consumer_state.device_id,
-                        flags::ConsumerDisconnect::default(),
-                    ),
+                    data: CommsData::ConsumerDisconnected(consumer_state.device_id, Disconnect::default()),
                 })
                 .await;
             }

--- a/power-policy-service/src/lib.rs
+++ b/power-policy-service/src/lib.rs
@@ -77,11 +77,7 @@ impl PowerPolicy {
         Ok(())
     }
 
-    async fn process_notify_disconnect(
-        &self,
-        device: &device::Device,
-        flags: flags::ConsumerDisconnect,
-    ) -> Result<(), Error> {
+    async fn process_notify_disconnect(&self, device: &device::Device, flags: flags::Disconnect) -> Result<(), Error> {
         self.context.send_response(Ok(policy::ResponseData::Complete)).await;
 
         self.remove_connected_provider(device.id()).await;

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -29,6 +29,7 @@ use embassy_time::Instant;
 use embedded_cfu_protocol::protocol_definitions::{FwUpdateOffer, FwUpdateOfferResponse, FwVersion};
 use embedded_services::GlobalRawMutex;
 use embedded_services::power::policy::device::StateKind;
+use embedded_services::power::policy::flags::DisconnectReason;
 use embedded_services::power::policy::{self, action, flags};
 use embedded_services::sync::Lockable;
 use embedded_services::type_c::controller::{self, Controller, PortStatus};
@@ -267,7 +268,10 @@ where
                     ),
                     _ => {}
                 }
-                if let Err(e) = connected_consumer.disconnect(flags::Disconnect::default()).await {
+                if let Err(e) = connected_consumer
+                    .disconnect(flags::Disconnect::default().with_reason(DisconnectReason::Reset))
+                    .await
+                {
                     error!(
                         "Port{}: Error disconnecting from ConnectedConsumer after PD hard reset: {:#?}",
                         global_port_id.0, e
@@ -275,7 +279,10 @@ where
                 }
             } else if let Ok(connected_provider) = power.try_device_action::<action::ConnectedProvider>().await {
                 info!("Port{}: Disconnecting provider after hard reset", global_port_id.0);
-                if let Err(e) = connected_provider.disconnect(flags::Disconnect::default()).await {
+                if let Err(e) = connected_provider
+                    .disconnect(flags::Disconnect::default().with_reason(DisconnectReason::Reset))
+                    .await
+                {
                     error!(
                         "Port{}: Error disconnecting from ConnectedProvider after PD hard reset: {:#?}",
                         global_port_id.0, e

--- a/type-c-service/src/wrapper/mod.rs
+++ b/type-c-service/src/wrapper/mod.rs
@@ -267,10 +267,7 @@ where
                     ),
                     _ => {}
                 }
-                if let Err(e) = connected_consumer
-                    .disconnect(flags::ConsumerDisconnect::default())
-                    .await
-                {
+                if let Err(e) = connected_consumer.disconnect(flags::Disconnect::default()).await {
                     error!(
                         "Port{}: Error disconnecting from ConnectedConsumer after PD hard reset: {:#?}",
                         global_port_id.0, e
@@ -278,10 +275,7 @@ where
                 }
             } else if let Ok(connected_provider) = power.try_device_action::<action::ConnectedProvider>().await {
                 info!("Port{}: Disconnecting provider after hard reset", global_port_id.0);
-                if let Err(e) = connected_provider
-                    .disconnect(flags::ConsumerDisconnect::default())
-                    .await
-                {
+                if let Err(e) = connected_provider.disconnect(flags::Disconnect::default()).await {
                     error!(
                         "Port{}: Error disconnecting from ConnectedProvider after PD hard reset: {:#?}",
                         global_port_id.0, e

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -2,6 +2,7 @@ use embassy_futures::yield_now;
 use embassy_sync::pubsub::WaitResult;
 use embassy_time::{Duration, Timer};
 use embedded_services::debug;
+use embedded_services::power::policy::flags::{Disconnect, DisconnectReason};
 use embedded_services::type_c::Cached;
 use embedded_services::type_c::controller::{InternalResponseData, Response};
 use embedded_usb_pd::constants::{T_PS_TRANSITION_EPR_MS, T_PS_TRANSITION_SPR_MS};
@@ -192,7 +193,7 @@ where
                 }
 
                 let _ = connected_consumer
-                    .disconnect(flags::ConsumerDisconnect::default().with_renegotiation(true))
+                    .disconnect(Disconnect::default().with_reason(DisconnectReason::ManualRenegotiation))
                     .await;
             }
         }

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -77,7 +77,10 @@ where
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
             // Transition from provider to consumer.
             // This handles role swaps from source to sink.
-            let Ok(state) = state.disconnect(flags::Disconnect::default()).await else {
+            let Ok(state) = state
+                .disconnect(flags::Disconnect::default().with_reason(DisconnectReason::RoleSwap))
+                .await
+            else {
                 error!("Error disconnecting as provider");
                 return PdError::Failed.into();
             };
@@ -151,7 +154,10 @@ where
                 }
             } else {
                 // No longer need to source, so disconnect
-                if let Err(e) = state.disconnect(flags::Disconnect::default()).await {
+                if let Err(e) = state
+                    .disconnect(flags::Disconnect::default().with_reason(DisconnectReason::RoleSwap))
+                    .await
+                {
                     error!("Error disconnecting as provider: {:?}", e);
                     return PdError::Failed.into();
                 }

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -77,7 +77,7 @@ where
         } else if let Ok(state) = power.try_device_action::<action::ConnectedProvider>().await {
             // Transition from provider to consumer.
             // This handles role swaps from source to sink.
-            let Ok(state) = state.disconnect(flags::ConsumerDisconnect::default()).await else {
+            let Ok(state) = state.disconnect(flags::Disconnect::default()).await else {
                 error!("Error disconnecting as provider");
                 return PdError::Failed.into();
             };
@@ -151,7 +151,7 @@ where
                 }
             } else {
                 // No longer need to source, so disconnect
-                if let Err(e) = state.disconnect(flags::ConsumerDisconnect::default()).await {
+                if let Err(e) = state.disconnect(flags::Disconnect::default()).await {
                     error!("Error disconnecting as provider: {:?}", e);
                     return PdError::Failed.into();
                 }
@@ -159,7 +159,7 @@ where
         } else if let Ok(state) = power.try_device_action::<action::ConnectedConsumer>().await {
             // Transition from consumer to provider.
             // This handles role swaps from sink to source.
-            let Ok(state) = state.disconnect(flags::ConsumerDisconnect::default()).await else {
+            let Ok(state) = state.disconnect(flags::Disconnect::default()).await else {
                 error!("Error disconnecting as consumer");
                 return PdError::Failed.into();
             };


### PR DESCRIPTION
Combine existing disconnect reasons into this enum and distinguishbetween renegotiation types. Also rename `ConsumerDisconnect` to `Disconnect` since this type is already used for provider disconnect flags as well.