### PR TITLE
type-c-service: Add Pd::reports_unconstrained_power and port unconstrained test from stable to main

### DIFF
--- a/type-c-interface-mocks/src/port/mod.rs
+++ b/type-c-interface-mocks/src/port/mod.rs
@@ -234,6 +234,10 @@ where
         Ok(())
     }
 
+    fn reports_unconstrained_power(&self) -> bool {
+        self.status.available_sink_contract.is_some() && self.status.unconstrained_power
+    }
+
     async fn get_other_vdm(&mut self) -> Result<OtherVdm, PdError> {
         Ok(OtherVdm::default())
     }

--- a/type-c-interface/src/port/pd.rs
+++ b/type-c-interface/src/port/pd.rs
@@ -28,6 +28,12 @@ pub trait Pd: Named {
     /// Set port unconstrained status
     fn set_unconstrained_power(&mut self, unconstrained: bool) -> impl Future<Output = Result<(), PdError>>;
 
+    /// Returns whether this port reports unconstrained power to the system.
+    ///
+    /// This is the port's own determination and can differ from
+    /// [`PortStatus::unconstrained_power`], which is what the partner reports in its PDO.
+    fn reports_unconstrained_power(&self) -> bool;
+
     /// Get the Rx Other VDM data for this port
     fn get_other_vdm(&mut self) -> impl Future<Output = Result<OtherVdm, PdError>>;
     /// Get the Rx Attention VDM data for this port

--- a/type-c-service/src/controller/pd.rs
+++ b/type-c-service/src/controller/pd.rs
@@ -114,6 +114,10 @@ impl<
             .await
     }
 
+    fn reports_unconstrained_power(&self) -> bool {
+        self.is_unconstrained_sink(&self.status)
+    }
+
     async fn get_other_vdm(&mut self) -> Result<OtherVdm, PdError> {
         self.controller.lock().await.get_other_vdm(self.port).await
     }

