### PR TITLE
type-c-service/tps6699x: Fix EPR capable flag not being set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.1#b9c9ca3b87fb5c0a505071ecd26e0e63b0cddb51"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.0#0c2f495621faf48f4042012e0fb5c1cfc9b29320"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.1#95d54c3caf36ab30fa093b1f9bef236e9829c060"
 dependencies = [
  "bincode",
  "bitfield 0.19.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-services = { path = "./embedded-service" }
 embedded-storage-async = "0.4.1"
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.1", default-features = false }
 mctp-rs = { git = "https://github.com/OpenDevicePartnership/mctp-rs", tag = "v0.1.0" }
 num_enum = { version = "0.7.5", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
@@ -79,6 +79,6 @@ serde = { version = "1.0.*", default-features = false }
 static_cell = "2.1.0"
 toml = { version = "0.8", default-features = false }
 syn = "2.0"
-tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v0.1.0" }
+tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v0.1.1" }
 tokio = { version = "1.42.0" }
 uuid = { version = "=1.17.0", default-features = false }

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -42,8 +42,12 @@ pub struct PortStatus {
     pub plug_orientation: PlugOrientation,
     /// power role
     pub power_role: PowerRole,
+    /// Port partner supports dual-data roles
+    pub dual_data: bool,
     /// data role
     pub data_role: DataRole,
+    /// Port partner is USB comms capable
+    pub usb_comms_capable: bool,
     /// Active alt-modes
     pub alt_mode: AltMode,
     /// Power path status
@@ -65,7 +69,9 @@ impl PortStatus {
             dual_power: false,
             plug_orientation: PlugOrientation::CC1,
             power_role: PowerRole::Sink,
+            dual_data: false,
             data_role: DataRole::Dfp,
+            usb_comms_capable: false,
             alt_mode: AltMode::none(),
             power_path: PowerPathStatus::none(),
             epr: false,

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -48,7 +48,7 @@ pub struct PortStatus {
     pub alt_mode: AltMode,
     /// Power path status
     pub power_path: PowerPathStatus,
-    /// EPR mode active
+    /// Port partner is EPR capable
     pub epr: bool,
     /// Port partner is unconstrained
     pub unconstrained_power: bool,

--- a/embedded-service/src/type_c/controller.rs
+++ b/embedded-service/src/type_c/controller.rs
@@ -5,9 +5,11 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use embassy_sync::signal::Signal;
 use embassy_time::{Duration, with_timeout};
+use embedded_usb_pd::pdo::sink::FrsRequiredCurrent;
 use embedded_usb_pd::ucsi::{self, lpm};
+use embedded_usb_pd::{DataRole, PlugOrientation, PowerRole, pdo};
 use embedded_usb_pd::{
-    DataRole, Error, GlobalPortId, LocalPortId, PdError, PlugOrientation, PowerRole,
+    Error, GlobalPortId, LocalPortId, PdError,
     ado::Ado,
     pdinfo::{AltMode, PowerPathStatus},
     type_c::ConnectionState,
@@ -26,36 +28,151 @@ use crate::{GlobalRawMutex, IntrusiveNode, broadcaster::immediate as broadcaster
 /// maximum number of data objects in a VDM
 pub const MAX_NUM_DATA_OBJECTS: usize = 7; // 7 VDOs of 4 bytes each
 
+/// Information about the negotiated source contract from PD
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PdSourceInfo {
+    /// Received 5V sink PDO data from port partner
+    ///
+    /// Contains various flags that aren't present in other PDOs
+    pub rx_fixed_5v_data: pdo::sink::FixedData,
+    /// PDO associated with this contract
+    pub pdo: pdo::source::Pdo,
+    /// RDO associated with this contract
+    pub rdo: pdo::Rdo,
+}
+
+/// Source contract
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SourceContract {
+    /// Power capability
+    pub capability: policy::PowerCapability,
+    /// PD contract information, if any
+    pub pd: Option<PdSourceInfo>,
+}
+
+impl SourceContract {
+    /// Returns true if the port partner has dual role power capability
+    pub fn dual_role_power(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.dual_role_power).unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has higher capability
+    pub fn higher_capability(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.higher_capability).unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has unconstrained power
+    pub fn unconstrained_power(&self) -> bool {
+        self.pd
+            .map(|pd| pd.rx_fixed_5v_data.unconstrained_power)
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the port partner is USB comms capable
+    pub fn usb_comms_capable(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.usb_comms_capable).unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has dual role data capability
+    pub fn dual_role_data(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.dual_role_data).unwrap_or(false)
+    }
+
+    /// Returns required FRS current for the port partner, if supported
+    pub fn frs_required_current(&self) -> Option<FrsRequiredCurrent> {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.frs_required_current)
+    }
+}
+
+/// Information about the negotiated sink contract from PD
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PdSinkInfo {
+    /// Received 5V source PDO data from port partner
+    ///
+    /// Contains various flags that aren't present in other PDOs
+    pub rx_fixed_5v_data: pdo::source::FixedData,
+    /// PDO associated with this contract
+    pub pdo: pdo::sink::Pdo,
+    /// PDO associated with this contract
+    pub rdo: pdo::Rdo,
+}
+
+/// Sink contract
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SinkContract {
+    /// Power capability
+    pub capability: policy::PowerCapability,
+    /// PD contract information, if any
+    pub pd: Option<PdSinkInfo>,
+}
+
+impl SinkContract {
+    /// Returns true if the port partner has dual role power capability
+    pub fn dual_role_power(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.dual_role_power).unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has USB suspend supported
+    pub fn usb_suspend_supported(&self) -> bool {
+        self.pd
+            .map(|pd| pd.rx_fixed_5v_data.usb_suspend_supported)
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has unconstrained power
+    pub fn unconstrained_power(&self) -> bool {
+        self.pd
+            .map(|pd| pd.rx_fixed_5v_data.unconstrained_power)
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the port partner is USB comms capable
+    pub fn usb_comms_capable(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.usb_comms_capable).unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has dual role data capability
+    pub fn dual_role_data(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.dual_role_data).unwrap_or(false)
+    }
+
+    /// Returns true if the port partner has unchunked extended messages support
+    pub fn unchunked_extended_messages_support(&self) -> bool {
+        self.pd
+            .map(|pd| pd.rx_fixed_5v_data.unchunked_extended_messages_support)
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the port partner is EPR capable
+    pub fn epr_capable(&self) -> bool {
+        self.pd.map(|pd| pd.rx_fixed_5v_data.epr_capable).unwrap_or(false)
+    }
+}
+
 /// Port status
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PortStatus {
     /// Current available source contract
-    pub available_source_contract: Option<policy::PowerCapability>,
+    pub available_source_contract: Option<SourceContract>,
     /// Current available sink contract
-    pub available_sink_contract: Option<policy::PowerCapability>,
+    pub available_sink_contract: Option<SinkContract>,
     /// Current connection state
     pub connection_state: Option<ConnectionState>,
-    /// Port partner supports dual-power roles
-    pub dual_power: bool,
     /// plug orientation
     pub plug_orientation: PlugOrientation,
     /// power role
     pub power_role: PowerRole,
-    /// Port partner supports dual-data roles
-    pub dual_data: bool,
     /// data role
     pub data_role: DataRole,
-    /// Port partner is USB comms capable
-    pub usb_comms_capable: bool,
     /// Active alt-modes
     pub alt_mode: AltMode,
     /// Power path status
     pub power_path: PowerPathStatus,
-    /// Port partner is EPR capable
-    pub epr: bool,
-    /// Port partner is unconstrained
-    pub unconstrained_power: bool,
 }
 
 impl PortStatus {
@@ -66,16 +183,11 @@ impl PortStatus {
             available_source_contract: None,
             available_sink_contract: None,
             connection_state: None,
-            dual_power: false,
             plug_orientation: PlugOrientation::CC1,
             power_role: PowerRole::Sink,
-            dual_data: false,
             data_role: DataRole::Dfp,
-            usb_comms_capable: false,
             alt_mode: AltMode::none(),
             power_path: PowerPathStatus::none(),
-            epr: false,
-            unconstrained_power: false,
         }
     }
 

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.1#b9c9ca3b87fb5c0a505071ecd26e0e63b0cddb51"
 dependencies = [
  "aquamarine",
  "bincode",

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.1#b9c9ca3b87fb5c0a505071ecd26e0e63b0cddb51"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.0#0c2f495621faf48f4042012e0fb5c1cfc9b29320"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.1#95d54c3caf36ab30fa093b1f9bef236e9829c060"
 dependencies = [
  "bincode",
  "bitfield 0.19.2",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -56,11 +56,11 @@ power-button-service = { path = "../../power-button-service", features = [
 power-policy-service = { path = "../../power-policy-service", features = [
     "defmt",
 ] }
-tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v0.1.0", features = [
+tps6699x = { git = "https://github.com/OpenDevicePartnership/tps6699x", tag = "v0.1.1", features = [
     "defmt",
     "embassy",
 ] }
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false, features = [
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.1", default-features = false, features = [
     "defmt",
 ] }
 type-c-service = { path = "../../type-c-service", features = ["defmt"] }

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.1#b9c9ca3b87fb5c0a505071ecd26e0e63b0cddb51"
 dependencies = [
  "aquamarine",
  "bincode",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "tps6699x"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.0#0c2f495621faf48f4042012e0fb5c1cfc9b29320"
+source = "git+https://github.com/OpenDevicePartnership/tps6699x?tag=v0.1.1#95d54c3caf36ab30fa093b1f9bef236e9829c060"
 dependencies = [
  "bincode",
  "bitfield 0.19.2",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -25,7 +25,7 @@ embassy-executor = { version = "0.10.0", features = [
 
 defmt = "0.3"
 
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0" }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.1" }
 embedded-services = { path = "../../embedded-service", features = ["log"] }
 cfu-service = { path = "../../cfu-service", features = ["log"] }
 embedded-cfu-protocol = { git = "https://github.com/OpenDevicePartnership/embedded-cfu", tag = "v0.1.0" }

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -6,14 +6,14 @@ use embedded_services::{
     power::policy::PowerCapability,
     type_c::{
         controller::{
-            AttnVdm, ControllerStatus, DiscoveredSvids, DpConfig, DpPinConfig, DpStatus, OtherVdm,
-            PdStateMachineConfig, PortStatus, RetimerFwUpdateState, SendVdm, SystemPowerState, TbtConfig,
-            TypeCStateMachineState, UsbControlConfig,
+            AttnVdm, ControllerStatus, DiscoveredSvids, DpConfig, DpPinConfig, DpStatus, OtherVdm, PdSinkInfo,
+            PdSourceInfo, PdStateMachineConfig, PortStatus, RetimerFwUpdateState, SendVdm, SinkContract,
+            SourceContract, SystemPowerState, TbtConfig, TypeCStateMachineState, UsbControlConfig,
         },
         event::PortEvent,
     },
 };
-use embedded_usb_pd::{Error, ado::Ado};
+use embedded_usb_pd::{Error, ado::Ado, pdo};
 use embedded_usb_pd::{LocalPortId, PdError};
 use embedded_usb_pd::{PowerRole, type_c::Current};
 use embedded_usb_pd::{type_c::ConnectionState, ucsi::lpm};
@@ -45,12 +45,50 @@ impl ControllerState {
         });
         match role {
             PowerRole::Source => {
-                status.available_source_contract = Some(capability);
-                status.unconstrained_power = unconstrained;
+                status.available_source_contract = Some(SourceContract {
+                    capability,
+                    pd: Some(PdSourceInfo {
+                        pdo: pdo::source::Pdo::Fixed(pdo::source::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            current_ma: capability.current_ma,
+                            unconstrained_power: unconstrained,
+                            ..Default::default()
+                        }),
+                        rdo: pdo::Rdo::Fixed(pdo::rdo::FixedVarData {
+                            operating_current_ma: capability.current_ma,
+                            max_operating_current_ma: capability.current_ma,
+                            ..Default::default()
+                        }),
+                        rx_fixed_5v_data: pdo::sink::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            operational_current_ma: capability.current_ma,
+                            ..Default::default()
+                        },
+                    }),
+                });
             }
             PowerRole::Sink => {
-                status.available_sink_contract = Some(capability);
-                status.unconstrained_power = unconstrained;
+                status.available_sink_contract = Some(SinkContract {
+                    capability,
+                    pd: Some(PdSinkInfo {
+                        pdo: pdo::sink::Pdo::Fixed(pdo::sink::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            operational_current_ma: capability.current_ma,
+                            ..Default::default()
+                        }),
+                        rdo: pdo::Rdo::Fixed(pdo::rdo::FixedVarData {
+                            operating_current_ma: capability.current_ma,
+                            max_operating_current_ma: capability.current_ma,
+                            ..Default::default()
+                        }),
+                        rx_fixed_5v_data: pdo::source::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            current_ma: capability.current_ma,
+                            unconstrained_power: unconstrained,
+                            ..Default::default()
+                        },
+                    }),
+                });
             }
         }
         *self.status.lock().await = status;

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -366,7 +366,19 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
                         return Err(PdError::InvalidParams.into());
                     }
 
-                    let source::Pdo::Fixed(fixed_source_pdo) = source_pdos[0] else {
+                    let source::Pdo::Fixed(source::FixedData {
+                        dual_role_power,
+                        unconstrained_power,
+                        epr_capable,
+                        usb_comms_capable,
+                        dual_role_data,
+                        usb_suspend_supported: _,
+                        unchunked_extended_messages_support: _,
+                        peak_current: _,
+                        voltage_mv: _,
+                        current_ma: _,
+                    }) = source_pdos[0]
+                    else {
                         error!("Port{}: First rx source PDO is not fixed", port.0);
                         return Err(PdError::InvalidParams.into());
                     };
@@ -376,9 +388,11 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
                     debug!("PDO: {:#?}", pdo);
                     debug!("RDO: {:#?}", rdo);
                     port_status.available_sink_contract = Contract::from_sink(pdo, rdo).try_into().ok();
-                    port_status.dual_power = fixed_source_pdo.dual_role_power;
-                    port_status.unconstrained_power = fixed_source_pdo.unconstrained_power;
-                    port_status.epr = fixed_source_pdo.epr_capable;
+                    port_status.dual_power = dual_role_power;
+                    port_status.dual_data = dual_role_data;
+                    port_status.unconstrained_power = unconstrained_power;
+                    port_status.epr = epr_capable;
+                    port_status.usb_comms_capable = usb_comms_capable;
                 }
             } else if status.port_role() {
                 // port_role is true for source

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -366,13 +366,19 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
                         return Err(PdError::InvalidParams.into());
                     }
 
+                    let source::Pdo::Fixed(fixed_source_pdo) = source_pdos[0] else {
+                        error!("Port{}: First rx source PDO is not fixed", port.0);
+                        return Err(PdError::InvalidParams.into());
+                    };
+
                     let pdo = sink::Pdo::try_from(pdo_raw).map_err(|_| Error::from(PdError::InvalidParams))?;
                     let rdo = Rdo::for_pdo(rdo_raw, pdo).ok_or(Error::Pd(PdError::InvalidParams))?;
                     debug!("PDO: {:#?}", pdo);
                     debug!("RDO: {:#?}", rdo);
                     port_status.available_sink_contract = Contract::from_sink(pdo, rdo).try_into().ok();
-                    port_status.dual_power = source_pdos[0].dual_role_power();
-                    port_status.unconstrained_power = source_pdos[0].unconstrained_power();
+                    port_status.dual_power = fixed_source_pdo.dual_role_power;
+                    port_status.unconstrained_power = fixed_source_pdo.unconstrained_power;
+                    port_status.epr = fixed_source_pdo.epr_capable;
                 }
             } else if status.port_role() {
                 // port_role is true for source

--- a/type-c-service/src/driver/tps6699x.rs
+++ b/type-c-service/src/driver/tps6699x.rs
@@ -13,14 +13,14 @@ use embedded_hal_async::i2c::I2c;
 use embedded_services::power::policy::PowerCapability;
 use embedded_services::type_c::ATTN_VDM_LEN;
 use embedded_services::type_c::controller::{
-    self, AttnVdm, Controller, ControllerStatus, DiscoveredSvids, DpPinConfig, OtherVdm, PortStatus, SendVdm,
-    TbtConfig, TypeCStateMachineState, UsbControlConfig,
+    self, AttnVdm, Controller, ControllerStatus, DiscoveredSvids, DpPinConfig, OtherVdm, PdSinkInfo, PdSourceInfo,
+    PortStatus, SendVdm, SinkContract, SourceContract, TbtConfig, TypeCStateMachineState, UsbControlConfig,
 };
 use embedded_services::type_c::event::PortEvent;
 use embedded_services::{debug, error, trace, type_c, warn};
 use embedded_usb_pd::ado::Ado;
 use embedded_usb_pd::pdinfo::PowerPathStatus;
-use embedded_usb_pd::pdo::{Common, Contract, Rdo, sink, source};
+use embedded_usb_pd::pdo::{Contract, Rdo, sink, source};
 use embedded_usb_pd::type_c::Current as TypecCurrent;
 use embedded_usb_pd::ucsi::lpm;
 use embedded_usb_pd::{DataRole, Error, LocalPortId, PdError, PlugOrientation, PowerRole};
@@ -343,12 +343,43 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
             if pdo_raw != 0 && rdo_raw != 0 {
                 // Got a valid explicit contract
                 if pd_status.is_source() {
+                    // active_rdo_contract doesn't contain the full picture
+                    let mut sink_pdos: [sink::Pdo; 1] = [sink::Pdo::default()];
+                    // Read 5V fixed supply sink PDO, guaranteed to be present as the first SPR PDO
+                    let (num_sprs, _) = self
+                        .tps6699x
+                        .lock_inner()
+                        .await
+                        .get_rx_snk_caps(port, &mut sink_pdos[..], &mut [])
+                        .await?;
+
+                    if num_sprs == 0 {
+                        // USB PD spec requires at least one sink PDO be present, something is really wrong
+                        error!("Port{} no source PDOs found", port.0);
+                        return Err(PdError::InvalidParams.into());
+                    }
+
+                    let sink::Pdo::Fixed(rx_fixed_5v_data) = sink_pdos[0] else {
+                        error!("Port{}: First rx sink PDO is not fixed", port.0);
+                        return Err(PdError::InvalidParams.into());
+                    };
+
                     let pdo = source::Pdo::try_from(pdo_raw).map_err(|_| Error::from(PdError::InvalidParams))?;
                     let rdo = Rdo::for_pdo(rdo_raw, pdo).ok_or(Error::Pd(PdError::InvalidParams))?;
                     debug!("PDO: {:#?}", pdo);
                     debug!("RDO: {:#?}", rdo);
-                    port_status.available_source_contract = Contract::from_source(pdo, rdo).try_into().ok();
-                    port_status.dual_power = pdo.dual_role_power();
+                    port_status.available_source_contract =
+                        Contract::from_source(pdo, rdo)
+                            .try_into()
+                            .ok()
+                            .map(|capability| SourceContract {
+                                capability,
+                                pd: Some(PdSourceInfo {
+                                    rx_fixed_5v_data,
+                                    pdo,
+                                    rdo,
+                                }),
+                            });
                 } else {
                     // active_rdo_contract doesn't contain the full picture
                     let mut source_pdos: [source::Pdo; 1] = [source::Pdo::default()];
@@ -366,19 +397,7 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
                         return Err(PdError::InvalidParams.into());
                     }
 
-                    let source::Pdo::Fixed(source::FixedData {
-                        dual_role_power,
-                        unconstrained_power,
-                        epr_capable,
-                        usb_comms_capable,
-                        dual_role_data,
-                        usb_suspend_supported: _,
-                        unchunked_extended_messages_support: _,
-                        peak_current: _,
-                        voltage_mv: _,
-                        current_ma: _,
-                    }) = source_pdos[0]
-                    else {
+                    let source::Pdo::Fixed(rx_fixed_5v_data) = source_pdos[0] else {
                         error!("Port{}: First rx source PDO is not fixed", port.0);
                         return Err(PdError::InvalidParams.into());
                     };
@@ -387,20 +406,28 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
                     let rdo = Rdo::for_pdo(rdo_raw, pdo).ok_or(Error::Pd(PdError::InvalidParams))?;
                     debug!("PDO: {:#?}", pdo);
                     debug!("RDO: {:#?}", rdo);
-                    port_status.available_sink_contract = Contract::from_sink(pdo, rdo).try_into().ok();
-                    port_status.dual_power = dual_role_power;
-                    port_status.dual_data = dual_role_data;
-                    port_status.unconstrained_power = unconstrained_power;
-                    port_status.epr = epr_capable;
-                    port_status.usb_comms_capable = usb_comms_capable;
+                    port_status.available_sink_contract =
+                        Contract::from_sink(pdo, rdo)
+                            .try_into()
+                            .ok()
+                            .map(|capability| SinkContract {
+                                capability,
+                                pd: Some(PdSinkInfo {
+                                    rx_fixed_5v_data,
+                                    pdo,
+                                    rdo,
+                                }),
+                            });
                 }
             } else if status.port_role() {
                 // port_role is true for source
                 // Implicit source contract
                 let current = TypecCurrent::try_from(port_control.typec_current()).map_err(Error::Pd)?;
                 debug!("Port{} type-C source current: {:#?}", port.0, current);
-                let new_contract = Some(PowerCapability::from(current));
-                port_status.available_source_contract = new_contract;
+                port_status.available_source_contract = Some(SourceContract {
+                    capability: PowerCapability::from(current),
+                    pd: None,
+                });
             } else {
                 // Implicit sink contract
                 let pull = pd_status.cc_pull_up();
@@ -413,7 +440,8 @@ impl<M: RawMutex, B: I2c> Controller for Tps6699x<'_, M, B> {
                     debug!("Port{} type-C sink current: {:#?}", port.0, current);
                     Some(PowerCapability::from(current))
                 };
-                port_status.available_sink_contract = new_contract;
+                port_status.available_sink_contract =
+                    new_contract.map(|capability| SinkContract { capability, pd: None });
             }
 
             port_status.plug_orientation = if status.plug_orientation() {

--- a/type-c-service/src/service/power.rs
+++ b/type-c-service/src/service/power.rs
@@ -58,11 +58,12 @@ impl<'a> Service<'a> {
             } else {
                 // Only one unconstrained device is present, see if that's one of our ports
                 let num_ports = self.context.get_num_ports();
-                let unconstrained_port = state
-                    .port_status
-                    .iter()
-                    .take(num_ports)
-                    .position(|status| status.available_sink_contract.is_some() && status.unconstrained_power);
+                let unconstrained_port = state.port_status.iter().take(num_ports).position(|status| {
+                    status
+                        .available_sink_contract
+                        .map(|sink_contract| sink_contract.unconstrained_power())
+                        .unwrap_or(false)
+                });
 
                 if let Some(unconstrained_index) = unconstrained_port {
                     // One of our ports is the unconstrained consumer

--- a/type-c-service/src/service/ucsi.rs
+++ b/type-c-service/src/service/ucsi.rs
@@ -79,7 +79,7 @@ impl<'a> Service<'a> {
                 // when new type-C PSUs are attached
                 let power_mw = port_status
                     .available_sink_contract
-                    .map(|contract| contract.max_power_mw())
+                    .map(|contract| contract.capability.max_power_mw())
                     .unwrap_or(0);
 
                 Some(self.config.ucsi_battery_charging_config.status_of(power_mw))

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -89,7 +89,12 @@ where
         if new_contract && !sink_ready && contract_changed {
             // Start the timeout
             // Double the spec maximum transition time to provide a safety margin for hardware/controller delays or out-of-spec controllers.
-            let timeout = Self::check_sink_ready_timeout_duration(status.epr);
+            let timeout = Self::check_sink_ready_timeout_duration(
+                status
+                    .available_sink_contract
+                    .map(|sink_contract| sink_contract.epr_capable())
+                    .unwrap_or(false),
+            );
             debug!("Port{}: Sink ready timeout started for {:?}", port.0, timeout);
             *deadline = Some(Instant::now() + timeout);
         } else if deadline.is_some()
@@ -188,8 +193,16 @@ where
                 // Enable the sink ready timeout as a recovery mechanism. If there's no renegotiation, then the timeout
                 // will result in us broadcasting the existing contract back to the power policy.
                 if port_state.sink_ready_deadline.is_none() {
-                    port_state.sink_ready_deadline =
-                        Some(Instant::now() + Self::check_sink_ready_timeout_duration(port_state.status.epr));
+                    port_state.sink_ready_deadline = Some(
+                        Instant::now()
+                            + Self::check_sink_ready_timeout_duration(
+                                port_state
+                                    .status
+                                    .available_sink_contract
+                                    .map(|c| c.epr_capable())
+                                    .unwrap_or(false),
+                            ),
+                    );
                 }
 
                 let _ = connected_consumer

--- a/type-c-service/src/wrapper/pd.rs
+++ b/type-c-service/src/wrapper/pd.rs
@@ -42,9 +42,9 @@ where
     }
 
     /// Returns the timeout duration for the sink ready check.
-    fn check_sink_ready_timeout_duration(is_epr: bool) -> Duration {
+    fn check_sink_ready_timeout_duration(epr_capable: bool) -> Duration {
         Duration::from_millis(
-            (if is_epr {
+            (if epr_capable {
                 T_PS_TRANSITION_EPR_MS
             } else {
                 T_PS_TRANSITION_SPR_MS

--- a/type-c-service/src/wrapper/power.rs
+++ b/type-c-service/src/wrapper/power.rs
@@ -40,10 +40,10 @@ where
             return Ok(());
         }
 
-        let available_sink_contract = status.available_sink_contract.map(|c| {
-            let mut c: ConsumerPowerCapability = c.into();
+        let available_sink_contract = status.available_sink_contract.map(|contract| {
+            let mut c: ConsumerPowerCapability = contract.capability.into();
             let unconstrained = match self.config.unconstrained_sink {
-                UnconstrainedSink::Auto => status.unconstrained_power,
+                UnconstrainedSink::Auto => contract.unconstrained_power(),
                 UnconstrainedSink::PowerThresholdMilliwatts(threshold) => c.capability.max_power_mw() >= threshold,
                 UnconstrainedSink::Never => false,
             };
@@ -109,7 +109,7 @@ where
         info!("current power state: {:?}", current_state);
 
         let contract = status.available_source_contract.map(|c| {
-            let mut c: ProviderPowerCapability = c.into();
+            let mut c: ProviderPowerCapability = c.capability.into();
             c.flags.set_psu_type(PsuType::TypeC);
             c
         });

--- a/type-c-service/tests/common/mock.rs
+++ b/type-c-service/tests/common/mock.rs
@@ -10,13 +10,14 @@ use embedded_services::{
     power::policy::PowerCapability,
     type_c::{
         controller::{
-            AttnVdm, ControllerStatus, DiscoveredSvids, DpConfig, DpStatus, OtherVdm, PdStateMachineConfig, PortStatus,
-            RetimerFwUpdateState, SendVdm, SystemPowerState, TbtConfig, TypeCStateMachineState, UsbControlConfig,
+            AttnVdm, ControllerStatus, DiscoveredSvids, DpConfig, DpStatus, OtherVdm, PdSinkInfo, PdSourceInfo,
+            PdStateMachineConfig, PortStatus, RetimerFwUpdateState, SendVdm, SinkContract, SourceContract,
+            SystemPowerState, TbtConfig, TypeCStateMachineState, UsbControlConfig,
         },
         event::PortEvent,
     },
 };
-use embedded_usb_pd::{Error, ado::Ado};
+use embedded_usb_pd::{Error, ado::Ado, pdo};
 use embedded_usb_pd::{LocalPortId, PdError};
 use embedded_usb_pd::{PowerRole, type_c::Current};
 use embedded_usb_pd::{type_c::ConnectionState, ucsi::lpm};
@@ -203,12 +204,50 @@ impl<'a> ControllerState<'a> {
         });
         match role {
             PowerRole::Source => {
-                status.available_source_contract = Some(capability);
-                status.unconstrained_power = unconstrained;
+                status.available_source_contract = Some(SourceContract {
+                    capability,
+                    pd: Some(PdSourceInfo {
+                        pdo: pdo::source::Pdo::Fixed(pdo::source::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            current_ma: capability.current_ma,
+                            unconstrained_power: unconstrained,
+                            ..Default::default()
+                        }),
+                        rdo: pdo::Rdo::Fixed(pdo::rdo::FixedVarData {
+                            operating_current_ma: capability.current_ma,
+                            max_operating_current_ma: capability.current_ma,
+                            ..Default::default()
+                        }),
+                        rx_fixed_5v_data: pdo::sink::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            operational_current_ma: capability.current_ma,
+                            ..Default::default()
+                        },
+                    }),
+                });
             }
             PowerRole::Sink => {
-                status.available_sink_contract = Some(capability);
-                status.unconstrained_power = unconstrained;
+                status.available_sink_contract = Some(SinkContract {
+                    capability,
+                    pd: Some(PdSinkInfo {
+                        pdo: pdo::sink::Pdo::Fixed(pdo::sink::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            operational_current_ma: capability.current_ma,
+                            ..Default::default()
+                        }),
+                        rdo: pdo::Rdo::Fixed(pdo::rdo::FixedVarData {
+                            operating_current_ma: capability.current_ma,
+                            max_operating_current_ma: capability.current_ma,
+                            ..Default::default()
+                        }),
+                        rx_fixed_5v_data: pdo::source::FixedData {
+                            voltage_mv: capability.voltage_mv,
+                            current_ma: capability.current_ma,
+                            unconstrained_power: unconstrained,
+                            ..Default::default()
+                        },
+                    }),
+                });
             }
         }
         self.next_result_get_port_status.push_back(Ok(status));


### PR DESCRIPTION
This flag was not being set properly. Also add two more useful fields to `PortStatus`.