### PR TITLE
hidi2c: fix command protocol

### DIFF
--- a/hidi2c-target-service/src/service.rs
+++ b/hidi2c-target-service/src/service.rs
@@ -641,7 +641,11 @@ impl<
                     .checked_sub(device_descriptor::HID_REPORT_HEADER_SIZE_BYTES))
                 .ok_or(Error::Protocol(ProtocolError::InvalidSize))? as usize;
 
-                let data_start_index = if hid_device.report_descriptor().report_ids_implicit() { 0 } else { 1 };
+                let data_start_index = if hid_device.report_descriptor().report_ids_implicit() {
+                    0
+                } else {
+                    1
+                };
                 let report_data = data
                     .get(data_start_index..report_size)
                     .ok_or(Error::Protocol(ProtocolError::InvalidSize))?;

--- a/hidi2c-target-service/src/service.rs
+++ b/hidi2c-target-service/src/service.rs
@@ -647,7 +647,7 @@ impl<
                     1
                 };
                 let report_data = data
-                    .get(data_start_index..report_size)
+                    .get(data_start_index..data_start_index + report_size)
                     .ok_or(Error::Protocol(ProtocolError::InvalidSize))?;
 
                 let set_report = match report_type {

--- a/hidi2c-target-service/src/service.rs
+++ b/hidi2c-target-service/src/service.rs
@@ -612,7 +612,13 @@ impl<
                 //        but as soon as the aggregation / HID library goes in, look into leveraging it for filtering out invalid report
                 //        IDs here.
 
-                bus.listen_for_response().await?;
+                match bus.listen_for_response().await? {
+                    Request::Read(_address) => {}
+                    other => {
+                        error!("Expected read request after get report command, got {:?}", other);
+                        return Err(Error::Protocol(ProtocolError::InvalidCommand));
+                    }
+                }
 
                 hid_device
                     .process_get_report(report_type.try_into()?, report_id, async |report| {

--- a/hidi2c-target-service/src/service.rs
+++ b/hidi2c-target-service/src/service.rs
@@ -612,6 +612,8 @@ impl<
                 //        but as soon as the aggregation / HID library goes in, look into leveraging it for filtering out invalid report
                 //        IDs here.
 
+                bus.listen_for_response().await?;
+
                 hid_device
                     .process_get_report(report_type.try_into()?, report_id, async |report| {
                         // Note: per HID spec, the length field needs to include its own length (2 bytes)
@@ -639,8 +641,9 @@ impl<
                     .checked_sub(device_descriptor::HID_REPORT_HEADER_SIZE_BYTES))
                 .ok_or(Error::Protocol(ProtocolError::InvalidSize))? as usize;
 
+                let data_start_index = if hid_device.report_descriptor().report_ids_implicit() { 0 } else { 1 };
                 let report_data = data
-                    .get(..report_size)
+                    .get(data_start_index..report_size)
                     .ok_or(Error::Protocol(ProtocolError::InvalidSize))?;
 
                 let set_report = match report_type {


### PR DESCRIPTION
This change fixes two bugs in the HID-I2C command protocol:
1. In the GET_REPORT path, we weren't listening for a read request before responding with the report payload. On some HALs, this causes the bytes you write to be dropped and never get transmitted over the bus.
2. In the SET_REPORT path, when not using implicit report IDs, the host actually writes the report ID twice; once in the command register and again in the data register. We were not accounting for the second write as the first byte in the data register.