--- a/type-c-service/src/controller/power.rs
+++ b/type-c-service/src/controller/power.rs
@@ -25,16 +25,25 @@ impl<
     LoopbackSender: NonBlockingSender<event::Loopback>,
 > Port<'device, C, Shared, PortNotifier, PowerNotifier, LoopbackSender>
 {
+    /// Whether the sink contract in the given status is unconstrained, per this port's configuration
+    pub(super) fn is_unconstrained_sink(&self, status: &PortStatus) -> bool {
+        let Some(contract) = status.available_sink_contract else {
+            return false;
+        };
+
+        match self.config.unconstrained_sink {
+            UnconstrainedSink::Auto => status.unconstrained_power,
+            UnconstrainedSink::PowerThresholdMilliwatts(threshold) => contract.max_power_mw() >= threshold,
+            UnconstrainedSink::Never => false,
+        }
+    }
+
     /// Handle a new contract as consumer
     pub(super) async fn process_new_consumer_contract(&mut self, new_status: &PortStatus) -> Result<(), PdError> {
         info!("Process new consumer contract");
+        let unconstrained = self.is_unconstrained_sink(new_status);
         let available_sink_contract = new_status.available_sink_contract.map(|c| {
             let mut c: ConsumerPowerCapability = c.into();
-            let unconstrained = match self.config.unconstrained_sink {
-                UnconstrainedSink::Auto => new_status.unconstrained_power,
-                UnconstrainedSink::PowerThresholdMilliwatts(threshold) => c.capability.max_power_mw() >= threshold,
-                UnconstrainedSink::Never => false,
-            };
             c.flags.set_unconstrained_power(unconstrained);
             c.flags.set_psu_type(PsuType::TypeC);
             c

--- a/type-c-service/src/service/power.rs
+++ b/type-c-service/src/service/power.rs
@@ -33,8 +33,7 @@ impl<'a, Reg: Registration<'a>> Service<'a, Reg> {
                 // Only one unconstrained device is present, see if that's one of our ports
                 let mut unconstrained_port = None;
                 for port in self.registration.ports().iter() {
-                    let status = port.lock().await.get_port_status().await?;
-                    if status.available_sink_contract.is_some() && status.unconstrained_power {
+                    if port.lock().await.reports_unconstrained_power() {
                         unconstrained_port = Some(*port);
                         break;
                     }

--- a/type-c-service/tests/unconstrained.rs
+++ b/type-c-service/tests/unconstrained.rs
@@ -1,0 +1,323 @@
+//! Test the unconstrained power logic of the type-C service
+#![allow(dead_code)]
+#![allow(clippy::indexing_slicing)]
+#![allow(clippy::panic)]
+#![allow(clippy::unwrap_used)]
+
+use embassy_time::{Duration, Timer, with_timeout};
+use embedded_services::named::Named;
+use embedded_usb_pd::{PowerRole, type_c::ConnectionState};
+use log::info;
+use power_policy_interface::{
+    capability::PowerCapability,
+    service::{UnconstrainedState, event::Event as PowerPolicyEvent},
+};
+use type_c_interface::{
+    control::pd::PortStatus,
+    port::event::{PortEvent, PortStatusEventBitfield},
+};
+use type_c_interface_test_mocks::controller::{FnCall as ControllerFnCall, pd::FnCall as PdFnCall};
+use type_c_service::controller::{
+    config::{Config as PortConfig, UnconstrainedSink},
+    event::Event,
+};
+
+use crate::common::{DEFAULT_PER_CALL_TIMEOUT, PowerPolicyServiceReceiver, Test, TestPort, TypeCServiceReceiver};
+
+mod common;
+
+/// The scenarios run for several seconds because the power policy service settles for 800ms after
+/// every consumer connect.
+const TEST_DURATION: Duration = Duration::from_secs(30);
+
+/// Time to wait for the power policy service to broadcast an unconstrained state change.
+const EVENT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Polling interval used while waiting for the type-C service to reach the controller mocks.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Number of results queued on each mock per step, enough to cover the most call-heavy step.
+const PRIME_DEPTH: usize = 4;
+
+/// Power threshold that [`CAPABILITY`] exceeds.
+const UNCONSTRAINED_THRESHOLD_MW: u32 = 15000;
+
+/// Sink contract offered by every simulated port partner.
+const CAPABILITY: PowerCapability = PowerCapability {
+    voltage_mv: 20000,
+    current_ma: 5000,
+};
+
+/// Port status of a detached port.
+const DETACHED: PortStatus = PortStatus::new();
+
+/// Port status of an attached sink offering [`CAPABILITY`].
+fn sink_status(unconstrained: bool) -> PortStatus {
+    PortStatus {
+        available_sink_contract: Some(CAPABILITY),
+        connection_state: Some(ConnectionState::Attached),
+        power_role: PowerRole::Sink,
+        unconstrained_power: unconstrained,
+        ..PortStatus::new()
+    }
+}
+
+/// Value of the most recent `set_unconstrained_power` call recorded by the port's controller mock.
+async fn last_unconstrained_call(port: &TestPort<'_, '_>) -> Option<bool> {
+    port.mock
+        .lock()
+        .await
+        .fn_calls
+        .iter()
+        .rev()
+        .find_map(|call| match call {
+            ControllerFnCall::Pd(PdFnCall::SetUnconstrainedPower(_, unconstrained)) => Some(*unconstrained),
+            _ => None,
+        })
+}
+
+/// Driver for multi-step unconstrained scenarios.
+///
+/// Every step re-primes all three mocks with the status their port currently reports, because the
+/// type-C service reads the port status a variable number of times depending on which branch of
+/// the unconstrained logic runs.
+struct Scenario<'a, 'port, 'ch> {
+    ports: [&'a TestPort<'port, 'ch>; 3],
+    power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+    statuses: [PortStatus; 3],
+}
+
+impl<'a, 'port, 'ch> Scenario<'a, 'port, 'ch> {
+    fn new(
+        ports: [&'a TestPort<'port, 'ch>; 3],
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+    ) -> Self {
+        Self {
+            ports,
+            power_policy_receiver,
+            statuses: [DETACHED; 3],
+        }
+    }
+
+    /// Drop the calls recorded by the previous step and queue results for the next one.
+    async fn prime(&self) {
+        for (port, status) in self.ports.iter().zip(self.statuses) {
+            let mut mock = port.mock.lock().await;
+            mock.fn_calls.clear();
+            mock.next_result_get_port_status.clear();
+            mock.next_result_enable_sink_path.clear();
+            mock.next_result_set_unconstrained_power.clear();
+
+            for _ in 0..PRIME_DEPTH {
+                mock.next_result_get_port_status.push_back(Ok(status));
+                mock.next_result_enable_sink_path.push_back(Ok(()));
+                mock.next_result_set_unconstrained_power.push_back(Ok(()));
+            }
+        }
+    }
+
+    async fn process(&self, index: usize, status_event: PortStatusEventBitfield) {
+        self.ports[index]
+            .port
+            .lock()
+            .await
+            .process_event(Event::PortEvent(PortEvent::StatusChanged(status_event)))
+            .await
+            .unwrap();
+    }
+
+    /// Simulate a sink attaching to the given port.
+    async fn connect_sink(&mut self, index: usize, unconstrained: bool) {
+        info!("Connecting port {index}, unconstrained: {unconstrained}");
+        self.statuses[index] = sink_status(unconstrained);
+        self.prime().await;
+
+        let mut status_event = PortStatusEventBitfield::none();
+        status_event.set_plug_inserted_or_removed(true);
+        status_event.set_new_power_contract_as_consumer(true);
+        // Report the sink as ready so the port doesn't arm its software sink-ready timer.
+        status_event.set_sink_ready(true);
+        self.process(index, status_event).await;
+    }
+
+    /// Simulate a detach on the given port.
+    async fn detach(&mut self, index: usize) {
+        info!("Disconnecting port {index}");
+        self.statuses[index] = DETACHED;
+        self.prime().await;
+
+        let mut status_event = PortStatusEventBitfield::none();
+        status_event.set_plug_inserted_or_removed(true);
+        self.process(index, status_event).await;
+    }
+
+    /// Wait for the power policy service to broadcast the expected unconstrained state, then check
+    /// the flag the type-C service applied to each port.
+    async fn expect_unconstrained(&self, expected: UnconstrainedState, expected_flags: [bool; 3]) {
+        let state = with_timeout(EVENT_TIMEOUT, async {
+            loop {
+                if let PowerPolicyEvent::Unconstrained(state) = self.power_policy_receiver.receive().await {
+                    return state;
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("Did not receive unconstrained event"));
+        assert_eq!(state, expected);
+
+        for (port, expected) in self.ports.iter().zip(expected_flags) {
+            let name = port.mock.lock().await.name();
+            let actual = with_timeout(DEFAULT_PER_CALL_TIMEOUT, async {
+                loop {
+                    if let Some(unconstrained) = last_unconstrained_call(port).await {
+                        return unconstrained;
+                    }
+                    Timer::after(POLL_INTERVAL).await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("({name}): set_unconstrained_power was not called"));
+            assert_eq!(actual, expected, "({name}): unexpected unconstrained flag");
+        }
+    }
+
+    /// Assert that the unconstrained state doesn't change and that no port is reconfigured.
+    async fn expect_no_unconstrained_change(&self) {
+        // Drain the events this step legitimately produces until the services go idle.
+        while let Ok(event) = with_timeout(DEFAULT_PER_CALL_TIMEOUT, self.power_policy_receiver.receive()).await {
+            assert!(
+                !matches!(event, PowerPolicyEvent::Unconstrained(_)),
+                "unexpected unconstrained event"
+            );
+        }
+
+        for port in self.ports {
+            let name = port.mock.lock().await.name();
+            assert!(
+                last_unconstrained_call(port).await.is_none(),
+                "({name}): unexpected set_unconstrained_power call"
+            );
+        }
+    }
+}
+
+/// Test the unconstrained logic driven by the unconstrained bit reported by the port partner.
+struct TestUnconstrained;
+
+impl Test for TestUnconstrained {
+    async fn run<'port, 'ch>(
+        &mut self,
+        _type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        port1: TestPort<'port, 'ch>,
+        port2: TestPort<'port, 'ch>,
+    ) {
+        let mut scenario = Scenario::new([&port0, &port1, &port2], power_policy_receiver);
+
+        // A single unconstrained port unconstrains the other ports, but not itself: the system
+        // stops being unconstrained as soon as that port starts sourcing.
+        scenario.connect_sink(0, true).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 1), [false, true, true])
+            .await;
+
+        // A constrained sink leaves the unconstrained state untouched.
+        scenario.connect_sink(1, false).await;
+        scenario.expect_no_unconstrained_change().await;
+
+        // Losing the only unconstrained port constrains every port.
+        scenario.detach(0).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(false, 0), [false, false, false])
+            .await;
+
+        // Detaching the remaining constrained port changes nothing.
+        scenario.detach(1).await;
+        scenario.expect_no_unconstrained_change().await;
+
+        scenario.connect_sink(0, true).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 1), [false, true, true])
+            .await;
+
+        // With more than one unconstrained port available the system stays unconstrained even if
+        // one of them starts sourcing, so every port gets the flag.
+        scenario.connect_sink(1, true).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 2), [true, true, true])
+            .await;
+
+        scenario.connect_sink(2, true).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 3), [true, true, true])
+            .await;
+
+        // Still more than one unconstrained port after the current consumer goes away.
+        scenario.detach(0).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 2), [true, true, true])
+            .await;
+
+        // Back down to a single unconstrained port, which is the current consumer.
+        scenario.detach(2).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 1), [true, false, true])
+            .await;
+
+        // Nothing left, every port ends up constrained.
+        scenario.detach(1).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(false, 0), [false, false, false])
+            .await;
+    }
+}
+
+/// Test the unconstrained logic for a sink that doesn't report the unconstrained bit.
+///
+/// [`UnconstrainedSink::PowerThresholdMilliwatts`] makes the port report unconstrained power based
+/// on contract power alone, so the service must attribute the system unconstrained state to that
+/// port and hold it constrained, just like a partner-reported unconstrained sink.
+struct TestUnconstrainedPowerThreshold;
+
+impl Test for TestUnconstrainedPowerThreshold {
+    async fn run<'port, 'ch>(
+        &mut self,
+        _type_c_receiver: TypeCServiceReceiver<'port, 'ch>,
+        power_policy_receiver: PowerPolicyServiceReceiver<'port, 'ch>,
+        port0: TestPort<'port, 'ch>,
+        port1: TestPort<'port, 'ch>,
+        port2: TestPort<'port, 'ch>,
+    ) {
+        let mut scenario = Scenario::new([&port0, &port1, &port2], power_policy_receiver);
+
+        scenario.connect_sink(0, false).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(true, 1), [false, true, true])
+            .await;
+
+        scenario.detach(0).await;
+        scenario
+            .expect_unconstrained(UnconstrainedState::new(false, 0), [false, false, false])
+            .await;
+    }
+}
+
+#[tokio::test]
+async fn unconstrained() {
+    common::run_test(TEST_DURATION, Default::default(), Default::default(), TestUnconstrained).await;
+}
+
+#[tokio::test]
+async fn unconstrained_power_threshold() {
+    let mut port_config = [PortConfig::default(); 3];
+    port_config[0].unconstrained_sink = UnconstrainedSink::PowerThresholdMilliwatts(UNCONSTRAINED_THRESHOLD_MW);
+
+    common::run_test(
+        TEST_DURATION,
+        Default::default(),
+        port_config,
+        TestUnconstrainedPowerThreshold,
+    )
+    .await;
+}


### PR DESCRIPTION
Add a new method to get whether a port itself reports unconstrained power to the port::Pd trait and port the type-C unconstrained.rs integration test from stable-v0.1.y to main

`PortStatus::unconstrained_power` is the bit the partner reports in its PDO, so it can't answer whether a port considers itself an unconstrained source. that also depends on the port's `UnconstrainedSink` policy. Add a method to the port's Pd trait that allows itself to report unconstrained power.

The type-C service maps the system unconstrained state from the power policy onto the unconstrained bit each port advertises to its partner.

The test drives port status changes end-to-end and asserts the resulting `set_unconstrained_power` calls on each controller mock.

A second test covers a threshold-flagged sink, where the system is unconstrained due to being over a power threshold.

Assisted-by: GitHub Copilot:claude-opus-5

Resolves #924 