### PR TITLE
Update embedded-usb-pd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,20 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,7 +546,7 @@ dependencies = [
  "embedded-mcu-hal",
  "embedded-storage",
  "fixed",
- "itertools 0.11.0",
+ "itertools",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
  "mimxrt685s-pac",
@@ -828,9 +814,8 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#071f163395e3eaea3094b817e3d943ab7265be3d"
 dependencies = [
- "aquamarine",
  "bincode",
  "bitfield 0.19.4",
  "defmt 0.3.100",
@@ -1096,25 +1081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,15 +1095,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,9 @@ embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-services = { path = "./embedded-service" }
 embedded-storage-async = "0.4.1"
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false, features = [
+    "ucsi-v1_2",
+] }
 fw-update-interface = { path = "./fw-update-interface" }
 fw-update-interface-test-mocks = { path = "./fw-update-interface-test-mocks" }
 generic-array = "1.4.1"

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -707,6 +707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-usb-pd"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#071f163395e3eaea3094b817e3d943ab7265be3d"
+dependencies = [
+ "bincode",
+ "bitfield 0.19.4",
+ "defmt 0.3.100",
+ "embedded-hal-async",
+]
+
+[[package]]
 name = "espi-device"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#e2a7c6f4bc8e0259d85f53b4014847eb276c885a"
@@ -1227,7 +1238,7 @@ dependencies = [
  "embedded-cfu-protocol",
  "embedded-mcu-hal",
  "embedded-services",
- "embedded-usb-pd",
+ "embedded-usb-pd 0.1.0 (git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0)",
  "hidi2c-target-service",
  "mimxrt600-fcb 0.1.0",
  "num_enum",
@@ -1481,7 +1492,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io-async 0.6.1",
  "embedded-services",
- "embedded-usb-pd",
+ "embedded-usb-pd 0.1.0 (git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0)",
  "fw-update-interface",
  "heapless",
  "itertools 0.14.0",
@@ -1558,7 +1569,7 @@ dependencies = [
  "bitfield 0.17.0",
  "defmt 0.3.100",
  "embedded-services",
- "embedded-usb-pd",
+ "embedded-usb-pd 0.1.0 (git+https://github.com/OpenDevicePartnership/embedded-usb-pd)",
  "heapless",
  "power-policy-interface",
 ]
@@ -1572,7 +1583,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-services",
- "embedded-usb-pd",
+ "embedded-usb-pd 0.1.0 (git+https://github.com/OpenDevicePartnership/embedded-usb-pd)",
  "fw-update-interface",
  "heapless",
  "power-policy-interface",

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -62,20 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,12 +371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
 name = "embassy-executor"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,9 +610,8 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#071f163395e3eaea3094b817e3d943ab7265be3d"
 dependencies = [
- "aquamarine",
  "bincode",
  "bitfield 0.19.4",
  "embedded-hal-async",
@@ -763,38 +742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "jiff"

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -25,7 +25,9 @@ embassy-executor = { version = "0.10.0", features = [
 
 defmt = "0.3"
 
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0" }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", features = [
+    "ucsi-v1_2",
+] }
 embedded-services = { path = "../../embedded-service", features = ["log"] }
 odp-service-common = { path = "../../odp-service-common" }
 power-policy-service = { path = "../../power-policy-service", features = [

--- a/examples/std/src/lib/type_c/mock_controller.rs
+++ b/examples/std/src/lib/type_c/mock_controller.rs
@@ -7,7 +7,7 @@ use embedded_usb_pd::ado::Ado;
 use embedded_usb_pd::vdm::structured::command::discover_identity::{sop, sop_prime};
 use embedded_usb_pd::{LocalPortId, PdError};
 use embedded_usb_pd::{PowerRole, type_c::Current};
-use embedded_usb_pd::{type_c::ConnectionState, ucsi::lpm};
+use embedded_usb_pd::{type_c::ConnectionState, ucsi::v1_2::lpm};
 use log::{debug, info};
 
 use power_policy_interface::capability::PowerCapability;

--- a/type-c-interface-test-mocks/src/controller/mod.rs
+++ b/type-c-interface-test-mocks/src/controller/mod.rs
@@ -55,7 +55,8 @@ pub struct Mock {
     /// Next results to return for [`type_c_interface::controller::pd::Pd::set_usb_control`]
     pub next_result_set_usb_control: VecDeque<Result<(), PdError>>,
     /// Next results to return for [`type_c_interface::ucsi::Lpm::execute_lpm_command`]
-    pub next_result_execute_lpm_command: VecDeque<Result<Option<embedded_usb_pd::ucsi::lpm::ResponseData>, PdError>>,
+    pub next_result_execute_lpm_command:
+        VecDeque<Result<Option<embedded_usb_pd::ucsi::v1_2::lpm::ResponseData>, PdError>>,
     /// Next results to return for [`type_c_interface::controller::pd::Pd::hard_reset`]
     pub next_result_hard_reset: VecDeque<Result<(), PdError>>,
     /// Next results to return for [`type_c_interface::controller::pd::Pd::get_discovered_svids`]

--- a/type-c-interface-test-mocks/src/controller/ucsi.rs
+++ b/type-c-interface-test-mocks/src/controller/ucsi.rs
@@ -1,5 +1,5 @@
 use embedded_usb_pd::PdError;
-use embedded_usb_pd::ucsi::lpm;
+use embedded_usb_pd::ucsi::v1_2::lpm;
 use type_c_interface::ucsi::Lpm as UcsiLpm;
 
 use super::FnCall as ControllerFnCall;

--- a/type-c-interface/src/ucsi.rs
+++ b/type-c-interface/src/ucsi.rs
@@ -1,5 +1,5 @@
 use embedded_services::named::Named;
-use embedded_usb_pd::{PdError, ucsi::lpm};
+use embedded_usb_pd::{PdError, ucsi::v1_2::lpm};
 
 /// UCSI LPM command execution trait
 pub trait Lpm: Named {

--- a/type-c-service/src/controller/ucsi.rs
+++ b/type-c-service/src/controller/ucsi.rs
@@ -1,6 +1,6 @@
 //! UCSI LPM port trait implementation
 use embedded_services::{event::NonBlockingSender, sync::Lockable};
-use embedded_usb_pd::{PdError, ucsi::lpm};
+use embedded_usb_pd::{PdError, ucsi::v1_2::lpm};
 use type_c_interface::ucsi::Lpm as UcsiLpm;
 
 use super::*;

--- a/type-c-service/src/service/config.rs
+++ b/type-c-service/src/service/config.rs
@@ -1,4 +1,4 @@
-use embedded_usb_pd::ucsi::{self, lpm::get_connector_status::BatteryChargingCapabilityStatus};
+use embedded_usb_pd::ucsi::{self, v1_2::lpm::get_connector_status::BatteryChargingCapabilityStatus};
 
 /// UCSI battery charging capability status configuration.
 ///
@@ -103,9 +103,9 @@ impl UcsiBatteryChargingThresholdConfig {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Config {
     /// UCSI capabilities
-    pub ucsi_capabilities: ucsi::ppm::get_capability::ResponseData,
+    pub ucsi_capabilities: ucsi::v1_2::ppm::get_capability::ResponseData,
     /// Optional override for UCSI port capabilities
-    pub ucsi_port_capabilities: Option<ucsi::lpm::get_connector_capability::ResponseData>,
+    pub ucsi_port_capabilities: Option<ucsi::v1_2::lpm::get_connector_capability::ResponseData>,
     /// UCSI battery charging configuration
     pub ucsi_battery_charging_config: UcsiBatteryChargingThresholdConfig,
 }

--- a/type-c-service/src/service/ucsi.rs
+++ b/type-c-service/src/service/ucsi.rs
@@ -1,12 +1,12 @@
 use embedded_services::sync::Lockable;
 use embedded_services::warn;
-use embedded_usb_pd::ucsi::cci::{Cci, GlobalCci};
-use embedded_usb_pd::ucsi::lpm::get_connector_status::{BatteryChargingCapabilityStatus, ConnectorStatusChange};
-use embedded_usb_pd::ucsi::ppm::set_notification_enable::NotificationEnable;
-use embedded_usb_pd::ucsi::ppm::state_machine::{
+use embedded_usb_pd::ucsi::v1_2::cci::{Cci, GlobalCci};
+use embedded_usb_pd::ucsi::v1_2::lpm::get_connector_status::{BatteryChargingCapabilityStatus, ConnectorStatusChange};
+use embedded_usb_pd::ucsi::v1_2::ppm::set_notification_enable::NotificationEnable;
+use embedded_usb_pd::ucsi::v1_2::ppm::state_machine::{
     GlobalInput as PpmInput, GlobalOutput as PpmOutput, GlobalStateMachine as StateMachine, InvalidTransition,
 };
-use embedded_usb_pd::ucsi::{GlobalCommand, ResponseData, lpm, ppm};
+use embedded_usb_pd::ucsi::v1_2::{GlobalCommand, ResponseData, lpm, ppm};
 use embedded_usb_pd::{PdError, PowerRole};
 use type_c_interface::ucsi::Lpm as _;
 

--- a/type-c-service/tests/ucsi.rs
+++ b/type-c-service/tests/ucsi.rs
@@ -6,18 +6,18 @@
 
 use embassy_time::with_timeout;
 use embedded_usb_pd::type_c::ConnectionState;
-use embedded_usb_pd::ucsi::cci::GlobalCci;
-use embedded_usb_pd::ucsi::lpm::get_connector_capability::{
+use embedded_usb_pd::ucsi::v1_2::cci::GlobalCci;
+use embedded_usb_pd::ucsi::v1_2::lpm::get_connector_capability::{
     OperationModeFlags, ResponseData as UcsiConnectorCapability,
 };
-use embedded_usb_pd::ucsi::lpm::get_connector_status::{
+use embedded_usb_pd::ucsi::v1_2::lpm::get_connector_status::{
     BatteryChargingCapabilityStatus, ConnectedStatus, ConnectorStatusChange,
 };
-use embedded_usb_pd::ucsi::lpm::{self, ResponseData as LpmResponseData};
-use embedded_usb_pd::ucsi::ppm::{
+use embedded_usb_pd::ucsi::v1_2::lpm::{self, ResponseData as LpmResponseData};
+use embedded_usb_pd::ucsi::v1_2::ppm::{
     self, ack_cc_ci::Ack, get_capability::ResponseData as PpmCapabilities, set_notification_enable::NotificationEnable,
 };
-use embedded_usb_pd::ucsi::{GlobalCommand, ResponseData as UcsiResponseData};
+use embedded_usb_pd::ucsi::v1_2::{GlobalCommand, ResponseData as UcsiResponseData};
 use embedded_usb_pd::{GlobalPortId, PdError, PowerRole};
 use log::info;
 use type_c_interface::control::pd::PortStatus;


### PR DESCRIPTION
examples/rt685s-evk is failing due to its dependency on the tps6699x crate, but `embedded-services` needs to be updated before `tps6699x` can.